### PR TITLE
Allow arbitrary command-line args to be used in Jest

### DIFF
--- a/packages/neutrino-preset-jest/src/index.js
+++ b/packages/neutrino-preset-jest/src/index.js
@@ -94,8 +94,12 @@ module.exports = (neutrino, opts = {}) => {
     return new Promise((resolve, reject) => {
       const configFile = join(tmpdir(), 'config.json');
       const options = normalizeJestOptions(opts, neutrino, args);
-      const cliOptions = { config: configFile, coverage: args.coverage, watch: args.watch };
+      const cliOptions = merge(
+        omit(['inspect', 'quiet', '_', 'version', 'help', 'use', 'options', '$0', 'files'], args),
+        { config: configFile, coverage: args.coverage, watch: args.watch }
+      );
 
+      cliOptions.findRelatedFiles = cliOptions.findRelatedFiles.split(' ');
       writeFileSync(configFile, `${JSON.stringify(options, null, 2)}\n`);
 
       jest.runCLI(cliOptions, [configFile], result =>


### PR DESCRIPTION
Addresses #287.

@okonet I tried using this in a project with Jest, but I don't think it's working properly; it just seems to run all the tests. Do you think you would be able to tell if my changes are doing what they should, and potentially offer any advice here?