### PR TITLE
[windows] fix spawn [..]\mocha ENOENT error

### DIFF
--- a/packages/neutrino-preset-mocha/src/mocha.js
+++ b/packages/neutrino-preset-mocha/src/mocha.js
@@ -20,7 +20,7 @@ module.exports = (mochaOpts = {}, babelOpts = {}, files = []) => new Promise((re
         [...argv, `--${toParam(key)}`, value];
     }, ['--require', require.resolve('./register')]);
 
-  proc = spawn(require.resolve('mocha/bin/mocha'), [...argv, ...files], {
+  proc = spawn(process.execPath, [require.resolve('mocha/bin/mocha'), ...argv, ...files], {
     cwd: process.cwd(),
     env: process.env,
     stdio: 'inherit'


### PR DESCRIPTION
This applies to **neutrino-preset-mocha**
I couldn't run **test** command on the Windows, it was failing with

```
events.js:182
      throw er; // Unhandled 'error' event
      ^

Error: spawn <5 directories deep>\node_modules\mocha\bin\mocha ENOENT
    at exports._errnoException (util.js:1022:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:189:19)
    at onErrorNT (internal/child_process.js:366:16)
    at _combinedTickCallback (internal/process/next_tick.js:102:11)
    at process._tickCallback (internal/process/next_tick.js:161:9)
npm ERR! Test failed.  See above for more details.
```

No matter which version of node.js, or neutrino I have installed.