### PR TITLE
dev-server/client host/port fix

### DIFF
--- a/packages/neutrino-preset-web/src/index.js
+++ b/packages/neutrino-preset-web/src/index.js
@@ -183,8 +183,12 @@ module.exports = ({ config }) => {
 
   if (process.env.NODE_ENV === 'development') {
     const protocol = !!process.env.HTTPS ? 'https' : 'http';
-    const host = process.env.HOST || 'localhost';
-    const port = parseInt(process.env.PORT) || 5000;
+    const host = process.env.HOST ||
+      PKG.config && PKG.config.neutrino && PKG.config.neutrino.devServer && PKG.config.neutrino.devServer.host ||
+      'localhost';
+    const port = parseInt(process.env.PORT) ||
+      PKG.config && PKG.config.devServer && PKG.config.neutrino.devServer && parseInt(PKG.config.neutrino.devServer.port) ||
+      5000;
 
     config.devtool('eval');
     config.devServer


### PR DESCRIPTION
client entry file no longer receives default host and post when the
user sets host and port via config

maybe some kind of deepPick function would be better here?
reopened from #80 


-------------------------
Sorry I don't think I explained the issue properly.

The problem that i'm seeing is that the dev-server is running on port 4999 but the webpack-dev-server/client is trying to send websocket connections to port 5000 still.

From look at the code it doesn't seem like package.json config will ever reach the variables `port` and `host` in the changed file. 

This is the error:
```
abstract-xhr.js:132 GET http://localhost:5000/sockjs-node/info?t=1488326064431 net::ERR_CONNECTION_REFUSED
```

it can be fixed by doing `PORT=4999 yarn start` but I'm assuming you also want port configured inside package.json to be applied to the client.

my package.json config looks like so 
```
  "config": {
    "neutrino": {
      "devServer": {
        "port": 4999
      }
    },
    "presets": [
      "neutrino-preset-infl.js"
    ]
  },
```
TLDR: the dev-server is running at the proper port, but webpack-dev-server/client is trying to talk to the default port.
