### PR TITLE
Should generate correct sourcemaps during dev

### DIFF
--- a/packages/neutrino-preset-web/index.js
+++ b/packages/neutrino-preset-web/index.js
@@ -105,7 +105,7 @@ module.exports = neutrino => {
     });
 
     config
-      .devtool('eval')
+      .devtool('source-map')
       .entry('index')
         .add(`webpack-dev-server/client?${protocol}://${host}:${port}/`)
         .add('webpack/hot/dev-server');


### PR DESCRIPTION
The current [devtool](https://webpack.js.org/configuration/devtool/) configuration of `eval` makes it very difficult to debug your source code when running the development command `neutrino start`.

I did some digging and there is an issue with sourcemaps and Webpack 2. See https://github.com/webpack/webpack/issues/3165 and https://github.com/webpack/webpack/issues/4423 for more information.

In the meantime, it would be great if the default setting for the development command `neutrino start` would generate correct sourcemaps with a reference to the original source and allow you to set breakpoints correctly. I did some tests in OS X Chrome v56.0.2924.87 (64-bit) by trying different [devtool](https://webpack.js.org/configuration/devtool/) configurations in a custom neutrino config that extends `neutrino-preset-web`.

### devtool test results

* `eval`: reports correct line in transformed code, and breakpoints work, but difficult to debug
* `cheap-eval-source-map`: reports incorrect line in transformed code, breakpoints can be added, but are on incorrect line and don't work
* `cheap-source-map`: reports incorrect line in transformed code, breakpoints work, but are on incorrect line
* `cheap-module-eval-source-map`: reports incorrect line in source, breakpoints can be added, but are on incorrect line and don't work
* `cheap-module-source-map`: reports incorrect line in source, breakpoints work, but are on incorrect line
* `eval-source-map`: reports correct line in source, but breakpoints don't work
* `source-map`: reports correct line in source, and breakpoints work
* `nosources-source-map`: reports correct line in source, but no source is generated

If you are just running `neutrino-preset-web` out of the box you should be able to debug your code easily. Making this change can cause slower rebuilds, but I'd be willing to wait a few 100ms (or whatever `--` means in time) to rebuild my code for better debugging.

If and when the above Webpack 2 issues are fixed, I would suggest revisiting the `devtool` option by changing it to `cheap-module-eval-source-map` or `eval-source-map` for speedier rebuilds with sourcemaps that point to source code vs transpiled code.