### PR TITLE
Defer test configuration overrides until on:test

### DIFF
--- a/packages/neutrino-preset-jest/src/index.js
+++ b/packages/neutrino-preset-jest/src/index.js
@@ -34,39 +34,39 @@ function normalizeJestOptions(jestOptions, config, args) {
 }
 
 module.exports = neutrino => {
-  const jestOptions = merge({
-    bail: true,
-    transform: {
-      "\\.(js|jsx)$": require.resolve('./transformer')
-    },
-    roots: [neutrino.options.tests],
-    testRegex: '(_test|_spec|\\.test|\\.spec)\\.jsx?$',
-    moduleFileExtensions: ['js', 'jsx'],
-    moduleDirectories: [join(__dirname, '../node_modules')],
-    moduleNameMapper: {
-      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve('./file-mock'),
-      '\\.(css|less|sass)$': require.resolve('./style-mock')
-    }
-  }, neutrino.options.jest || {});
-
-  neutrino.use(loaderMerge('compile', 'babel'), {
-    env: {
-      test: {
-        retainLines: true,
-        presets: [require.resolve('babel-preset-jest')],
-        plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
-      }
-    }
-  });
-
-  if (neutrino.config.module.rules.has('lint')) {
-    neutrino.use(loaderMerge('lint', 'eslint'), {
-      plugins: ['jest'],
-      envs: ['jest']
-    });
-  }
-
   neutrino.on('test', args => {
+    const jestOptions = merge({
+      bail: true,
+      transform: {
+        "\\.(js|jsx)$": require.resolve('./transformer')
+      },
+      roots: [neutrino.options.tests],
+      testRegex: '(_test|_spec|\\.test|\\.spec)\\.jsx?$',
+      moduleFileExtensions: ['js', 'jsx'],
+      moduleDirectories: [join(__dirname, '../node_modules')],
+      moduleNameMapper: {
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve('./file-mock'),
+        '\\.(css|less|sass)$': require.resolve('./style-mock')
+      }
+    }, neutrino.options.jest || {});
+
+    neutrino.use(loaderMerge('compile', 'babel'), {
+      env: {
+        test: {
+          retainLines: true,
+          presets: [require.resolve('babel-preset-jest')],
+          plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
+        }
+      }
+    });
+
+    if (neutrino.config.module.rules.has('lint')) {
+      neutrino.use(loaderMerge('lint', 'eslint'), {
+        plugins: ['jest'],
+        envs: ['jest']
+      });
+    }
+
     const options = normalizeJestOptions(jestOptions, neutrino.config, args);
     const configFile = join(tmpdir(), 'config.json');
 

--- a/packages/neutrino-preset-karma/index.js
+++ b/packages/neutrino-preset-karma/index.js
@@ -3,43 +3,41 @@ const merge = require('deepmerge');
 const { join } = require('path');
 
 module.exports = (neutrino) => {
-  const tests = join(neutrino.options.tests, '**/*_test.js');
-  const sources = join(neutrino.options.source, '**/*.js');
-
-  const defaults = {
-    plugins: [
-      require.resolve('karma-webpack'),
-      require.resolve('karma-chrome-launcher'),
-      require.resolve('karma-coverage'),
-      require.resolve('karma-mocha'),
-      require.resolve('karma-mocha-reporter')
-    ],
-    basePath: neutrino.options.root,
-    browsers: [process.env.CI ? 'ChromeCI' : 'Chrome'],
-    customLaunchers: {
-      ChromeCI: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
-    frameworks: ['mocha'],
-    files: [tests],
-    preprocessors: {
-      [tests]: ['webpack'],
-      [sources]: ['webpack']
-    },
-    webpackMiddleware: { noInfo: true },
-    reporters: ['mocha', 'coverage'],
-    coverageReporter: {
-      dir: '.coverage',
-      reporters: [
-        { type: 'html', subdir: 'report-html' },
-        { type: 'lcov', subdir: 'report-lcov' }
-      ]
-    }
-  };
-
   neutrino.on('test', ({ files, watch }) => {
+    const tests = join(neutrino.options.tests, '**/*_test.js');
+    const sources = join(neutrino.options.source, '**/*.js');
+    const defaults = {
+      plugins: [
+        require.resolve('karma-webpack'),
+        require.resolve('karma-chrome-launcher'),
+        require.resolve('karma-coverage'),
+        require.resolve('karma-mocha'),
+        require.resolve('karma-mocha-reporter')
+      ],
+      basePath: neutrino.options.root,
+      browsers: [process.env.CI ? 'ChromeCI' : 'Chrome'],
+      customLaunchers: {
+        ChromeCI: {
+          base: 'Chrome',
+          flags: ['--no-sandbox']
+        }
+      },
+      frameworks: ['mocha'],
+      files: [tests],
+      preprocessors: {
+        [tests]: ['webpack'],
+        [sources]: ['webpack']
+      },
+      webpackMiddleware: { noInfo: true },
+      reporters: ['mocha', 'coverage'],
+      coverageReporter: {
+        dir: '.coverage',
+        reporters: [
+          { type: 'html', subdir: 'report-html' },
+          { type: 'lcov', subdir: 'report-lcov' }
+        ]
+      }
+    };
     const karma = merge.all([
       defaults,
       neutrino.options.karma || {},

--- a/packages/neutrino-preset-mocha/src/index.js
+++ b/packages/neutrino-preset-mocha/src/index.js
@@ -3,17 +3,19 @@ const merge = require('deepmerge');
 const loaderMerge = require('neutrino-middleware-loader-merge');
 
 module.exports = neutrino => {
-  neutrino.use(loaderMerge('compile', 'babel'), {
-    env: {
-      test: {
-        plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
+  neutrino.on('test', ({ files }) => {
+    neutrino.use(loaderMerge('compile', 'babel'), {
+      env: {
+        test: {
+          plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
+        }
       }
-    }
-  });
+    });
 
-  neutrino.on('test', ({ files }) => mocha(
-    merge({ reporter: 'spec', ui: 'tdd', bail: true }, neutrino.options.mocha || {}),
-    neutrino.config.module.rule('compile').use('babel').get('options'),
-    files
-  ));
+    return mocha(
+      merge({ reporter: 'spec', ui: 'tdd', bail: true }, neutrino.options.mocha || {}),
+      neutrino.config.module.rule('compile').use('babel').get('options'),
+      files
+    )
+  });
 };


### PR DESCRIPTION
Fixes #107 by deferring the override of configuration until testing is done. This also prevents bugs in changing configs and options that should only be done in test mode, giving other presets a chance to preload prior to the test runner.