### PR TITLE
Simplify configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "scripts": {
-    "fix-line-endings": "find packages -name package.json | xargs sed -i '' -e '$a\\'",
-    "bootstrap": "oao bootstrap && yarn fix-line-endings",
+    "bootstrap": "oao bootstrap",
+    "add-dep": "oao add",
+    "remove-dep": "oao remove",
     "clear-deps": "rm -rf packages/**/node_modules",
     "docs:build": "gitbook build",
     "docs:deploy": "npm run docs:build && gh-pages --dist _book --remote upstream",
@@ -22,6 +23,6 @@
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-github": "^2.0.0",
     "gitbook-plugin-prism": "^2.1.0",
-    "oao": "^0.4.1"
+    "oao": "^0.5.0"
   }
 }

--- a/packages/neutrino-preset-base/package.json
+++ b/packages/neutrino-preset-base/package.json
@@ -22,8 +22,7 @@
     "exports-loader": "0.6.3",
     "imports-loader": "^0.7.0",
     "progress-bar-webpack-plugin": "^1.9.3",
-    "webpack": "^2.2.1",
-    "webpack-chain": "^1.2.0"
+    "webpack": "^2.2.1"
   },
   "peerDependencies": {
     "neutrino": "^4.0.0"

--- a/packages/neutrino-preset-base/src/index.js
+++ b/packages/neutrino-preset-base/src/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Config = require('webpack-chain');
 const CleanPlugin = require('clean-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const path = require('path');
@@ -14,9 +13,7 @@ const PROJECT_MODULES = path.join(CWD, 'node_modules');
 const BASE_MODULES = path.join(__dirname, '../node_modules');
 const SRC = path.join(CWD, 'src');
 
-module.exports = () => {
-  const config = new Config();
-
+module.exports = ({ config }) => {
   config
     .context(CWD)
     .entry('index')
@@ -71,6 +68,4 @@ module.exports = () => {
       .plugin('clean')
       .use(CleanPlugin, [BUILD], { root: CWD });
   }
-
-  return config;
 };

--- a/packages/neutrino-preset-base/yarn.lock
+++ b/packages/neutrino-preset-base/yarn.lock
@@ -2531,10 +2531,6 @@ watchpack@^1.2.0:
     chokidar "^1.4.3"
     graceful-fs "^4.1.2"
 
-webpack-chain@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-1.2.0.tgz#38e2a7352e9961d6227d5819712b6c464d47833f"
-
 webpack-sources@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.4.tgz#ccc2c817e08e5fa393239412690bb481821393cd"

--- a/packages/neutrino-preset-karma/src/index.js
+++ b/packages/neutrino-preset-karma/src/index.js
@@ -1,23 +1,6 @@
 const { Server } = require('karma');
 
 module.exports = neutrino => {
-  neutrino.on('test', (config, args) => {
-    const { karma } = neutrino.custom;
-
-    delete config.plugins;
-    karma.webpack = config;
-    karma.singleRun = !args.watch;
-    karma.autoWatch = args.watch;
-
-    if (args.files && args.files.length) {
-      karma.files = args.files;
-    }
-
-    return new Promise(resolve => {
-      new Server(karma, resolve).start();
-    });
-  });
-
   neutrino.custom.karma = {
     plugins: [
       require.resolve('karma-webpack'),
@@ -50,4 +33,21 @@ module.exports = neutrino => {
       ]
     }
   };
+
+  neutrino.on('test', ({ files, watch }) => {
+    const { karma } = neutrino.custom;
+
+    karma.singleRun = !watch;
+    karma.autoWatch = watch;
+    karma.webpack = neutrino.getWebpackOptions();
+    delete karma.webpack.plugins;
+
+    if (files && files.length) {
+      karma.files = files;
+    }
+
+    return new Promise(resolve => {
+      new Server(karma, resolve).start();
+    });
+  });
 };

--- a/packages/neutrino-preset-mocha/package.json
+++ b/packages/neutrino-preset-mocha/package.json
@@ -19,7 +19,6 @@
     "babel-register": "^6.22.0",
     "change-case": "^3.0.1",
     "deepmerge": "^1.3.2",
-    "mocha": "^3.2.0",
-    "webpack-chain": "^1.2.0"
+    "mocha": "^3.2.0"
   }
 }

--- a/packages/neutrino-preset-mocha/src/index.js
+++ b/packages/neutrino-preset-mocha/src/index.js
@@ -2,43 +2,29 @@ const mocha = require('./mocha');
 const merge = require('deepmerge');
 
 module.exports = neutrino => {
-  neutrino.on('test', (config, args) => {
-    let loader;
-
-    config.module.rules.some(r => {
-      let l = r.use.find(l => l.loader.includes('babel-loader'));
-
-      if (l) {
-        loader = l;
-        return true;
-      }
-
-      return false;
-    });
-
-    return mocha(neutrino.custom.mocha, loader.options, args.files);
-  });
-
   neutrino.custom.mocha = {
     reporter: 'spec',
     ui: 'tdd',
     bail: true
   };
 
-  const config = neutrino.configs.find(c => c.module.rules.has('compile'));
-
-  config
-    .module
+  neutrino.config.module
     .rule('compile')
-      .loader('babel', ({ options }) => {
-        return {
-          options: merge(options, {
-            env: {
-              test: {
-                plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
-              }
+    .loader('babel', ({ options }) => {
+      return {
+        options: merge(options, {
+          env: {
+            test: {
+              plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
             }
-          })
-        };
-      });
+          }
+        })
+      };
+    });
+
+  neutrino.on('test', ({ files }) => {
+    const babelOptions = neutrino.config.module.rule('compile').loaders.get('babel').options;
+
+    return mocha(neutrino.custom.mocha, babelOptions, files);
+  });
 };

--- a/packages/neutrino-preset-mocha/yarn.lock
+++ b/packages/neutrino-preset-mocha/yarn.lock
@@ -219,17 +219,11 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-debug@2.2.0:
+debug@2.2.0, debug@^2.1.1, debug@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
-
-debug@^2.1.1, debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
-  dependencies:
-    ms "0.7.2"
 
 deepmerge@^1.3.2:
   version "1.3.2"
@@ -464,10 +458,6 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-
 no-case@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
@@ -599,10 +589,6 @@ upper-case-first@^1.1.0, upper-case-first@^1.1.2:
 upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1, upper-case@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
-
-webpack-chain@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-1.2.0.tgz#38e2a7352e9961d6227d5819712b6c464d47833f"
 
 wrappy@1:
   version "1.0.2"

--- a/packages/neutrino-preset-node/src/index.js
+++ b/packages/neutrino-preset-node/src/index.js
@@ -12,37 +12,82 @@ const TEST = path.join(CWD, 'test');
 const MODULES = path.join(__dirname, '../node_modules');
 
 module.exports = neutrino => {
-  return neutrino.extend(base, config => {
-    config
-      .target('node')
-      .devtool('source-map')
-      .externals([nodeExternals()])
-      .node
-        .set('__filename', false)
-        .set('__dirname', false)
-        .end()
-      .output
-        .filename('[name].js')
-        .libraryTarget('commonjs2');
+  base(neutrino);
 
-    config.resolve.modules.add(MODULES);
-    config.resolveLoader.modules.add(MODULES);
+  const { config } = neutrino;
 
-    config
-      .plugin('banner')
-      .use(webpack.BannerPlugin, {
-        banner: `require(${require.resolve('source-map-support')}).install();`,
-        raw: true,
-        entryOnly: true
-      });
+  config
+    .target('node')
+    .devtool('source-map')
+    .externals([nodeExternals()])
+    .node
+      .set('__filename', false)
+      .set('__dirname', false)
+      .end()
+    .output
+      .filename('[name].js')
+      .libraryTarget('commonjs2');
 
-    config.options.set('performance', {
-      hints: false
+  config.resolve.modules.add(MODULES);
+  config.resolveLoader.modules.add(MODULES);
+  config.options.set('performance', { hints: false });
+
+  config
+    .plugin('banner')
+    .use(webpack.BannerPlugin, {
+      banner: `require(${require.resolve('source-map-support')}).install();`,
+      raw: true,
+      entryOnly: true
     });
 
-    config
-      .module
-      .rule('compile')
+  config.module
+    .rule('lint')
+    .loader('eslint', ({ options }) => {
+      return {
+        options: merge(options, {
+          envs: ['node'],
+          rules: {
+            // enforce return after a callback
+            'callback-return': 'off',
+
+            // require all requires be top-level
+            // http://eslint.org/docs/rules/global-require
+            'global-require': 'error',
+
+            // enforces error handling in callbacks (node environment)
+            'handle-callback-err': 'off',
+
+            // Allow console in Node.js
+            'no-console': 'off',
+
+            // disallow mixing regular variable and require declarations
+            'no-mixed-requires': ['off', false],
+
+            // disallow use of new operator with the require function
+            'no-new-require': 'error',
+
+            // disallow string concatenation with __dirname and __filename
+            // http://eslint.org/docs/rules/no-path-concat
+            'no-path-concat': 'error',
+
+            // disallow use of process.env
+            'no-process-env': 'off',
+
+            // disallow process.exit()
+            'no-process-exit': 'off',
+
+            // restrict usage of specified node modules
+            'no-restricted-modules': 'off',
+
+            // disallow use of synchronous methods (off by default)
+            'no-sync': 'off'
+          }
+        })
+      };
+    });
+
+  config.module
+    .rule('compile')
       .test(/\.js$/)
       .include(SRC, TEST)
       .loader('babel', require.resolve('babel-loader'), {
@@ -57,64 +102,6 @@ module.exports = neutrino => {
               }
             }
           ]
-        ],
-        plugins: [],
-        env: {
-          test: {
-            plugins: [
-              // FIXME: This currently breaks the coverage
-              //[require.resolve('babel-plugin-istanbul'), { exclude: ['test/**/*'] }]
-            ]
-          }
-        }
+        ]
       });
-
-    config.module
-      .rule('lint')
-      .loader('eslint', ({ options }) => {
-        return {
-          options: merge(options, {
-            envs: ['node'],
-            rules: {
-              // enforce return after a callback
-              'callback-return': 'off',
-
-              // require all requires be top-level
-              // http://eslint.org/docs/rules/global-require
-              'global-require': 'error',
-
-              // enforces error handling in callbacks (node environment)
-              'handle-callback-err': 'off',
-
-              // Allow console in Node.js
-              'no-console': 'off',
-
-              // disallow mixing regular variable and require declarations
-              'no-mixed-requires': ['off', false],
-
-              // disallow use of new operator with the require function
-              'no-new-require': 'error',
-
-              // disallow string concatenation with __dirname and __filename
-              // http://eslint.org/docs/rules/no-path-concat
-              'no-path-concat': 'error',
-
-              // disallow use of process.env
-              'no-process-env': 'off',
-
-              // disallow process.exit()
-              'no-process-exit': 'off',
-
-              // restrict usage of specified node modules
-              'no-restricted-modules': 'off',
-
-              // disallow use of synchronous methods (off by default)
-              'no-sync': 'off'
-            }
-          })
-        };
-      });
-
-    return config;
-  });
 };

--- a/packages/neutrino-preset-react/src/index.js
+++ b/packages/neutrino-preset-react/src/index.js
@@ -8,73 +8,64 @@ const webpack = require('webpack');
 const MODULES = path.join(__dirname, '../node_modules');
 
 module.exports = neutrino => {
-  return neutrino.extend(web, config => {
-    // modify lint rule and loader
-    config.module
-      .rule('lint')
-      .test(/\.jsx?$/)
-      .loader('eslint', ({ options }) => {
-        return {
-          options: merge(options, {
-            plugins: ['react'],
-            baseConfig: {
-              extends: ['plugin:react/recommended']
-            },
-            parserOptions: {
-              ecmaFeatures: {
-                experimentalObjectRestSpread: true
-              }
-            },
-            rules: {
-              'react/prop-types': ['off'],
-              'jsx-quotes': ['error', 'prefer-double']
+  web(neutrino);
+
+  const { config } = neutrino;
+
+  config.module
+    .rule('lint')
+    .test(/\.jsx?$/)
+    .loader('eslint', ({ options }) => {
+      return {
+        options: merge(options, {
+          plugins: ['react'],
+          baseConfig: {
+            extends: ['plugin:react/recommended']
+          },
+          parserOptions: {
+            ecmaFeatures: {
+              experimentalObjectRestSpread: true
             }
-          })
-        };
-      });
+          },
+          rules: {
+            'react/prop-types': ['off'],
+            'jsx-quotes': ['error', 'prefer-double']
+          }
+        })
+      };
+    });
 
-    config.module
-      .rule('compile')
-      .test(/\.jsx?$/)
-      .loader('babel', ({ options }) => {
-        if (process.env.NODE_ENV === 'development') {
-          options.plugins.push(require.resolve('react-hot-loader/babel'));
-        }
+  config.module
+    .rule('compile')
+    .test(/\.jsx?$/)
+    .loader('babel', ({ options }) => {
+      return {
+        options: merge(options, {
+          presets: [require.resolve('babel-preset-react')],
+          plugins: [require.resolve('babel-plugin-transform-object-rest-spread')],
+          env: {
+            development: {
+              plugins: [require.resolve('react-hot-loader/babel')]
+            }
+          }
+        })
+      };
+    });
 
-        return {
-          options: merge(options, {
-            presets: [
-              require.resolve('babel-preset-react')
-            ],
-            plugins: [
-              require.resolve('babel-plugin-transform-object-rest-spread')
-            ]
-          })
-        };
-      });
+  config.resolve.modules.add(MODULES);
+  config.resolve.extensions.add('.jsx');
+  config.resolveLoader.modules.add(MODULES);
 
-    config.resolve
-      .modules
-        .add(MODULES)
-        .end()
-      .extensions
-        .add('.jsx');
+  config
+    .externals({
+      'react/addons': true,
+      'react/lib/ExecutionEnvironment': true,
+      'react/lib/ReactContext': 'window'
+    });
 
-    config.resolveLoader.modules.add(MODULES);
-
+  if (process.env.NODE_ENV === 'development') {
     config
-      .externals({
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': 'window'
-      });
-
-    if (process.env.NODE_ENV === 'development') {
-      config
-        .entry('index')
-        .prepend(require.resolve('react-hot-loader/patch'));
-    }
-
-    return config;
-  });
+      .entry('index')
+      .prepend(require.resolve('react-hot-loader/patch'));
+  }
 };

--- a/packages/neutrino-preset-web/package.json
+++ b/packages/neutrino-preset-web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
+    "babel-preset-babili": "^0.0.11",
     "babel-preset-env": "^1.1.8",
     "css-loader": "^0.26.1",
     "deepmerge": "^1.3.2",
@@ -20,12 +21,12 @@
     "file-loader": "^0.10.0",
     "html-webpack-plugin": "^2.28.0",
     "html-webpack-template": "^6.0.1",
-    "neutrino-preset-base": "4.0.0",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
     "webpack": "^2.2.1",
     "webpack-merge": "^2.6.1",
-    "worker-loader": "0.7.1"
+    "worker-loader": "0.7.1",
+    "neutrino-preset-base": "4.0.0"
   },
   "peerDependencies": {
     "neutrino": "^4.0.0"

--- a/packages/neutrino-preset-web/src/index.js
+++ b/packages/neutrino-preset-web/src/index.js
@@ -19,199 +19,181 @@ const URL_LOADER = require.resolve('url-loader');
 const MODULES = path.join(__dirname, '../node_modules');
 
 module.exports = neutrino => {
-  return neutrino.extend(base, config => {
-    config.target('web');
-    config.output.publicPath('./');
-    config.resolve.modules.add(MODULES);
-    config.resolveLoader.modules.add(MODULES);
+  base(neutrino);
 
-    config.node
-      .set('console', false)
-      .set('global', true)
-      .set('process', true)
-      .set('Buffer', true)
-      .set('__filename', 'mock')
-      .set('__dirname', 'mock')
-      .set('setImmediate', true)
-      .set('fs', 'empty')
-      .set('tls', 'empty');
+  const { config } = neutrino;
 
-    config.module
-      .rule('html')
-      .test(/\.html$/)
-      .loader('file', FILE_LOADER, {
-        name: '[name].[ext]'
-      });
+  config.target('web');
+  config.output.publicPath('./');
+  config.resolve.modules.add(MODULES);
+  config.resolveLoader.modules.add(MODULES);
 
-    config.module
-      .rule('css')
-      .test(/\.css$/)
-      .loader('style', STYLE_LOADER)
-      .loader('css', CSS_LOADER);
+  config.node
+    .set('console', false)
+    .set('global', true)
+    .set('process', true)
+    .set('Buffer', true)
+    .set('__filename', 'mock')
+    .set('__dirname', 'mock')
+    .set('setImmediate', true)
+    .set('fs', 'empty')
+    .set('tls', 'empty');
 
-    config.module
-      .rule('woff')
-      .test(/\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
-      .loader('url', URL_LOADER, {
-        limit: '10000',
-        mimetype: 'application/font-woff'
-      });
+  config.module
+    .rule('html')
+    .test(/\.html$/)
+    .loader('file', FILE_LOADER, {
+      name: '[name].[ext]'
+    });
 
-    config.module
-      .rule('ttf')
-      .test(/\.ttf(\?v=\d+\.\d+\.\d+)?$/)
-      .loader('url', URL_LOADER, {
-        limit: '10000',
-        mimetype: 'application/octet-stream'
-      });
+  config.module
+    .rule('css')
+    .test(/\.css$/)
+    .loader('style', STYLE_LOADER)
+    .loader('css', CSS_LOADER);
 
-    config.module
-      .rule('eot')
-      .test(/\.eot(\?v=\d+\.\d+\.\d+)?$/)
-      .loader('file', FILE_LOADER);
+  config.module
+    .rule('woff')
+    .test(/\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
+    .loader('url', URL_LOADER, {
+      limit: '10000',
+      mimetype: 'application/font-woff'
+    });
 
-    config.module
-      .rule('svg')
-      .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
-      .loader('url', URL_LOADER, {
-        limit: '10000',
-        mimetype: 'application/svg+xml'
-      });
+  config.module
+    .rule('ttf')
+    .test(/\.ttf(\?v=\d+\.\d+\.\d+)?$/)
+    .loader('url', URL_LOADER, {
+      limit: '10000',
+      mimetype: 'application/octet-stream'
+    });
 
-    config.module
-      .rule('img')
-      .test(/\.(png|jpg)$/)
-      .loader('url', URL_LOADER, {
-        limit: 8192
-      });
+  config.module
+    .rule('eot')
+    .test(/\.eot(\?v=\d+\.\d+\.\d+)?$/)
+    .loader('file', FILE_LOADER);
 
-    config.module
-      .rule('ico')
-      .test(/\.ico(\?v=\d+\.\d+\.\d+)?$/)
-      .loader('url', URL_LOADER);
+  config.module
+    .rule('svg')
+    .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
+    .loader('url', URL_LOADER, {
+      limit: '10000',
+      mimetype: 'application/svg+xml'
+    });
 
-    config
-      .module
-      .rule('compile')
-        .test(/\.js$/)
-        .include(SRC, TEST)
-        .loader('babel', require.resolve('babel-loader'), {
-          presets: [
-            [require.resolve('babel-preset-env'), {
-              modules: false,
-              useBuiltIns: true,
-              include: ['transform-regenerator'],
-              targets: {
-                browsers: [
-                  'last 2 Chrome versions',
-                  'last 2 Firefox versions',
-                  'last 2 Edge versions',
-                  'last 2 Opera versions',
-                  'last 2 Safari versions',
-                  'last 2 iOS versions'
-                ]
-              }
-            }]
-          ],
-          plugins: [],
-          env: {
-            test: {
-              plugins: [
-                // FIXME: This currently breaks the coverage
-                //[require.resolve('babel-plugin-istanbul'), { exclude: ['test/**/*'] }]
+  config.module
+    .rule('img')
+    .test(/\.(png|jpg)$/)
+    .loader('url', URL_LOADER, {
+      limit: 8192
+    });
+
+  config.module
+    .rule('ico')
+    .test(/\.ico(\?v=\d+\.\d+\.\d+)?$/)
+    .loader('url', URL_LOADER);
+
+  config.module
+    .rule('compile')
+      .test(/\.js$/)
+      .include(SRC, TEST)
+      .loader('babel', require.resolve('babel-loader'), {
+        presets: [
+          [require.resolve('babel-preset-env'), {
+            modules: false,
+            useBuiltIns: true,
+            include: ['transform-regenerator'],
+            targets: {
+              browsers: [
+                'last 2 Chrome versions',
+                'last 2 Firefox versions',
+                'last 2 Edge versions',
+                'last 2 Opera versions',
+                'last 2 Safari versions',
+                'last 2 iOS versions'
               ]
             }
+          }]
+        ],
+        env: {
+          production: {
+            presets: [require.resolve('babel-preset-babili')]
           }
-        });
+        }
+      });
 
-    config.module
-      .rule('lint')
-      .loader('eslint', ({ options }) => {
-        return {
-          options: merge(options, {
-            globals: ['Buffer'],
-            envs: ['browser', 'commonjs']
-          })
-        };
+  config.module
+    .rule('lint')
+    .loader('eslint', ({ options }) => {
+      return {
+        options: merge(options, {
+          globals: ['Buffer'],
+          envs: ['browser', 'commonjs']
+        })
+      };
+    });
+
+  config
+    .plugin('env')
+    .use(webpack.EnvironmentPlugin, ['NODE_ENV']);
+
+  config
+    .plugin('html')
+    .use(HtmlPlugin, merge({
+      inject: false,
+      template: htmlTemplate,
+      appMountId: 'root',
+      xhtml: true,
+      mobile: true,
+      minify: {
+        useShortDoctype: true,
+        keepClosingSlash: true,
+        collapseWhitespace: true,
+        preserveLineBreaks: true,
+      }
+    }, PKG.config && PKG.config.html ? PKG.config.html : {}));
+
+  if (process.env.NODE_ENV !== 'test') {
+    config
+      .plugin('chunk')
+      .use(webpack.optimize.CommonsChunkPlugin, {
+        names: ['vendor', 'manifest'],
+        minChunks: Infinity
+      });
+  } else if (process.env.NODE_ENV === 'development') {
+    const protocol = !!process.env.HTTPS ? 'https' : 'http';
+    const host = process.env.HOST || 'localhost';
+    const port = parseInt(process.env.PORT) || 5000;
+
+    config.devServer
+      .host(host)
+      .port(port)
+      .https(protocol === 'https')
+      .contentBase(SRC)
+      .historyApiFallback(true)
+      .hot(true)
+      .stats({
+        assets: false,
+        children: false,
+        chunks: false,
+        colors: true,
+        errors: true,
+        errorDetails: true,
+        hash: false,
+        modules: false,
+        publicPath: false,
+        timings: false,
+        version: false,
+        warnings: true
       });
 
     config
-      .plugin('env')
-      .use(webpack.EnvironmentPlugin, ['NODE_ENV']);
+      .entry('index')
+        .add(`webpack-dev-server/client?${protocol}://${host}:${port}/`)
+        .add('webpack/hot/dev-server');
 
     config
-      .plugin('html')
-      .use(HtmlPlugin, merge({
-        inject: false,
-        template: htmlTemplate,
-        appMountId: 'root',
-        xhtml: true,
-        mobile: true,
-        minify: {
-          useShortDoctype: true,
-          keepClosingSlash: true,
-          collapseWhitespace: true,
-          preserveLineBreaks: true,
-        }
-      }, PKG.config && PKG.config.html ? PKG.config.html : {}));
-
-    if (process.env.NODE_ENV !== 'test') {
-      config
-        .plugin('chunk')
-        .use(webpack.optimize.CommonsChunkPlugin, {
-          names: ['vendor', 'manifest'],
-          minChunks: Infinity
-        });
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      const protocol = !!process.env.HTTPS ? 'https' : 'http';
-      const host = process.env.HOST || 'localhost';
-      const port = parseInt(process.env.PORT) || 5000;
-
-      config.devServer
-        .host(host)
-        .port(port)
-        .https(protocol === 'https')
-        .contentBase(SRC)
-        .historyApiFallback(true)
-        .hot(true)
-        .stats({
-          assets: false,
-          children: false,
-          chunks: false,
-          colors: true,
-          errors: true,
-          errorDetails: true,
-          hash: false,
-          modules: false,
-          publicPath: false,
-          timings: false,
-          version: false,
-          warnings: true
-        });
-
-      config
-        .entry('index')
-          .add(`webpack-dev-server/client?${protocol}://${host}:${port}/`)
-          .add('webpack/hot/dev-server');
-
-      config
-        .plugin('hot')
-        .use(webpack.HotModuleReplacementPlugin);
-    } else if (process.env.NODE_ENV === 'production') {
-      config
-        .plugin('minify')
-        .use(webpack.optimize.UglifyJsPlugin, {
-          sourceMap: false,
-          compress: { warnings: false }
-        });
-
-      config
-        .plugin('minimize')
-        .use(webpack.LoaderOptionsPlugin, { minimize: true });
-    }
-
-    return config;
-  });
+      .plugin('hot')
+      .use(webpack.HotModuleReplacementPlugin);
+  }
 };

--- a/packages/neutrino-preset-web/yarn.lock
+++ b/packages/neutrino-preset-web/yarn.lock
@@ -222,6 +222,10 @@ babel-helper-define-map@^6.22.0:
     babel-types "^6.22.0"
     lodash "^4.2.0"
 
+babel-helper-evaluate-path@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz#1d103ac9d4a59e5d431842212f151785f7ac547b"
+
 babel-helper-explode-assignable-expression@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz#c97bf76eed3e0bae4048121f2b9dae1a4e7d0478"
@@ -229,6 +233,10 @@ babel-helper-explode-assignable-expression@^6.22.0:
     babel-runtime "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-flip-expressions@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz#7bab2cf61162bc92703e9b298ef512bcf77d6787"
 
 babel-helper-function-name@^6.22.0:
   version "6.22.0"
@@ -253,6 +261,18 @@ babel-helper-hoist-variables@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-is-nodes-equiv@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz#34e9b300b1479ddd98ec77ea0bbe9342dfe39684"
+
+babel-helper-is-void-0@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz#ed74553b883e68226ae45f989a99b02c190f105a"
+
+babel-helper-mark-eval-scopes@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.0.2.tgz#909fd1f2384570cd3003283773852d9d63922a37"
 
 babel-helper-optimise-call-expression@^6.22.0:
   version "6.22.0"
@@ -279,6 +299,10 @@ babel-helper-remap-async-to-generator@^6.22.0:
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
 
+babel-helper-remove-or-void@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.0.1.tgz#f602790e465acf2dfbe84fb3dd210c43a2dd7262"
+
 babel-helper-replace-supers@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz#1fcee2270657548908c34db16bcc345f9850cf42"
@@ -289,6 +313,10 @@ babel-helper-replace-supers@^6.22.0:
     babel-template "^6.22.0"
     babel-traverse "^6.22.0"
     babel-types "^6.22.0"
+
+babel-helper-to-multiple-sequence-expressions@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.3.tgz#c789a0faccd2669c51234be2cea7a3e5a0573c25"
 
 babel-helpers@^6.22.0:
   version "6.22.0"
@@ -317,6 +345,65 @@ babel-plugin-check-es2015-constants@^6.3.13:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-minify-constant-folding@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.4.tgz#b6e231026a6035e88ceadd206128d7db2b5c15e6"
+  dependencies:
+    babel-helper-evaluate-path "^0.0.3"
+    jsesc "^2.4.0"
+
+babel-plugin-minify-dead-code-elimination@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.3.tgz#7882c014619934cb9aca69d85c968ed124ac97e3"
+  dependencies:
+    babel-helper-mark-eval-scopes "^0.0.2"
+    babel-helper-remove-or-void "^0.0.1"
+    lodash.some "^4.6.0"
+
+babel-plugin-minify-flip-comparisons@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz#7d0953aa5876ede6118966bda9edecc63bf346ab"
+  dependencies:
+    babel-helper-is-void-0 "^0.0.1"
+
+babel-plugin-minify-guarded-expressions@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz#957104a760e6a7ffd967005a7a11621bb42fd11c"
+  dependencies:
+    babel-helper-flip-expressions "^0.0.2"
+
+babel-plugin-minify-infinity@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz#4cc99b61d12b434ce80ad675103335c589cba9a1"
+
+babel-plugin-minify-mangle-names@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.7.tgz#fcc5f9a4c4c9c0731e73a4a4e3d002fcb800ef41"
+  dependencies:
+    babel-helper-mark-eval-scopes "^0.0.2"
+
+babel-plugin-minify-numeric-literals@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz#9597e6c31154d7daf3744d0bd417c144b275bd53"
+
+babel-plugin-minify-replace@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz#5d5aea7cb9899245248d1ee9ce7a2fe556a8facc"
+
+babel-plugin-minify-simplify@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.7.tgz#4198d589ea10b4bc5bf9310206619a743c0d0664"
+  dependencies:
+    babel-helper-flip-expressions "^0.0.2"
+    babel-helper-is-nodes-equiv "^0.0.1"
+    babel-helper-to-multiple-sequence-expressions "^0.0.3"
+
+babel-plugin-minify-type-constructors@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.3.tgz#ab59c1ad835b6b6e8e932b875d4df4dc393d9d26"
+  dependencies:
+    babel-helper-is-void-0 "^0.0.1"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -514,11 +601,57 @@ babel-plugin-transform-exponentiation-operator@^6.8.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-inline-consecutive-adds@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz#a58fcecfc09c08fbf9373a5a3e70746c03d01fc1"
+
+babel-plugin-transform-member-expression-literals@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.1.tgz#60b78cb2b814ac71dd6104ef51c496c62e877337"
+
+babel-plugin-transform-merge-sibling-variables@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.2.tgz#498acd07481ab340c1bad8b726c2fad1b8f644e5"
+
+babel-plugin-transform-minify-booleans@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.0.tgz#b1a48864a727847696b84eae36fa4d085a54b42b"
+  dependencies:
+    babel-runtime "^6.0.0"
+
+babel-plugin-transform-property-literals@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.1.tgz#05ed01f6024820b18f1d0495c80fe287176bccd9"
+
 babel-plugin-transform-regenerator@^6.6.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"
   dependencies:
     regenerator-transform "0.9.8"
+
+babel-plugin-transform-regexp-constructors@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.5.tgz#74d95e0c567e6fc1d9c699a084894d40de8e581d"
+
+babel-plugin-transform-remove-console@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.0.tgz#c4162f01ee169491776e64093f4dad8d61125a90"
+  dependencies:
+    babel-runtime "^6.0.0"
+
+babel-plugin-transform-remove-debugger@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.0.tgz#d3ece7d8400473f7a706177ba22fd3026ad7e020"
+  dependencies:
+    babel-runtime "^6.0.0"
+
+babel-plugin-transform-remove-undefined@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.5.tgz#12ef11805e06e861dd2eb0c7cc041d2184b8f410"
+
+babel-plugin-transform-simplify-comparison-operators@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.1.tgz#a307088e0d1c728081777fba568f4107396ab25c"
 
 babel-plugin-transform-strict-mode@^6.22.0:
   version "6.22.0"
@@ -526,6 +659,39 @@ babel-plugin-transform-strict-mode@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
+
+babel-plugin-transform-undefined-to-void@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.0.tgz#bc5b6b4908d3b1262170e67cb3963903ddce167e"
+  dependencies:
+    babel-runtime "^6.0.0"
+
+babel-preset-babili@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/babel-preset-babili/-/babel-preset-babili-0.0.11.tgz#9461fd902d6a3c8bc032b8f06c2f691674c12a1f"
+  dependencies:
+    babel-plugin-minify-constant-folding "^0.0.4"
+    babel-plugin-minify-dead-code-elimination "^0.1.3"
+    babel-plugin-minify-flip-comparisons "^0.0.2"
+    babel-plugin-minify-guarded-expressions "^0.0.4"
+    babel-plugin-minify-infinity "^0.0.3"
+    babel-plugin-minify-mangle-names "^0.0.7"
+    babel-plugin-minify-numeric-literals "^0.0.1"
+    babel-plugin-minify-replace "^0.0.1"
+    babel-plugin-minify-simplify "^0.0.7"
+    babel-plugin-minify-type-constructors "^0.0.3"
+    babel-plugin-transform-inline-consecutive-adds "^0.0.2"
+    babel-plugin-transform-member-expression-literals "^6.8.1"
+    babel-plugin-transform-merge-sibling-variables "^6.8.2"
+    babel-plugin-transform-minify-booleans "^6.8.0"
+    babel-plugin-transform-property-literals "^6.8.1"
+    babel-plugin-transform-regexp-constructors "^0.0.5"
+    babel-plugin-transform-remove-console "^6.8.0"
+    babel-plugin-transform-remove-debugger "^6.8.0"
+    babel-plugin-transform-remove-undefined "^0.0.5"
+    babel-plugin-transform-simplify-comparison-operators "^6.8.1"
+    babel-plugin-transform-undefined-to-void "^6.8.0"
+    lodash.isplainobject "^4.0.6"
 
 babel-preset-env@^1.1.8:
   version "1.1.8"
@@ -572,7 +738,7 @@ babel-register@^6.22.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
@@ -1810,6 +1976,10 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.4.0.tgz#8568d223ff69c0b5e081b4f8edf5a23d978c9867"
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -1895,9 +2065,17 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.memoize@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.some@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.uniq@^4.3.0:
   version "4.5.0"

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "ora": "^1.1.0",
     "webpack": "^2.2.1",
+    "webpack-chain": "^1.3.0",
     "webpack-dev-server": "^2.3.0",
-    "webpack-merge": "^2.6.1",
     "yargs": "^6.6.0"
   }
 }

--- a/packages/neutrino/yarn.lock
+++ b/packages/neutrino/yarn.lock
@@ -499,13 +499,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
-  dependencies:
-    ms "0.7.2"
-
-debug@~2.2.0:
+debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1199,7 +1193,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4:
+lodash@^4.14.0, lodash@^4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2135,6 +2129,10 @@ wbuf@^1.1.0, wbuf@^1.4.0:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+webpack-chain@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-1.3.0.tgz#30b9e1429812a9ee8d683ad6e7447f06f2e062ea"
+
 webpack-dev-middleware@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz#7d5be2651e692fddfafd8aaed177c16ff51f0eb8"
@@ -2165,12 +2163,6 @@ webpack-dev-server@^2.3.0:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.9.0"
     yargs "^6.0.0"
-
-webpack-merge@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-2.6.1.tgz#f1d801d2c5d39f83ffec9f119240b3e3be994a1c"
-  dependencies:
-    lodash "^4.17.4"
 
 webpack-sources@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,9 +1389,9 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-oao@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/oao/-/oao-0.4.1.tgz#dddf0b89a2cca6c600cecc036aebbdde7667abbd"
+oao@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/oao/-/oao-0.5.0.tgz#bd8b8534548bd0263cfe8721bccc8e590cae0c8a"
   dependencies:
     babel-polyfill "6.22.0"
     commander "2.9.0"
@@ -1401,7 +1401,7 @@ oao@^0.4.1:
     shelljs "0.7.6"
     split "1.0.0"
     storyboard "^3.0.0-rc.2"
-    storyboard-preset-console "^3.0.0-rc.2"
+    storyboard-preset-console "^3.0.0-rc.4"
     timm "^1.2.3"
 
 oauth-sign@~0.8.0, oauth-sign@~0.8.1:
@@ -1842,9 +1842,9 @@ storyboard-listener-console@^3.0.0-rc.2:
   dependencies:
     timm "^1.2.3"
 
-storyboard-preset-console@^3.0.0-rc.2:
-  version "3.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/storyboard-preset-console/-/storyboard-preset-console-3.0.0-rc.2.tgz#7dc2984c802a3b7754af48c981d0020aaad68409"
+storyboard-preset-console@^3.0.0-rc.4:
+  version "3.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/storyboard-preset-console/-/storyboard-preset-console-3.0.0-rc.4.tgz#6aed03b299d8f2a60b917dc61526bec1b8efa092"
   dependencies:
     storyboard-listener-console "^3.0.0-rc.2"
 


### PR DESCRIPTION
- No more need to return configuration
- No more need for presets to merge configuration
- No special API to extend a preset; simply call it with a Neutrino instance
- No more need for presets to instantiate webpack-chain
- No more dual configuration API when configuring and responding to events
- Config from package.json no longer matches webpack config, but rather, maps to merge-able webpack-chain object
- Switched from Uglify to Babili since babel-preset-env won't convert backticks to strings in web preset without breaking Uglify

### Preset API

- Configuration

```js
module.exports = neutrino => {
  // modify Neutrino configuration instance
  neutrino.config...
}
```

- Configuration with extending

```js
const otherPreset = require('neutrino-preset-something');

module.exports = neutrino => {
  otherPreset(neutrino);

  // modify Neutrino configuration instance
  neutrino.config...
};
```

- Configuration "schema" for package.json (will be converted into something usable by webpack-chain)

Note that while webpack-chain can take `plugin` from a config object, we can't do this from JSON, so it's not in Neutrino.

```json
{
  "config": {
    "neutrino": {
      "target": "web",
      "output": {
        "publicPath": "./"
      },
      "node": {
        "console": false
      },
      "resolve": {
        "extensions": ".jsx"
      },
      "resolveLoader": {
        "modules": "./modules"
      },
      "devServer": {
        "port": 4500
      },
      "entry": {
        "vendor": [
          "react"
        ]
      },
      "module": {
        "rule": {
          "compile": {
            "loader": {
              "babel": {
                "loader": "babel-loader",
                "options": {}
              }
            }
          }
        }
      }
    }
  }
}
```