### PR TITLE
Fix neutrino-middleware-loader-merge when using with babel

### DIFF
--- a/packages/neutrino-middleware-loader-merge/index.js
+++ b/packages/neutrino-middleware-loader-merge/index.js
@@ -1,6 +1,7 @@
+const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 
 module.exports = (ruleId, loaderId) => ({ config }, options) => config.module
   .rule(ruleId)
   .use(loaderId)
-  .tap(opts => merge(opts, options));
+  .tap(opts => (loaderId === 'babel' ? babelMerge(opts, options) : merge(opts, options)));

--- a/packages/neutrino-middleware-loader-merge/package.json
+++ b/packages/neutrino-middleware-loader-merge/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
+    "babel-merge": "^1.1.0",
     "deepmerge": "^1.5.2"
   },
   "peerDependencies": {

--- a/packages/neutrino-middleware-loader-merge/yarn.lock
+++ b/packages/neutrino-middleware-loader-merge/yarn.lock
@@ -2,6 +2,35 @@
 # yarn lockfile v1
 
 
-deepmerge@^1.5.2:
+babel-merge@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-merge/-/babel-merge-1.1.0.tgz#bb7d985a52b44ce82a4cb7bcdd4be60f02b71fbb"
+  dependencies:
+    deepmerge "^1.5.1"
+    object.omit "^3.0.0"
+
+deepmerge@^1.5.1, deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
+is-extendable@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
+
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+object.omit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-3.0.0.tgz#0e3edc2fce2ba54df5577ff529f6d97bd8a522af"
+  dependencies:
+    is-extendable "^1.0.0"


### PR DESCRIPTION
This is to fix #348 

But yet I know it isn't safe to hardcode to check for `babel` only, but how can we know when to use `babelMerge`?