### PR TITLE
use correct value for package.json config

### DIFF
--- a/docs/customization/advanced.md
+++ b/docs/customization/advanced.md
@@ -41,7 +41,7 @@ your project._
 
 ```json
 {
-  "config": {
+  "neutrino": {
     "use": [
       "neutrino-preset-react",
       "neutrino-preset-karma",


### PR DESCRIPTION
This might have been an old way to define the configuration?
Only works when I use `neutrino`, otherwise I get an error:
```
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
- configuration misses the property 'entry'.
...
```