### PR TITLE
Prevent null chunks from preventing naming

### DIFF
--- a/packages/neutrino-middleware-chunk/index.js
+++ b/packages/neutrino-middleware-chunk/index.js
@@ -12,7 +12,7 @@ module.exports = ({ config }) => config
     .use(NamedChunksPlugin, [
       chunk => (
         chunk.name ||
-        hash(chunk.modules.map(({ context = '', request = '' }) => relative(context, request)).join('_'))
+        hash(chunk.modules.map(({ context, request }) => relative(context || '', request || '')).join('_'))
       )
     ])
     .end()


### PR DESCRIPTION
Defaulting to `''` still lets `null` `context` and `request` modules from getting through, which fails being able to create a chunk name.