### PR TITLE
fix eslint-semi-off middleware example

### DIFF
--- a/packages/neutrino-preset-airbnb-base/README.md
+++ b/packages/neutrino-preset-airbnb-base/README.md
@@ -195,8 +195,10 @@ const airbnb = require('neutrino-preset-airbnb-base');
 
 module.exports = neutrino => {
   neutrino.use(airbnb, {
-    rules: {
-      semi: 'off'
+    eslint: {
+      rules: {
+        semi: 'off'
+      }
     }
   });
 };


### PR DESCRIPTION

`neutrino-preset-airbnb-base` looks like below, `options` to merge should have same structure as neutrino-preset-airbnb-base's ? 

```
(neutrino, options) => {
  neutrino.use(lint, merge({
    eslint: {
      baseConfig: {
        extends: ['airbnb-base']
      },
      rules: {
        // handled by babel rules
        'new-cap': 'off',

        // handled by babel rules
        'object-curly-spacing': 'off',

        // require a capital letter for constructors
        'babel/new-cap': ['error', { newIsCap: true }],

        // require padding inside curly braces
        'babel/object-curly-spacing': ['error', 'always']
      }
    }
  }, options));
```