### PR TITLE
Small API docs change to avoid confusion.

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -33,7 +33,7 @@ Using `require`:
 ```js
 const { Neutrino } = require('neutrino');
 
-const neutrino = Neutrino(options);
+const api = Neutrino(options);
 ```
 
 Using ES imports:
@@ -41,7 +41,7 @@ Using ES imports:
 ```js
 import { Neutrino } from 'neutrino';
 
-const neutrino = Neutrino(options);
+const api = Neutrino(options);
 ```
 
 ## API options


### PR DESCRIPTION
The API is first assigned to `neutrino`, but the rest of the doc uses `api`, which was seeming to come from nowhere.