### PR TITLE
Add an .npmignore to all packages

### DIFF
--- a/packages/neutrino-middleware-banner/.npmignore
+++ b/packages/neutrino-middleware-banner/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-chunk/.npmignore
+++ b/packages/neutrino-middleware-chunk/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-clean/.npmignore
+++ b/packages/neutrino-middleware-clean/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-compile-loader/.npmignore
+++ b/packages/neutrino-middleware-compile-loader/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-copy/.npmignore
+++ b/packages/neutrino-middleware-copy/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-dev-server/.npmignore
+++ b/packages/neutrino-middleware-dev-server/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-env/.npmignore
+++ b/packages/neutrino-middleware-env/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-eslint/.npmignore
+++ b/packages/neutrino-middleware-eslint/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-font-loader/.npmignore
+++ b/packages/neutrino-middleware-font-loader/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-hot/.npmignore
+++ b/packages/neutrino-middleware-hot/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-html-loader/.npmignore
+++ b/packages/neutrino-middleware-html-loader/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-html-template/.npmignore
+++ b/packages/neutrino-middleware-html-template/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-image-loader/.npmignore
+++ b/packages/neutrino-middleware-image-loader/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-loader-merge/.npmignore
+++ b/packages/neutrino-middleware-loader-merge/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-minify/.npmignore
+++ b/packages/neutrino-middleware-minify/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-pwa/.npmignore
+++ b/packages/neutrino-middleware-pwa/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-start-server/.npmignore
+++ b/packages/neutrino-middleware-start-server/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-middleware-style-loader/.npmignore
+++ b/packages/neutrino-middleware-style-loader/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-airbnb-base/.npmignore
+++ b/packages/neutrino-preset-airbnb-base/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-jest/.npmignore
+++ b/packages/neutrino-preset-jest/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-karma/.npmignore
+++ b/packages/neutrino-preset-karma/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-mocha/.npmignore
+++ b/packages/neutrino-preset-mocha/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-node/.npmignore
+++ b/packages/neutrino-preset-node/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-react/.npmignore
+++ b/packages/neutrino-preset-react/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino-preset-web/.npmignore
+++ b/packages/neutrino-preset-web/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock

--- a/packages/neutrino/.npmignore
+++ b/packages/neutrino/.npmignore
@@ -1,0 +1,2 @@
+/test/
+yarn.lock


### PR DESCRIPTION
Excluding the test directory and `yarn.lock` reduces the package size significantly (for example 85-90% reduction in both compressed and uncompressed size of neutrino-preset-web), plus reduces the noise when consumers need to grep their local `node_modules`.

An `.npmignore` has been used instead of the `files` directive in `package.json` since the latter can cause breakage that isn't shown in CI if the directory layout changes (which is likely given the Neutrino packages have a mixture of using the `src` directory and not, depending on how many files they include). 

`.npmignore` was used instead of `.yarnignore` since npm doesn't support the latter whereas yarn supports both.

Fixes #289.