### PR TITLE
Preserve ESLint default include when just exclude set

### DIFF
--- a/packages/neutrino-middleware-eslint/index.js
+++ b/packages/neutrino-middleware-eslint/index.js
@@ -29,7 +29,7 @@ module.exports = (neutrino, opts = {}) => {
   const failBuild = process.env.NODE_ENV !== 'development' || neutrino.options.command !== 'start';
   const options = merge.all([
     opts,
-    !opts.include && !opts.exclude ? { include: [neutrino.options.source] } : {}
+    !opts.include ? { include: [neutrino.options.source] } : {}
   ]);
 
   neutrino.config

--- a/packages/neutrino-preset-airbnb-base/index.js
+++ b/packages/neutrino-preset-airbnb-base/index.js
@@ -20,7 +20,6 @@ module.exports = (neutrino, opts = {}) => {
         }
       }
     },
-    opts,
-    !opts.include && !opts.exclude ? { include: [neutrino.options.source] } : {}
+    opts
   ]));
 };


### PR DESCRIPTION
Previously if `exclude` was set manually, it would prevent the default value for `include` being used. Now consumers of the middleware can pass just `exclude` and not have to pass both. See:
https://github.com/mozilla-neutrino/neutrino-dev/pull/315#discussion_r141779549

The default include in neutrino-preset-airbnb-base has also been removed, since it just duplicated that in neutrino-middleware-eslint.