### PR TITLE
Fix typo in preset-jest

### DIFF
--- a/docs/presets/neutrino-preset-jest/README.md
+++ b/docs/presets/neutrino-preset-jest/README.md
@@ -31,7 +31,7 @@ another Neutrino preset for building your application source code.
 #### npm
 
 ```bash
-❯ npm install --save-dev neutrino-preset-mocha
+❯ npm install --save-dev neutrino-preset-jest
 ```
 
 ## Project Layout
@@ -65,7 +65,7 @@ let's pretend this is a Node.js project:
 ```json
 {
   "scripts": {
-    "test": "neutrino test --presets neutrino-preset-node neutrino-preset-mocha"
+    "test": "neutrino test --presets neutrino-preset-node neutrino-preset-jest"
   }
 }
 ```


### PR DESCRIPTION
Documentation shows that to use jest, you must install the Jest presets and use the Mocha script. Which does not work.

Signed-off-by: Marco Casula <mc@clickbit.net>