### PR TITLE
add option for node debugging

### DIFF
--- a/packages/neutrino-middleware-start-server/index.js
+++ b/packages/neutrino-middleware-start-server/index.js
@@ -1,13 +1,8 @@
 const StartServerPlugin = require('start-server-webpack-plugin');
 
-module.exports = (neutrino, options) => {
-  if (neutrino.options.args && neutrino.options.args.debug) {
-    // start server with --inspect
-    return neutrino.config.plugin('start-server').use(StartServerPlugin, [{
-      name: options.name,
-      nodeArgs: ['--inspect']
-    }]);
-  }
-  // normal start-server
-  return neutrino.config.plugin('start-server').use(StartServerPlugin, [options.name]);
-};
+module.exports = (neutrino, options) => neutrino.config
+  .plugin('start-server')
+  .use(StartServerPlugin, [{
+    name: options.name,
+    nodeArgs: neutrino.options.debug ? ['--inspect'] : []
+  }]);

--- a/packages/neutrino-middleware-start-server/index.js
+++ b/packages/neutrino-middleware-start-server/index.js
@@ -1,3 +1,13 @@
 const StartServerPlugin = require('start-server-webpack-plugin');
 
-module.exports = ({ config }, options) => config.plugin('start-server').use(StartServerPlugin, [options.name]);
+module.exports = (neutrino, options) => {
+  if (neutrino.options.args && neutrino.options.args.debug) {
+    // start server with --inspect
+    return neutrino.config.plugin('start-server').use(StartServerPlugin, [{
+      name: options.name,
+      nodeArgs: ['--inspect']
+    }]);
+  }
+  // normal start-server
+  return neutrino.config.plugin('start-server').use(StartServerPlugin, [options.name]);
+};

--- a/packages/neutrino-middleware-start-server/package.json
+++ b/packages/neutrino-middleware-start-server/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "start-server-webpack-plugin": "^2.1.2"
+    "start-server-webpack-plugin": "^2.2.0"
   },
   "peerDependencies": {
     "neutrino": "^5.0.0"

--- a/packages/neutrino-middleware-start-server/yarn.lock
+++ b/packages/neutrino-middleware-start-server/yarn.lock
@@ -3,5 +3,5 @@
 
 
 start-server-webpack-plugin@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/start-server-webpack-plugin/-/start-server-webpack-plugin-2.1.2.tgz#5489bd97ec61e85e41038d0063021744d6ed98c3"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/start-server-webpack-plugin/-/start-server-webpack-plugin-2.2.0.tgz#1fab5af8d4bb7cea6b657077d4ce4949c7f7f12e"

--- a/packages/neutrino/bin/neutrino
+++ b/packages/neutrino/bin/neutrino
@@ -30,6 +30,12 @@ const args = yargs
     string: true,
     global: true
   })
+  .option('debug', {
+    description: 'Run in debug mode',
+    boolean: true,
+    default: false,
+    global: true
+  })
   .command('start', 'Build a project in development mode')
   .command('build', 'Compile the source directory to a bundled build')
   .command('test [files..]', 'Run all suites from the test directory or provided files', {
@@ -64,10 +70,12 @@ const normalizeOptions = (args) => {
   const pkg = getPackageJson();
   const options = pathOr({}, ['neutrino', 'options'], pkg);
   const env = args.inspect ? getNodeEnv(args._[0], args.env) : args.env;
+  const debug = args.debug ? args.debug : options.debug;
 
   return Object.assign(options, {
     config: pathOr({}, ['neutrino', 'config'], pkg),
-    args: Object.assign(args, { env })
+    args: Object.assign(args, { env }),
+    debug
   });
 };
 

--- a/packages/neutrino/bin/neutrino
+++ b/packages/neutrino/bin/neutrino
@@ -70,12 +70,11 @@ const normalizeOptions = (args) => {
   const pkg = getPackageJson();
   const options = pathOr({}, ['neutrino', 'options'], pkg);
   const env = args.inspect ? getNodeEnv(args._[0], args.env) : args.env;
-  const debug = args.debug ? args.debug : options.debug;
 
   return Object.assign(options, {
     config: pathOr({}, ['neutrino', 'config'], pkg),
     args: Object.assign(args, { env }),
-    debug
+    debug: args.debug || options.debug
   });
 };
 

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -17,6 +17,7 @@ const getOptions = (options = {}) => {
   let tests = defaultTo('test', options.tests);
   let node_modules = defaultTo('node_modules', options.node_modules); // eslint-disable-line camelcase
   let entry = defaultTo('index', options.entry);
+  let debug = defaultTo(false, options.debug);
 
   Object.defineProperties(options, {
     root: {
@@ -65,6 +66,14 @@ const getOptions = (options = {}) => {
       },
       set(value) {
         entry = defaultTo('index', value);
+      }
+    },
+    debug: {
+      get() {
+        return normalizePath(this.source, debug);
+      },
+      set(value) {
+        debug = defaultTo('index', value);
       }
     }
   });

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -17,7 +17,6 @@ const getOptions = (options = {}) => {
   let tests = defaultTo('test', options.tests);
   let node_modules = defaultTo('node_modules', options.node_modules); // eslint-disable-line camelcase
   let entry = defaultTo('index', options.entry);
-  let debug = defaultTo(false, options.debug);
 
   Object.defineProperties(options, {
     root: {
@@ -66,14 +65,6 @@ const getOptions = (options = {}) => {
       },
       set(value) {
         entry = defaultTo('index', value);
-      }
-    },
-    debug: {
-      get() {
-        return normalizePath(this.source, debug);
-      },
-      set(value) {
-        debug = defaultTo('index', value);
       }
     }
   });


### PR DESCRIPTION
As discussed in #208 this pr adds a possibility to start the node server with `--inspect` option.
This is mostly relevant for neutrino node apps.

A `--debug` flag was added to neutrino, to which `neutrino-middleware-start-server` reacts and starts the `start-server-webpack-plugin` with the inspect flag. For that to work I had to update `neutrino-middleware-start-server` to v2.2.0.

Users could add a debug script to package.json like this:
```JavaScript
  "scripts": {
    "dev": "neutrino start --use neutrino-preset-node --use neutrino-middleware-start-server --debug",
    "build": "neutrino build --use neutrino-preset-node"
  }
```
Hope that helps to add this feature and improve debugging possibilities for neutrino node apps.
 
fixes #208 