### PR TITLE
performance hints

### DIFF
--- a/docs/customization/README.md
+++ b/docs/customization/README.md
@@ -296,7 +296,7 @@ _Example: Neutrino's Node.js preset has performance hints disabled. Let's re-ena
 module.exports = {
   use: [
     'neutrino-preset-node',
-    (neutrino) => neutrino.config.performance.hints(true)
+    (neutrino) => neutrino.config.performance.hints('error')
   ]
 };
 ```


### PR DESCRIPTION
The available enums are `false | "error" | "warning"`. `true` is not one of them.

https://webpack.js.org/configuration/performance/#performance-hints