### PR TITLE
Fix svg mime-type

### DIFF
--- a/packages/neutrino-middleware-image-loader/index.js
+++ b/packages/neutrino-middleware-image-loader/index.js
@@ -9,7 +9,7 @@ module.exports = ({ config }, options) => {
     .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options({ limit, mimetype: 'application/svg+xml' });
+      .options({ limit, mimetype: 'image/svg+xml' });
 
   config.module
     .rule('img')


### PR DESCRIPTION
Browsers don't display svg from data-uri if the mimetype is `application/svg+xml` (testing with `<img>` tag in Firefox and Chrome). However, `image/svg+xml` works.