### PR TITLE
neutrino-middleware-image-loader: Use svg-url-loader for svg rule

### DIFF
--- a/packages/neutrino-middleware-image-loader/index.js
+++ b/packages/neutrino-middleware-image-loader/index.js
@@ -3,13 +3,14 @@ const merge = require('deepmerge');
 module.exports = ({ config }, options) => {
   const { limit } = merge({ limit: 8192 }, options);
   const urlLoader = require.resolve('url-loader');
+  const svgUrlLoader = require.resolve('svg-url-loader');
 
   config.module
     .rule('svg')
     .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
-    .use('url')
-      .loader(urlLoader)
-      .options({ limit, mimetype: 'image/svg+xml' });
+    .use('svgUrl')
+      .loader(svgUrlLoader)
+      .options({ limit });
 
   config.module
     .rule('img')

--- a/packages/neutrino-middleware-image-loader/index.js
+++ b/packages/neutrino-middleware-image-loader/index.js
@@ -8,7 +8,7 @@ module.exports = ({ config }, options) => {
   config.module
     .rule('svg')
     .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
-    .use('svgUrl')
+    .use('url')
       .loader(svgUrlLoader)
       .options({ limit });
 

--- a/packages/neutrino-middleware-image-loader/package.json
+++ b/packages/neutrino-middleware-image-loader/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "deepmerge": "^1.3.2",
     "file-loader": "^0.10.1",
+    "svg-url-loader": "^2.0.2",
     "url-loader": "^0.5.8"
   },
   "peerDependencies": {

--- a/packages/neutrino-middleware-image-loader/yarn.lock
+++ b/packages/neutrino-middleware-image-loader/yarn.lock
@@ -14,6 +14,12 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+file-loader@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.10.0.tgz#bbe6db7474ac92c7f54fdc197cf547e98b6b8e12"
+  dependencies:
+    loader-utils "~0.2.5"
+
 file-loader@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.10.1.tgz#815034119891fc6441fb5a64c11bc93c22ddd842"
@@ -23,6 +29,15 @@ file-loader@^0.10.1:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+loader-utils@0.2.16, loader-utils@~0.2.5:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
 
 loader-utils@^1.0.2:
   version "1.0.2"
@@ -35,6 +50,17 @@ loader-utils@^1.0.2:
 mime@1.3.x:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+svg-url-loader@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-2.0.2.tgz#079b4764b4bc12eed9d01b6d76d98e234246194f"
+  dependencies:
+    file-loader "0.10.0"
+    loader-utils "0.2.16"
 
 url-loader@^0.5.8:
   version "0.5.8"


### PR DESCRIPTION
Because base64 encoding SVG content doesn't make sense.