### PR TITLE
Allow setting karma middleware options as overridable

### DIFF
--- a/packages/neutrino-preset-karma/index.js
+++ b/packages/neutrino-preset-karma/index.js
@@ -2,51 +2,55 @@ const { Server } = require('karma');
 const merge = require('deepmerge');
 const { join } = require('path');
 
-module.exports = (neutrino) => {
+module.exports = (neutrino, tap) => {
+  const tests = join(neutrino.options.tests, '**/*_test.js');
+  const sources = join(neutrino.options.source, '**/*.js*');
+  const defaults = {
+    plugins: [
+      require.resolve('karma-webpack'),
+      require.resolve('karma-chrome-launcher'),
+      require.resolve('karma-coverage'),
+      require.resolve('karma-mocha'),
+      require.resolve('karma-mocha-reporter')
+    ],
+    basePath: neutrino.options.root,
+    browsers: [process.env.CI ? 'ChromeCI' : 'Chrome'],
+    customLaunchers: {
+      ChromeCI: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+    frameworks: ['mocha'],
+    files: [tests],
+    preprocessors: {
+      [tests]: ['webpack'],
+      [sources]: ['webpack']
+    },
+    webpackMiddleware: { noInfo: true },
+    reporters: ['mocha', 'coverage'],
+    coverageReporter: {
+      dir: '.coverage',
+      reporters: [
+        { type: 'html', subdir: 'report-html' },
+        { type: 'lcov', subdir: 'report-lcov' }
+      ]
+    }
+  };
+
+  Object.assign(neutrino.options, {
+    karma: merge(defaults, neutrino.options.karma || {})
+  });
+
   neutrino.on('test', ({ files, watch }) => {
-    const tests = join(neutrino.options.tests, '**/*_test.js');
-    const sources = join(neutrino.options.source, '**/*.js');
-    const defaults = {
-      plugins: [
-        require.resolve('karma-webpack'),
-        require.resolve('karma-chrome-launcher'),
-        require.resolve('karma-coverage'),
-        require.resolve('karma-mocha'),
-        require.resolve('karma-mocha-reporter')
-      ],
-      basePath: neutrino.options.root,
-      browsers: [process.env.CI ? 'ChromeCI' : 'Chrome'],
-      customLaunchers: {
-        ChromeCI: {
-          base: 'Chrome',
-          flags: ['--no-sandbox']
-        }
-      },
-      frameworks: ['mocha'],
-      files: [tests],
-      preprocessors: {
-        [tests]: ['webpack'],
-        [sources]: ['webpack']
-      },
-      webpackMiddleware: { noInfo: true },
-      reporters: ['mocha', 'coverage'],
-      coverageReporter: {
-        dir: '.coverage',
-        reporters: [
-          { type: 'html', subdir: 'report-html' },
-          { type: 'lcov', subdir: 'report-lcov' }
-        ]
-      }
-    };
-    const karma = merge.all([
-      defaults,
-      neutrino.options.karma || {},
-      {
-        singleRun: !watch,
-        autoWatch: watch,
-        webpack: neutrino.config.toConfig()
-      }
-    ]);
+    const base = typeof tap === 'function' ?
+      tap(neutrino.options.karma) :
+      neutrino.options.karma;
+    const karma = merge(base, {
+      singleRun: !watch,
+      autoWatch: watch,
+      webpack: neutrino.config.toConfig()
+    });
 
     delete karma.webpack.plugins;
 

--- a/packages/neutrino/bin/test.js
+++ b/packages/neutrino/bin/test.js
@@ -4,4 +4,8 @@ module.exports = (middleware, options) => test(middleware, options)
   .fork((err) => {
     console.error(err.stack || err);
     process.exit(1);
-  }, Function.prototype);
+  }, () => {
+    // Some test runners do not cleanly exit after resolving their promise.
+    // Force exit once we get here.
+    process.exit(0);
+  });


### PR DESCRIPTION
Right now setting `neutrino.options.karma` will merge the configuration, which can cause duplication problems.