### PR TITLE
Add React Router starter kit and blog post

### DIFF
--- a/docs/learning-resources.md
+++ b/docs/learning-resources.md
@@ -9,6 +9,7 @@ community, file an issue or submit a pull request.
 * [Modern JavaScript Apps with Neutrino](https://davidwalsh.name/neutrino) by [@eliperelman](https://twitter.com/eliperelman)
 * [Using Neutrino to jump-start modern JavaScript development](https://hacks.mozilla.org/2017/02/using-neutrino-for-modern-javascript-development/) by [@eliperelman](https://twitter.com/eliperelman)
 * [Custom Neutrino Linting](https://davidwalsh.name/neutrino-linting) by [@davidwalshblog](https://twitter.com/davidwalshblog)
+* [Code Splitting for React Router with Webpack and HMR](https://medium.com/@hassanhelfi/code-splitting-for-react-router-with-webpack-and-hmr-bb509968e86f) by [@hassanhelfi](https://twitter.com/hassanhelfi)
 
 ## Screencasts & Videos
 
@@ -17,5 +18,6 @@ community, file an issue or submit a pull request.
 * [mozilla-neutrino/node-starter](https://github.com/mozilla-neutrino/node-starter)
 * [mozilla-neutrino/express-starter](https://github.com/mozilla-neutrino/express-starter)
 * [mozilla-neutrino/react-starter](https://github.com/mozilla-neutrino/react-starter)
+* [mozilla-neutrino/react-router-starter](https://github.com/mozilla-neutrino/react-router-starter)
 * [mozilla-neutrino/web-starter](https://github.com/mozilla-neutrino/web-starter)
 * [jerolimov/feathers-starter](https://github.com/jerolimov/feathers-starter)


### PR DESCRIPTION
* Add [blog post](https://medium.com/@hassanhelfi/code-splitting-for-react-router-with-webpack-and-hmr-bb509968e86f) on how to do code splitting with react router
* Add `react-router-starter` to list of starter kit repositories