### PR TITLE
missing object in the example of preset

### DIFF
--- a/docs/creating-presets.md
+++ b/docs/creating-presets.md
@@ -107,7 +107,7 @@ Let's edit this `index.js` file to add our preset:
 const path = require('path');
 
 module.exports = neutrino => {
-  neutrino.config
+  neutrino.config.module
     .rule('lint')
       .pre()
       .test(/\.jsx?$/)


### PR DESCRIPTION
`neutrino.config` exposes many objects. In order to create a _webpack's pipe_ it is necessary to use `neutrino.config.module`


Signed-off-by: Marco Casula <mc@clickbit.net>