### PR TITLE
Use string version of specifying target

### DIFF
--- a/packages/neutrino-preset-node/index.js
+++ b/packages/neutrino-preset-node/index.js
@@ -25,7 +25,7 @@ module.exports = (neutrino) => {
     Object.assign(neutrino.options, {
       compile: {
         targets: {
-          node: 6.9
+          node: '6.9'
         }
       }
     });


### PR DESCRIPTION
I get the following, very annoying, warning when building. This change fixes it.

```
Warning, the following targets are using a decimal version:

  node: 6.9

We recommend using a string for minor/patch versions to avoid numbers like 6.10
getting parsed as 6.1, which can lead to unexpected behavior.
```