### PR TITLE
CLI: register before run; CLI: add --quiet; API: run registered command

### DIFF
--- a/packages/neutrino/bin/build.js
+++ b/packages/neutrino/bin/build.js
@@ -3,29 +3,37 @@ const merge = require('deepmerge');
 const ora = require('ora');
 
 module.exports = (middleware, args) => {
-  const spinner = ora('Building project').start();
+  const spinner = args.quiet ? null : ora('Building project').start();
   const options = merge({
     args,
     debug: args.debug,
+    quiet: args.quiet,
     env: {
       NODE_ENV: 'production'
     }
   }, args.options);
   const api = Neutrino(options);
 
+  api.register('build', build);
+
   return api
-    .run('build', middleware, build)
+    .run('build', middleware)
     .fork((errors) => {
-      spinner.fail('Building project failed');
-      errors.forEach(err => console.error(err));
+      if (!args.quiet) {
+        spinner.fail('Building project failed');
+        errors.forEach(err => console.error(err));
+      }
+
       process.exit(1);
     }, (stats) => {
-      spinner.succeed('Building project completed');
-      console.log(stats.toString(merge({
-        modules: false,
-        colors: true,
-        chunks: false,
-        children: false
-      }, stats.compilation.compiler.options.stats || {})));
+      if (!args.quiet) {
+        spinner.succeed('Building project completed');
+        console.log(stats.toString(merge({
+          modules: false,
+          colors: true,
+          chunks: false,
+          children: false
+        }, stats.compilation.compiler.options.stats || {})));
+      }
     });
 };

--- a/packages/neutrino/bin/inspect.js
+++ b/packages/neutrino/bin/inspect.js
@@ -12,16 +12,22 @@ module.exports = (middleware, args) => {
   const options = merge({
     args,
     debug: args.debug,
+    quiet: args.quiet,
     env: {
       NODE_ENV: defaultTo('development', envs[args._[0]])
     }
   }, args.options);
   const api = Neutrino(options);
 
+  api.register('inspect', inspect);
+
   return api
-    .run('inspect', middleware, inspect)
+    .run('inspect', middleware)
     .fork((err) => {
-      console.error(err);
+      if (!args.quiet) {
+        console.error(err);
+      }
+
       process.exit(1);
     }, console.log);
 };

--- a/packages/neutrino/bin/neutrino
+++ b/packages/neutrino/bin/neutrino
@@ -31,6 +31,12 @@ const args = yargs
     default: {},
     global: true
   })
+  .option('quiet', {
+    description: 'Disable console output of CLI commands',
+    boolean: true,
+    default: false,
+    global: true
+  })
   .option('debug', {
     description: 'Run in debug mode',
     boolean: true,
@@ -66,8 +72,11 @@ const middleware = [...new Set([
 ])];
 
 process.on('unhandledRejection', (err) => {
-  console.error('');
-  console.error(err);
+  if (!args.quiet) {
+    console.error('');
+    console.error(err);
+  }
+
   process.exit(1);
 });
 

--- a/packages/neutrino/bin/start.js
+++ b/packages/neutrino/bin/start.js
@@ -3,23 +3,33 @@ const merge = require('deepmerge');
 const ora = require('ora');
 
 module.exports = (middleware, args) => {
-  const spinner = ora('Building project').start();
+  const spinner = args.quiet ? null : ora('Building project').start();
   const options = merge({
     args,
     debug: args.debug,
+    quiet: args.quiet,
     env: {
       NODE_ENV: 'development'
     }
   }, args.options);
   const api = Neutrino(options);
 
+  api.register('start', start);
+
   return api
-    .run('start', middleware, start)
+    .run('start', middleware)
     .fork((errors) => {
-      spinner.fail('Building project failed');
-      errors.forEach(err => console.error(err));
+      if (!args.quiet) {
+        spinner.fail('Building project failed');
+        errors.forEach(err => console.error(err));
+      }
+
       process.exit(1);
     }, (compiler) => {
+      if (args.quiet) {
+        return;
+      }
+
       if (!compiler.options.devServer) {
         spinner.succeed('Build completed');
       } else {

--- a/packages/neutrino/bin/test.js
+++ b/packages/neutrino/bin/test.js
@@ -5,14 +5,17 @@ module.exports = (middleware, args) => {
   const options = merge({
     args,
     debug: args.debug,
+    quiet: args.quiet,
     env: {
       NODE_ENV: 'test'
     }
   }, args.options);
   const api = Neutrino(options);
 
+  api.register('test', test);
+
   return api
-    .run('test', middleware, test)
+    .run('test', middleware)
     .fork((err) => {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
Switching up the API slightly for the `run()` method. With v6, the usefulness of the `register()` method was limited to the `call()` method. By making `run` execute registered commands, it makes the use of `register` more consistent.

Each CLI command will now register its command prior to running it (similar to this):

`neutrino build -> neutrino.register('build', require('neutrino/src/build'))`
`neutrino start -> neutrino.register('start', require('neutrino/src/start'))`
`neutrino test -> neutrino.register('test', require('neutrino/src/test'))`
`neutrino <command> -> neutrino.register('<command>-cli', api.commands[command])`
`neutrino <command> --inspect -> neutrino.register('inspect', require('neutrino/src/inspect'))`

I've also added a `--quiet` CLI flag for shutting off CLI console output.