### PR TITLE
Make yarn lint/publish commands work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "repository": "mozilla-neutrino/neutrino-dev",
   "scripts": {
-    "lint": "packages/neutrino/bin/neutrino lint",
+    "lint": "node packages/neutrino/bin/neutrino lint",
     "bootstrap": "oao bootstrap --no-parallel",
     "changelog": "changelog mozilla-neutrino/neutrino-dev all --markdown > CHANGELOG.md",
     "deps:add": "oao add",
@@ -19,7 +19,7 @@
     "docs:build": "gitbook build && cp CNAME _book",
     "docs:deploy": "yarn docs:build && gh-pages --dist _book --remote upstream",
     "docs:serve": "gitbook serve",
-    "release": ".scripts/publish",
+    "release": "node .scripts/publish",
     "test": "nyc --reporter lcov ava packages/*/test",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
Even though MSYS2 and related cygwin-based environments for Windows understand shebangs, when a package.json script command is run via a Windows yarn/npm install, it runs outside of the bash shell and so if it's a direct path to a local script (rather than a package in `node_modules/.bin/` which already has the Windows compatible `.cmd` script/shim created by yarn), it fails with eg:

```
'packages\neutrino\bin\neutrino' is not recognized as an internal or external command,
operable program or batch file.
```

To make the package.json scripts truly portable, local scripts must be explicitly run with `node`:
http://alan.norbauer.com/articles/cross-platform-nodejs/#Shell-scripts-that-rely-on-Unix-shebangs