### PR TITLE
Lint the JS config files in the root of the repo

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -2,6 +2,7 @@ module.exports = {
   use: [
     ['./packages/neutrino-preset-airbnb-base', {
       include: [
+        '.*.js',
         'packages/*/*.js',
         'packages/*/src/**/*.js',
         'packages/neutrino/bin/*'


### PR DESCRIPTION
Previously the `.neutrinorc.js` and `.eslintrc.js` files were not being included in the eslint run.