### PR TITLE
Update upgrading-neutrino.md (eslint middleware)

### DIFF
--- a/docs/upgrading-neutrino.md
+++ b/docs/upgrading-neutrino.md
@@ -167,7 +167,9 @@ neutrino.config.module
 const eslint = require('neutrino-middleware-eslint');
 
 neutrino.use(eslint, {
-  rules: { /* */ }
+  eslint: {
+    rules: { /* */ }
+  }
 })
 ```
 


### PR DESCRIPTION
The code explaining the usage of `neutrino-middleware-eslint` was wrong here.
It caused me a great headache last night, when I was migrating a pair of eslint presets.
Thank god [eslint middleware documentation page](https://neutrino.js.org/middleware/neutrino-middleware-eslint/) is OK and you can
compare and infer the correct usage.