### PR TITLE
Add community presets page to docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
   "title": "Neutrino",
   "root": "./docs",
-  "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
+  "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs", "npmsearchlist"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/docs",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   * [Karma](/presets/neutrino-preset-karma/README.md)
   * [Mocha](/presets/neutrino-preset-mocha/README.md)
   * [Jest](/presets/neutrino-preset-jest/README.md)
+  * [Community presets](/presets/community-presets.md)
 * [Customization](/customization/README.md)
   * [Simple](/customization/simple.md)
   * [Advanced](/customization/advanced.md)

--- a/docs/presets/community-presets.md
+++ b/docs/presets/community-presets.md
@@ -1,0 +1,12 @@
+# Community Presets
+
+A collection of Neutrino presets published on npm. In order to have your preset show up in this list, it must:
+
+- Be published to npm
+- Contain the `neutrino-preset` keyword in package.json
+- Not be deprecated
+
+It should also have a relevant description. If you prefer, you can also add your preset to the
+[neutrino-dev wiki](https://github.com/mozilla-neutrino/neutrino-dev/wiki/Community-Presets).
+
+{% npmsearchlist "keywords:neutrino-preset+not:deprecated" %}{% endnpmsearchlist %}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gitbook-plugin-anchorjs": "^1.1.1",
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-github": "^2.0.0",
+    "gitbook-plugin-npmsearchlist": "^1.0.0",
     "gitbook-plugin-prism": "^2.1.0",
     "oao": "^0.5.7"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,6 +634,10 @@ gitbook-plugin-github@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/gitbook-plugin-github/-/gitbook-plugin-github-2.0.0.tgz#5166e763cfcc402d432880b7a6c85c1c54b56a8d"
 
+gitbook-plugin-npmsearchlist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gitbook-plugin-npmsearchlist/-/gitbook-plugin-npmsearchlist-1.0.0.tgz#b3672d7b511c340fb4464d542671aa977c81bde4"
+
 gitbook-plugin-prism@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/gitbook-plugin-prism/-/gitbook-plugin-prism-2.1.0.tgz#adab85359095c200ff20d7213920114ce177be51"
@@ -1815,13 +1819,13 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", semver@5.1.0, "semver@^2.3.0 || 3.x || 4 || 5", semver@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
-
-semver@5.3.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", semver@5.3.0, "semver@^2.3.0 || 3.x || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@5.1.0, semver@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
 
 semver@^4.0.3, semver@^4.1.0:
   version "4.3.6"


### PR DESCRIPTION
Adds a new "Community Presets" page which auto-populates search results from npms.io with packages matching `keyword:neutrino-preset`.

Resolves #75.