### PR TITLE
Make the lint command check .jsx files too

### DIFF
--- a/docs/middleware/neutrino-middleware-eslint/README.md
+++ b/docs/middleware/neutrino-middleware-eslint/README.md
@@ -46,6 +46,7 @@ neutrino.use(eslint, {
     cwd: neutrino.options.root,
     useEslintrc: false,
     root: true,
+    extensions: ['js', 'jsx'],
     plugins: ['babel'],
     baseConfig: {},
     envs: ['es6'],

--- a/packages/neutrino-middleware-eslint/README.md
+++ b/packages/neutrino-middleware-eslint/README.md
@@ -46,6 +46,7 @@ neutrino.use(eslint, {
     cwd: neutrino.options.root,
     useEslintrc: false,
     root: true,
+    extensions: ['js', 'jsx'],
     plugins: ['babel'],
     baseConfig: {},
     envs: ['es6'],

--- a/packages/neutrino-middleware-eslint/index.js
+++ b/packages/neutrino-middleware-eslint/index.js
@@ -56,6 +56,9 @@ module.exports = (neutrino, opts = {}) => {
             cwd: neutrino.options.root,
             useEslintrc: false,
             root: true,
+            // eslint-loader uses executeOnText(), which ignores the `extensions` setting.
+            // However it's still needed for the lint command, as it uses executeOnFiles().
+            extensions: ['js', 'jsx'],
             plugins: ['babel'],
             baseConfig: {},
             envs: ['es6'],


### PR DESCRIPTION
Previously the `neutrino lint` command would only check `.js` files, which was inconsistent with the build/start commands, since they use `eslint-loader` and so instead use the `test` regex of `/\.(js|jsx)$/`.

This now means there is redundancy in the eslint middleware options, however there isn't a reliable way to turn the `test` regex into a flat array of file extensions. 

In a future major release, perhaps the eslint middleware could drop support for `options.test` and instead only accept the `options.extensions` array, which could then be mapped back to the `test` regex internally. However this would mean less flexible selection of files to be matched, plus mean that there would be inconsistent support for `options.test` between the various loader middlewares, so not sure whether it's the best way forwards anyway.

Fixes #332.