### PR TITLE
Switch Travis runs from Ubuntu Precise to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
 - '6.9'


### PR DESCRIPTION
See:
https://docs.travis-ci.com/user/trusty-ci-environment/

This also fixes the warning about not using a C++11 compiler:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements

Note this intentionally isn't switching to their container based infra, since whilst it has faster boot times, these jobs still take longer at the moment, due to the lower CPU/RAM allowances. If #248 manages to improve the overall runtime this may be worth revisiting.