### PR TITLE
dev-server/client host/port fix

### DIFF
--- a/packages/neutrino-preset-web/src/index.js
+++ b/packages/neutrino-preset-web/src/index.js
@@ -183,8 +183,12 @@ module.exports = ({ config }) => {
 
   if (process.env.NODE_ENV === 'development') {
     const protocol = !!process.env.HTTPS ? 'https' : 'http';
-    const host = process.env.HOST || 'localhost';
-    const port = parseInt(process.env.PORT) || 5000;
+    const host = process.env.HOST
+      || PKG.config && PKG.config.devServer && PKG.config.devServer.host
+      || 'localhost';
+    const port = parseInt(process.env.PORT)
+      || PKG.config && PKG.config.devServer && parseInt(PKG.config.devServer.port)
+      || 5000;
 
     config.devtool('eval');
     config.devServer


### PR DESCRIPTION
client entry file no longer receives default host and post when the
user sets host and port via config