### PR TITLE
Add support building react-native app

### DIFF
--- a/packages/neutrino-preset-react/index.js
+++ b/packages/neutrino-preset-react/index.js
@@ -20,6 +20,7 @@ module.exports = (neutrino) => {
 
   config.resolve.modules.add(MODULES);
   config.resolve.extensions.add('.jsx');
+  config.resolve.alias.set('react-native', 'react-native-web');
   config.resolveLoader.modules.add(MODULES);
   config.externals({
     'react/addons': true,


### PR DESCRIPTION
Based on [create-react-app webpack config](https://github.com/facebookincubator/create-react-app/blob/7c899fc392c7065b4d041d463b0a947b602ed356/packages/react-scripts/config/webpack.config.dev.js#L93)

Probably needs a merge with existing configuration aliases, e.g.
```javascript
config.resolve.set('alias', Object.assign({ 'react-native': 'react-native-web' }, config.resolve.get('alias'));
```

Do you think it's a good idea to add it to this preset?