### PR TITLE
Use latest version of yarn on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# Use the fully virtualised infra not for sudo, but since their container
+# infra's 4GB of RAM is not sufficient to prevent yarn bootstrap OOMs:
+# https://github.com/guigrpa/oao/issues/51
+# https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
+sudo: required
 dist: trusty
 language: node_js
 cache: yarn
@@ -6,14 +11,13 @@ node_js:
 - '7'
 - '8'
 before_install:
-# oao breaks on node 6 for anything newer than yarn 0.28.4:
-# https://github.com/guigrpa/oao/issues/51
-- curl -sSfL https://yarnpkg.com/install.sh | bash -s -- --version 0.28.4
+# Use newer yarn than that pre-installed in the Travis image.
+- curl -sSfL https://yarnpkg.com/install.sh | bash
 - export PATH="$HOME/.yarn/bin:$PATH"
 install:
 - yarn install --frozen-lockfile
 before_script:
-- yarn bootstrap
+- yarn bootstrap --frozen-lockfile
 script:
 - yarn lint
 - yarn test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "mozilla-neutrino/neutrino-dev",
   "scripts": {
     "lint": "node packages/neutrino/bin/neutrino lint",
-    "bootstrap": "oao bootstrap --no-parallel --frozen-lockfile",
+    "bootstrap": "oao bootstrap --no-parallel",
     "changelog": "changelog mozilla-neutrino/neutrino-dev all --markdown > CHANGELOG.md",
     "deps:add": "oao add",
     "deps:remove": "oao remove",


### PR DESCRIPTION
The only remaining error with oao + recent yarn turned out to be due to OOM (https://github.com/guigrpa/oao/issues/51), which can be solved by switching to Travis' fully virtualised infra, which [has more RAM](https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments).

The `--frozen-lockfile` parameter has also been moved to `.travis.yml` so that the lockfiles are still updated when working making changes locally.

Being on latest yarn makes it a lot easier to experiment with switching to yarn workspaces and/or lerna.