### PR TITLE
Add api.call for direct use and command execution

### DIFF
--- a/packages/neutrino-middleware-eslint/index.js
+++ b/packages/neutrino-middleware-eslint/index.js
@@ -1,9 +1,27 @@
-const merge = require('deepmerge');
-const { basename, join } = require('path');
 const Future = require('fluture');
+const merge = require('deepmerge');
+const clone = require('lodash.clonedeep');
 const { CLIEngine } = require('eslint');
+const { assoc, curry, evolve, keys, omit, pipe, prop, reduce } = require('ramda');
+const { basename, join } = require('path');
 
 const MODULES = join(__dirname, 'node_modules');
+const getEslintOptions = config => config.module.rule('lint').use('eslint').get('options');
+const renameKeys = curry((definition, obj) =>
+  reduce((acc, key) => assoc(definition[key] || key, obj[key], acc), {}, keys(obj)));
+const reduceToTrueKeys = reduce((acc, key) => assoc(key, true, acc), {});
+const getEslintRcConfig = pipe(
+  getEslintOptions,
+  clone,
+  assoc('useEslintrc', true),
+  omit(['failOnError', 'emitWarning', 'emitError']),
+  renameKeys({ envs: 'env', baseConfig: 'extends' }),
+  evolve({
+    extends: prop('extends'),
+    globals: reduceToTrueKeys,
+    env: reduceToTrueKeys
+  })
+);
 
 module.exports = (neutrino, opts = {}) => {
   const isNotDev = process.env.NODE_ENV !== 'development';
@@ -11,35 +29,6 @@ module.exports = (neutrino, opts = {}) => {
     opts,
     !opts.include && !opts.exclude ? { include: [neutrino.options.source], exclude: [neutrino.options.static] } : {}
   ]);
-
-  neutrino.register('lint', () => {
-    const { fix = false } = neutrino.options.args;
-    const ignorePattern = (options.exclude || [])
-      .map(exclude => join(
-        basename(neutrino.options.source),
-        basename(exclude),
-        '**/*'
-      ));
-    const eslintConfig = merge(
-      neutrino.config.module.rule('lint').use('eslint').get('options'),
-      { ignorePattern, fix }
-    );
-
-    return Future
-      .of(eslintConfig)
-      .map(options => new CLIEngine(options))
-      .chain(cli => Future.both(Future.of(cli.executeOnFiles(options.include)), Future.of(cli.getFormatter())))
-      .map(([report, formatter]) => {
-        fix && CLIEngine.outputFixes(report);
-        return [report, formatter];
-      })
-      .chain(([report, formatter]) => {
-        const errors = CLIEngine.getErrorResults(report.results);
-        const formatted = formatter(report.results);
-
-        return errors.length ? Future.reject(formatted) : Future.of(formatted);
-      });
-  });
 
   neutrino.config
     .resolve
@@ -84,4 +73,31 @@ module.exports = (neutrino, opts = {}) => {
             globals: ['process'],
             rules: {}
           }, options.eslint || {}));
+
+  neutrino.register('eslintrc', () => getEslintRcConfig(neutrino.config));
+  neutrino.register('lint', () => {
+    const { fix = false } = neutrino.options.args;
+    const ignorePattern = (options.exclude || [])
+      .map(exclude => join(
+        basename(neutrino.options.source),
+        basename(exclude),
+        '**/*'
+      ));
+    const eslintConfig = merge(getEslintOptions(neutrino.config), { ignorePattern, fix });
+
+    return Future
+      .of(eslintConfig)
+      .map(options => new CLIEngine(options))
+      .chain(cli => Future.both(Future.of(cli.executeOnFiles(options.include)), Future.of(cli.getFormatter())))
+      .map(([report, formatter]) => {
+        fix && CLIEngine.outputFixes(report);
+        return [report, formatter];
+      })
+      .chain(([report, formatter]) => {
+        const errors = CLIEngine.getErrorResults(report.results);
+        const formatted = formatter(report.results);
+
+        return errors.length ? Future.reject(formatted) : Future.of(formatted);
+      });
+  });
 };

--- a/packages/neutrino-middleware-eslint/package.json
+++ b/packages/neutrino-middleware-eslint/package.json
@@ -22,7 +22,8 @@
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-import": "^2.3.0",
     "fluture": "^6.2.1",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "ramda": "^0.24.1"
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^11.2.0"

--- a/packages/neutrino-middleware-eslint/yarn.lock
+++ b/packages/neutrino-middleware-eslint/yarn.lock
@@ -958,6 +958,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"

--- a/packages/neutrino/bin/execute.js
+++ b/packages/neutrino/bin/execute.js
@@ -1,5 +1,4 @@
 const { Neutrino } = require('../src');
-// const { defaultTo } = require('ramda');
 const merge = require('deepmerge');
 const ora = require('ora');
 


### PR DESCRIPTION
Adding a new API method named `call`. This method will immediately `use` all the middleware passed to it, then invoke a registered command. The results of this command are returned, be it a value, promise, or future.

This is being used in the ESLint middleware to expose a new way to fetch the eslint config for a `.eslintrc.js` file, making it as short as (when using `.neutrinorc.js`):

```js
// .eslintrc.js
module.exports = require('neutrino/src/api')().call('eslintrc');
```