### PR TITLE
Switch fast-async to spec mode

### DIFF
--- a/packages/neutrino-preset-node/index.js
+++ b/packages/neutrino-preset-node/index.js
@@ -40,7 +40,7 @@ module.exports = (neutrino, opts = {}) => {
     babel: {
       plugins: [
         !opts.polyfills || opts.polyfills.async !== false ?
-          [require.resolve('fast-async'), { useRuntimeModule: true }] :
+          [require.resolve('fast-async'), { spec: true }] :
           {},
         require.resolve('babel-plugin-dynamic-import-node')
       ],
@@ -79,7 +79,6 @@ module.exports = (neutrino, opts = {}) => {
     .externals([nodeExternals({ whitelist: [/^webpack/] })])
     .context(neutrino.options.root)
     .entry('index')
-      .when(options.polyfills.async, entry => entry.add(require.resolve('nodent-runtime')))
       .add(neutrino.options.entry)
       .end()
     .output

--- a/packages/neutrino-preset-web/index.js
+++ b/packages/neutrino-preset-web/index.js
@@ -32,7 +32,7 @@ module.exports = (neutrino, opts = {}) => {
     babel: {
       plugins: [
         !opts.polyfills || opts.polyfills.async !== false ?
-          [require.resolve('fast-async'), { useRuntimeModule: true }] :
+          [require.resolve('fast-async'), { spec: true }] :
           {},
         require.resolve('babel-plugin-syntax-dynamic-import')
       ],
@@ -82,9 +82,6 @@ module.exports = (neutrino, opts = {}) => {
     .when(options.polyfills.babel, config => config
       .entry('polyfill')
         .add(require.resolve('./polyfills.js')))
-    .when(options.polyfills.async, config => config
-      .entry('index')
-        .add(require.resolve('nodent-runtime')))
     .entry('index')
       .add(neutrino.options.entry)
       .end()


### PR DESCRIPTION
Turns out if you use fast-async in spec mode, it doesn't need a runtime. I'm OK with sacrificing a little performance if it means we can have a smaller bundle.