### PR TITLE
Update neutrino-middleware-hot to use named plugin

### DIFF
--- a/packages/neutrino-middleware-hot/README.md
+++ b/packages/neutrino-middleware-hot/README.md
@@ -57,6 +57,7 @@ The following is a list of plugins and their identifiers which can be overridden
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `hot` | Enables Hot Module Replacement. | all |
+| `named-modules` | Show the relative path of the module to be displayed when HMR is enabled. | all |
 
 ## Contributing
 

--- a/packages/neutrino-middleware-hot/index.js
+++ b/packages/neutrino-middleware-hot/index.js
@@ -1,3 +1,10 @@
-const { HotModuleReplacementPlugin } = require('webpack');
+const { HotModuleReplacementPlugin, NamedModulesPlugin } = require('webpack');
 
-module.exports = ({ config }) => config.plugin('hot').use(HotModuleReplacementPlugin);
+module.exports = ({ config }) => {
+  config
+    .plugin('hot')
+      .use(HotModuleReplacementPlugin)
+      .end()
+    .plugin('named-modules')
+      .use(NamedModulesPlugin);
+};


### PR DESCRIPTION
Sorry, accidentally made a silly mistake, (https://github.com/mozilla-neutrino/neutrino-dev/pull/347)