### PR TITLE
Misc documentation fixes - part 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,11 @@ externally.
 ## Support
 
 Neutrino team members and contributors are here to help you! Should you need assistance or have questions in using
-Neutrino or its core presets, please consider asking on Stack Overflow or other channel rather than filing issues. We
-would prefer to keep our GitHub issues clear for bugs, feature requests, discussions, and relevant information related
-to its development.
+Neutrino or its core presets, please consider asking on our Slack channel, Stack Overflow, or other channel rather than
+filing issues. We would prefer to keep our GitHub issues clear for bugs, feature requests, discussions, and
+relevant information related to its development.
+
+[Join our Slack channel!](https://neutrino-slack.herokuapp.com/)
 
 ## Guidelines
 

--- a/docs/middleware/neutrino-middleware-banner/README.md
+++ b/docs/middleware/neutrino-middleware-banner/README.md
@@ -89,7 +89,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-banner.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-banner.svg

--- a/docs/middleware/neutrino-middleware-chunk/README.md
+++ b/docs/middleware/neutrino-middleware-chunk/README.md
@@ -66,7 +66,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-chunk.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-chunk.svg

--- a/docs/middleware/neutrino-middleware-clean/README.md
+++ b/docs/middleware/neutrino-middleware-clean/README.md
@@ -80,7 +80,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-clean.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-clean.svg

--- a/docs/middleware/neutrino-middleware-compile-loader/README.md
+++ b/docs/middleware/neutrino-middleware-compile-loader/README.md
@@ -126,7 +126,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-compile-loader.svg

--- a/docs/middleware/neutrino-middleware-copy/README.md
+++ b/docs/middleware/neutrino-middleware-copy/README.md
@@ -86,7 +86,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-copy.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-copy.svg

--- a/docs/middleware/neutrino-middleware-dev-server/README.md
+++ b/docs/middleware/neutrino-middleware-dev-server/README.md
@@ -131,7 +131,7 @@ may also specify the following options:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-dev-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-dev-server.svg

--- a/docs/middleware/neutrino-middleware-env/README.md
+++ b/docs/middleware/neutrino-middleware-env/README.md
@@ -78,7 +78,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-env.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-env.svg

--- a/docs/middleware/neutrino-middleware-eslint/README.md
+++ b/docs/middleware/neutrino-middleware-eslint/README.md
@@ -194,7 +194,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-eslint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-eslint.svg

--- a/docs/middleware/neutrino-middleware-font-loader/README.md
+++ b/docs/middleware/neutrino-middleware-font-loader/README.md
@@ -91,7 +91,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-font-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-font-loader.svg

--- a/docs/middleware/neutrino-middleware-hot/README.md
+++ b/docs/middleware/neutrino-middleware-hot/README.md
@@ -62,7 +62,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-hot.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-hot.svg

--- a/docs/middleware/neutrino-middleware-html-loader/README.md
+++ b/docs/middleware/neutrino-middleware-html-loader/README.md
@@ -80,7 +80,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-loader.svg

--- a/docs/middleware/neutrino-middleware-html-template/README.md
+++ b/docs/middleware/neutrino-middleware-html-template/README.md
@@ -107,7 +107,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-template.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-template.svg

--- a/docs/middleware/neutrino-middleware-image-loader/README.md
+++ b/docs/middleware/neutrino-middleware-image-loader/README.md
@@ -91,7 +91,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-image-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-image-loader.svg

--- a/docs/middleware/neutrino-middleware-loader-merge/README.md
+++ b/docs/middleware/neutrino-middleware-loader-merge/README.md
@@ -68,7 +68,7 @@ for extending the options for a rule loader which has created its own convention
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-loader-merge.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-loader-merge.svg

--- a/docs/middleware/neutrino-middleware-minify/README.md
+++ b/docs/middleware/neutrino-middleware-minify/README.md
@@ -79,7 +79,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `minify` | Minifies source code using `BabelMinifyWebpackPlugin` | all |
+| `minify` | Minifies source code using `BabelMinifyWebpackPlugin`. | all |
 
 ## Contributing
 

--- a/docs/middleware/neutrino-middleware-minify/README.md
+++ b/docs/middleware/neutrino-middleware-minify/README.md
@@ -85,7 +85,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-minify.svg

--- a/docs/middleware/neutrino-middleware-pwa/README.md
+++ b/docs/middleware/neutrino-middleware-pwa/README.md
@@ -115,7 +115,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-pwa.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-pwa.svg

--- a/docs/middleware/neutrino-middleware-start-server/README.md
+++ b/docs/middleware/neutrino-middleware-start-server/README.md
@@ -87,7 +87,7 @@ This can be done from the [API](../../api#optionsdebug) or the [CLI using `--deb
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-start-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-start-server.svg

--- a/docs/middleware/neutrino-middleware-style-loader/README.md
+++ b/docs/middleware/neutrino-middleware-style-loader/README.md
@@ -83,7 +83,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-style-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-style-loader.svg

--- a/docs/presets/neutrino-preset-airbnb-base/README.md
+++ b/docs/presets/neutrino-preset-airbnb-base/README.md
@@ -312,7 +312,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-airbnb-base.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-airbnb-base.svg

--- a/docs/presets/neutrino-preset-jest/README.md
+++ b/docs/presets/neutrino-preset-jest/README.md
@@ -275,7 +275,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-jest.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-jest.svg

--- a/docs/presets/neutrino-preset-karma/README.md
+++ b/docs/presets/neutrino-preset-karma/README.md
@@ -196,7 +196,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-karma.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-karma.svg

--- a/docs/presets/neutrino-preset-mocha/README.md
+++ b/docs/presets/neutrino-preset-mocha/README.md
@@ -208,7 +208,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-mocha.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-mocha.svg

--- a/docs/presets/neutrino-preset-node/README.md
+++ b/docs/presets/neutrino-preset-node/README.md
@@ -332,7 +332,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-node.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-node.svg

--- a/docs/presets/neutrino-preset-react/README.md
+++ b/docs/presets/neutrino-preset-react/README.md
@@ -272,7 +272,7 @@ load();
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-react.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-react.svg

--- a/docs/presets/neutrino-preset-react/README.md
+++ b/docs/presets/neutrino-preset-react/README.md
@@ -16,7 +16,7 @@
   - Automatic creation of HTML pages, no templating necessary
   - Hot Module Replacement support
   - Tree-shaking to create smaller bundles
-  - Production-optimized bundles with Babili minification and easy chunking
+  - Production-optimized bundles with Babili minification, easy chunking, and scope-hoisted modules for faster execution
   - Easily extensible to customize your project as needed
 
 ## Requirements

--- a/docs/presets/neutrino-preset-web/README.md
+++ b/docs/presets/neutrino-preset-web/README.md
@@ -268,7 +268,7 @@ The following is a list of rules and their identifiers which can be overridden:
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `compile` | Compiles JS files from the `src` directory using Babel. Contains a single loader named `babel`. From `neutrino-middleware-compile-loader`. | all |
-| `html` | Allows importing HTML files from modules. Contains a single loader named `file`. From `neutrino-middleware-html-loader`. | all |
+| `html` | Allows importing HTML files from modules. Contains a single loader named `html`. From `neutrino-middleware-html-loader`. | all |
 | `style` | Allows importing CSS stylesheets from modules. Contains two loaders named `style` and `css`. From `neutrino-middleware-style-loader`. | all |
 | `img`, `svg`, `ico` | Allows import image files from modules. Each contains a single loader named `url`. From `neutrino-middleware-image-loader`. | all |
 | `woff`, `ttf` | Allows importing WOFF and TTF font files from modules. Each contains a single loader named `url`. From `neutrino-middleware-font-loader`. | all |
@@ -280,8 +280,6 @@ The following is a list of rules and their identifiers which can be overridden:
 The following is a list of plugins and their identifiers which can be overridden:
 
 _Note: Some plugins are only available in certain environments. To override them, they should be modified conditionally._
-
-### Override configuration
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
@@ -297,6 +295,8 @@ _Note: Some plugins are only available in certain environments. To override them
 | `clean` | Removes the `build` directory prior to building. From `neutrino-middleware-clean`. | `build` command |
 | `minify` | Minifies source code using `BabiliWebpackPlugin`. From `neutrino-middleware-minify`. | `NODE_ENV production` |
 | `module-concat` | Concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser. | `NODE_ENV production` |
+
+### Override configuration
 
 By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also

--- a/docs/presets/neutrino-preset-web/README.md
+++ b/docs/presets/neutrino-preset-web/README.md
@@ -322,7 +322,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing/README.md) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-web.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-web.svg

--- a/docs/presets/neutrino-preset-web/README.md
+++ b/docs/presets/neutrino-preset-web/README.md
@@ -12,7 +12,7 @@
 - Automatic creation of HTML pages, no templating necessary
 - Hot Module Replacement support
 - Tree-shaking to create smaller bundles
-- Production-optimized bundles with Babili minification and easy chunking
+- Production-optimized bundles with Babili minification, easy chunking, and scope-hoisted modules for faster execution
 - Easily extensible to customize your project as needed
 
 ## Requirements

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -26,7 +26,7 @@ necessary for creating your builds.
 
 When creating a build bundle, a preset will put the compiled assets, including any generated
 JavaScript files, into a directory named `build` by default. Typically your Neutrino preset will copy
-any files from the static directory over to the build directory, allowing you to maintain
+any files from the `static` directory over to the build directory, allowing you to maintain
 the same relative path structure for static assets as is used for the source files.
 
 Normally most projects will exclude checking in this build directory to source control.

--- a/docs/webpack-chain.md
+++ b/docs/webpack-chain.md
@@ -97,7 +97,7 @@ module.exports = (neutrino) => {
             ['babel-preset-es2015', { modules: false }]
           ]
         });
-  
+
   // Create named plugins too!
   neutrino.config
     .plugin('clean')
@@ -557,7 +557,7 @@ neutrino.config
 ```
 
 #### Config plugins: removing
- 
+
 ```js
 neutrino.config.plugins.delete(name)
 ```
@@ -596,7 +596,7 @@ neutrino.config.resolve
 ```
 
 #### Config resolve plugins: removing
- 
+
 ```js
 neutrino.config.resolve.plugins.delete(name)
 ```

--- a/packages/neutrino-preset-airbnb-base/README.md
+++ b/packages/neutrino-preset-airbnb-base/README.md
@@ -74,6 +74,7 @@ project. ESLint errors during build will not build the project, and will cause t
 
 ```bash
 ❯ yarn start
+
 ✔ Development server running on: http://localhost:5000
 ✔ Build completed
 
@@ -115,6 +116,7 @@ you want to ease introduction of this linting preset to your project, consider o
 
 ```bash
 ❯ yarn build
+
 clean-webpack-plugin: /web/build has been removed.
 Build completed in 1.287s
 

--- a/packages/neutrino-preset-jest/README.md
+++ b/packages/neutrino-preset-jest/README.md
@@ -109,6 +109,7 @@ Run the tests, and view the results in your console:
 
 ```bash
 ❯ yarn test
+
  PASS  test/simple_test.js
   simple
     ✓ should be sane (2ms)
@@ -177,9 +178,12 @@ helpful during continuous integration of your project:
 
 ## Additional options
 
-You can pass any additional option Jest accepts. See the [Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for more configuration options.
+You can pass any additional option Jest accepts. See the
+[Jest documentation](https://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array) for more
+configuration options.
 
-For example, if you want to run tests on the precommit hook with [lint-staged](https://github.com/okonet/lint-staged)  you can run:
+For example, if you want to run tests on the precommit hook with [lint-staged](https://github.com/okonet/lint-staged),
+you can run:
 
 ```bash
 npx mrm lintstaged
@@ -191,8 +195,8 @@ and update the configuration in your `package.json` to:
 {
   "lint-staged": {
     "*.js": [
-      "eslint --fix",
-      "neutrino test --findRelatedTests"
+      "neutrino lint --fix",
+      "neutrino test --findRelatedTests",
       "git add"
     ]
   }

--- a/packages/neutrino-preset-karma/README.md
+++ b/packages/neutrino-preset-karma/README.md
@@ -92,10 +92,10 @@ Run the tests, and view the results in your console:
 ❯ yarn test
 
 START:
-16 02 2017 10:36:34.713:INFO [karma]: Karma v1.7.0 server started at http://0.0.0.0:9876/
+16 02 2017 10:36:34.713:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
 16 02 2017 10:36:34.715:INFO [launcher]: Launching browser Chrome with unlimited concurrency
 16 02 2017 10:36:34.731:INFO [launcher]: Starting browser Chrome
-16 02 2017 10:36:35.655:INFO [Chrome 56.0.2924 (Mac OS X 10.12.3)]: Connected on socket MkTbqJLpAAa2HFaeAAAA with id 21326158
+16 02 2017 10:36:35.655:INFO [Chrome 60 (Mac OS X 10.12.3)]: Connected on socket MkTbqJLpAAa2HFaeAAAA with id 21326158
   simple
     ✔ should be sane
 
@@ -112,10 +112,10 @@ SUMMARY:
 ❯ npm test
 
 START:
-16 02 2017 10:38:12.865:INFO [karma]: Karma v1.7.0 server started at http://0.0.0.0:9876/
+16 02 2017 10:38:12.865:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
 16 02 2017 10:38:12.867:INFO [launcher]: Launching browser Chrome with unlimited concurrency
 16 02 2017 10:38:12.879:INFO [launcher]: Starting browser Chrome
-16 02 2017 10:38:13.688:INFO [Chrome 56.0.2924 (Mac OS X 10.12.3)]: Connected on socket svRGoxU0etKTKQWhAAAA with id 68456725
+16 02 2017 10:38:13.688:INFO [Chrome 60 (Mac OS X 10.12.3)]: Connected on socket svRGoxU0etKTKQWhAAAA with id 68456725
   simple
     ✔ should be sane
 
@@ -154,9 +154,9 @@ To do this in Travis-CI, you will need to add the following to your `.travis.yml
 
 ```yaml
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+- export CHROME_BIN=chromium-browser
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 ```
 
 ## Preset options

--- a/packages/neutrino-preset-node/README.md
+++ b/packages/neutrino-preset-node/README.md
@@ -133,11 +133,12 @@ quick start example above as a reference:
 
 ```bash
 ❯ yarn build
+
 clean-webpack-plugin: /node/build has been removed.
 Build completed in 0.419s
 
 Hash: 89e4fb250fc535920ba4
-Version: webpack 2.6.1
+Version: webpack 3.5.6
 Time: 424ms
        Asset     Size  Chunks             Chunk Names
     index.js  4.29 kB       0  [emitted]  index
@@ -298,6 +299,8 @@ The following is a list of rules and their identifiers which can be overridden:
 ### Plugins
 
 The following is a list of plugins and their identifiers which can be overridden:
+
+_Note: Some plugins are only available in certain environments. To override them, they should be modified conditionally._
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |

--- a/packages/neutrino-preset-react/README.md
+++ b/packages/neutrino-preset-react/README.md
@@ -16,7 +16,7 @@
   - Automatic creation of HTML pages, no templating necessary
   - Hot Module Replacement support
   - Tree-shaking to create smaller bundles
-  - Production-optimized bundles with Babili minification and easy chunking
+  - Production-optimized bundles with Babili minification, easy chunking, and scope-hoisted modules for faster execution
   - Easily extensible to customize your project as needed
 
 ## Requirements

--- a/packages/neutrino-preset-react/README.md
+++ b/packages/neutrino-preset-react/README.md
@@ -118,7 +118,7 @@ the quick start example above as a reference:
 
 ✔ Building project completed
 Hash: b26ff013b5a2d5f7b824
-Version: webpack 2.6.1
+Version: webpack 3.5.6
 Time: 9773ms
                            Asset       Size    Chunks             Chunk Names
    index.dfbad882ab3d86bfd747.js     181 kB     index  [emitted]  index
@@ -151,7 +151,7 @@ preset builds. You can modify React preset settings from `.neutrinorc.js` by ove
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the React preset and override its options. See the
-[Web documentation](https://neutrino.js.org/presets/neutrino-preset-web#presetoptions) for specific options you can override with this object.
+[Web documentation](https://neutrino.js.org/presets/neutrino-preset-web#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {

--- a/packages/neutrino-preset-web/README.md
+++ b/packages/neutrino-preset-web/README.md
@@ -112,7 +112,7 @@ quick start example above as a reference:
 
 ✔ Building project completed
 Hash: 2e1191cdf700df46370d
-Version: webpack 2.6.1
+Version: webpack 3.5.6
 Time: 4145ms
                            Asset       Size    Chunks             Chunk Names
    index.523b6da56c6363aaf056.js    10.1 kB     index  [emitted]  index
@@ -281,7 +281,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 _Note: Some plugins are only available in certain environments. To override them, they should be modified conditionally._
 
-| Name | Description | Environments or Commands |
+| Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `env` | Inject environment variables into source code at `process.env`, defaults to only inject `NODE_ENV`. From `neutrino-middleware-env`. | all |
 | `html` | Automatically generates HTML files for configured entry-points. From `neutrino-middleware-html-template` | all |


### PR DESCRIPTION
Re-syncs the docs again & other fixes. Notably the contributing links are now the same across both the `packages/` and `docs/` versions of the docs, making the diffs much smaller - so hopefully it should be easier to keep everything in sync moving forwards.

See individual commits for more details.