### PR TITLE
Make sourcemap support optional for node libraries

### DIFF
--- a/docs/presets/neutrino-preset-node/README.md
+++ b/docs/presets/neutrino-preset-node/README.md
@@ -35,6 +35,20 @@
 ❯ npm install --save-dev neutrino neutrino-preset-node
 ```
 
+If you want to have automatically wired sourcemaps added to your project, add `source-map-support`:
+
+#### Yarn
+
+```bash
+❯ yarn add source-map-support
+```
+
+#### npm
+
+```bash
+❯ npm install --save source-map-support
+```
+
 ## Project Layout
 
 `neutrino-preset-node` follows the standard [project layout](/project-layout.md) specified by Neutrino. This
@@ -180,7 +194,8 @@ The following is a list of rules and their identifiers which can be overridden:
 
 The following is a list of plugins and their identifiers which can be overridden:
 
-- `banner`: Injects source-map-support into the entry point of your application.
+- `banner`: Injects source-map-support into the entry point of your application if detected in `dependencies` or
+`devDependencies` of your package.json.
 - `copy`: Copies non-JS files from `src` to `build` when using `neutrino build`.
 - `clean`: Clears the contents of `build` prior to creating a production bundle.
 - `progress`: Displays a progress bar when using `neutrino build`.

--- a/packages/neutrino-preset-node/package.json
+++ b/packages/neutrino-preset-node/package.json
@@ -22,7 +22,6 @@
     "exports-loader": "^0.6.4",
     "imports-loader": "^0.7.1",
     "progress-bar-webpack-plugin": "^1.9.3",
-    "source-map-support": "^0.4.6",
     "webpack": "^2.2.1",
     "webpack-node-externals": "1.5.4"
   },

--- a/packages/neutrino-preset-node/src/index.js
+++ b/packages/neutrino-preset-node/src/index.js
@@ -14,9 +14,12 @@ const BUILD = path.join(CWD, 'build');
 const TEST = path.join(CWD, 'test');
 const PROJECT_MODULES = path.join(CWD, 'node_modules');
 const MODULES = path.join(__dirname, '../node_modules');
+const PKG = require(path.join(CWD, 'package.json'));
 
 module.exports = neutrino => {
   const { config } = neutrino;
+  const hasSourceMap = (PKG.dependencies && 'source-map-support' in PKG.dependencies) ||
+    (PKG.devDependencies && 'source-map-support' in PKG.devDependencies);
 
   config
     .target('node')
@@ -53,13 +56,15 @@ module.exports = neutrino => {
 
   config.options.set('performance', { hints: false });
 
-  config
-    .plugin('banner')
-    .use(webpack.BannerPlugin, {
-      banner: `require('${require.resolve('source-map-support')}').install();`,
-      raw: true,
-      entryOnly: true
-    });
+  if (hasSourceMap) {
+    config
+      .plugin('banner')
+      .use(webpack.BannerPlugin, {
+        banner: `require('source-map-support').install();`,
+        raw: true,
+        entryOnly: true
+      });
+  }
 
   if (config.module.rules.has('lint')) {
     config.module

--- a/packages/neutrino-preset-node/yarn.lock
+++ b/packages/neutrino-preset-node/yarn.lock
@@ -2184,7 +2184,7 @@ source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
-source-map-support@^0.4.2, source-map-support@^0.4.6:
+source-map-support@^0.4.2:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.11.tgz#647f939978b38535909530885303daf23279f322"
   dependencies:


### PR DESCRIPTION
Since libraries don't necessarily need source-map-support, we are switching this to optional. If it is detected in `dependencies` or `devDependencies` we add it as a banner to the bundle, otherwise we don't. Also, this adds it back as a module, not a path, since it should be relative to the bundle, not the preset.

This should fix #84.