### PR TITLE
feat: Allow passing any Jest CLI options to neutrino-jest test task

### DIFF
--- a/docs/presets/neutrino-preset-jest/README.md
+++ b/docs/presets/neutrino-preset-jest/README.md
@@ -175,8 +175,29 @@ helpful during continuous integration of your project:
 }
 ```
 
-See the [Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for
-more configuration options for generating coverage reports.
+## Additional options
+
+You can pass any additional option Jest accepts. See the [Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for more configuration options.
+
+For example, if you want to run tests on the precommit hook with [lint-staged](https://github.com/okonet/lint-staged)  you can run:
+
+```bash
+npx mrm lintstaged
+```
+
+and update the configuration in your `package.json` to:
+
+```json
+{
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "neutrino test --findRelatedTests"
+      "git add"
+    ]
+  }
+}
+```
 
 ## Preset options
 

--- a/packages/neutrino-preset-jest/README.md
+++ b/packages/neutrino-preset-jest/README.md
@@ -175,8 +175,29 @@ helpful during continuous integration of your project:
 }
 ```
 
-See the [Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for
-more configuration options for generating coverage reports.
+## Additional options
+
+You can pass any additional option Jest accepts. See the [Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for more configuration options.
+
+For example, if you want to run tests on the precommit hook with [lint-staged](https://github.com/okonet/lint-staged)  you can run:
+
+```bash
+npx mrm lintstaged
+```
+
+and update the configuration in your `package.json` to:
+
+```json
+{
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "neutrino test --findRelatedTests"
+      "git add"
+    ]
+  }
+}
+```
 
 ## Preset options
 

--- a/packages/neutrino-preset-jest/package.json
+++ b/packages/neutrino-preset-jest/package.json
@@ -22,7 +22,8 @@
     "jest-cli": "^20.0.4",
     "lodash.clonedeep": "^4.5.0",
     "neutrino-middleware-loader-merge": "^6.1.8",
-    "ramda": "^0.24.1"
+    "ramda": "^0.24.1",
+    "yargs": "^8.0.2"
   },
   "peerDependencies": {
     "neutrino": "^6.0.0"


### PR DESCRIPTION
Closes #287 

At the moment it's not possible to run `neutrino test` with additional options Jest provides. This includes `--findRelatedTests` or `--onlyChanged` which can be very useful. 

This PR implements an ability to pass arbitrary options to the Jest CLI tool.