### PR TITLE
Cleanly exit command processes.

### DIFF
--- a/packages/neutrino/src/webpack/develop.js
+++ b/packages/neutrino/src/webpack/develop.js
@@ -23,6 +23,4 @@ module.exports = _config => new Promise((resolve) => {
       building.start();
     });
   });
-
-  process.on('SIGINT', resolve);
 });

--- a/packages/neutrino/src/webpack/watch.js
+++ b/packages/neutrino/src/webpack/watch.js
@@ -6,10 +6,8 @@ module.exports = config => new Promise((resolve) => {
   const compiler = webpack(config);
   const building = ora('Waiting for initial build to finish').start();
 
-  const watcher = compiler.watch(config.watchOptions || {}, handle((errors) => {
+  compiler.watch(config.watchOptions || {}, handle((errors) => {
     building.succeed('Build completed');
     logErrors(errors);
   }));
-
-  process.on('SIGINT', () => watcher.close(resolve));
 });


### PR DESCRIPTION
Previously `process.exit()` was chained off of the command called in `neutrino/bin`. This had undesired consequences of not processing code attached to the webpack `done` event.

The `process.exit()` call was thought to be unnecessary as the process would exit naturally with the exitcode of 0.

What I missed was that the commands `develop` and `watch` implement   handlers `process.on('SIGINT', () => ` which removes the default behavior of exiting the process.

https://nodejs.org/api/process.html#process_signal_events

> SIGTERM and SIGINT have default handlers on non-Windows platforms that resets the terminal mode before exiting with code 128 + signal number. If one of these signals has a listener installed, its default behavior will be removed (Node.js will no longer exit).

---

Reimplementing the default behavior of calling exit on the process, fixes the issue of ports remaining open after run.

*Two things to note:*

1. `watcher.close(resolve)` was removed. `SIGINT` is meant to be immediately handled, and adding async functionality inside of it, does not quite make sense. Additionally, the explicit call to exit should result in the watch process stopping as well.
2. `process.nextTick(() => process.exit(0))` was added to allow the Promise to resolve prior to exiting. I'm not necessarily a fan of this, but it keeps the previous functionality.

Which leaves me with a final question... Is it important the promise resolves after there was clear intent to immediately exit the process? I think if the choice were up to me, I would remove `process.on('SIGINT'` altogether and just allow the process to naturally terminate.