### PR TITLE
Ensure test cases are not run 2x in watch mode.

### DIFF
--- a/packages/neutrino-preset-karma/index.js
+++ b/packages/neutrino-preset-karma/index.js
@@ -24,7 +24,12 @@ module.exports = (neutrino, opts = {}) => {
       }
     },
     frameworks: ['mocha'],
-    files: [tests],
+    files: [{
+      pattern: tests,
+      watched: false,
+      included: true,
+      served: true
+    }],
     preprocessors: {
       [tests]: ['webpack'],
       [sources]: ['webpack']


### PR DESCRIPTION
Prior to this change, modifications of test files resulted in test cases being run 2x.

Reference: https://github.com/nikku/karma-browserify/issues/67#issuecomment-84448491