### PR TITLE
Adding Module to preset config

### DIFF
--- a/docs/presets/neutrino-lint-base/README.md
+++ b/docs/presets/neutrino-lint-base/README.md
@@ -78,7 +78,7 @@ const merge = require('deepmerge');
 
 module.exports = neutrino => {
   lint(neutrino);
-  neutrino.config
+  neutrino.config.module
     .rule('lint')
     .loader('eslint', props => merge(props, {
       options: {
@@ -98,7 +98,7 @@ const merge = require('deepmerge');
 
 module.exports = neutrino => {
   lint(neutrino);
-  neutrino.config
+  neutrino.config.module
     .rule('lint')
     .loader('eslint', props => merge(props, {
       options: {


### PR DESCRIPTION
Added the `.module` to the `neutrino.config.rule()` statement.