### PR TITLE
Add eslintrc.js to .npmignore

### DIFF
--- a/packages/neutrino-middleware-eslint/.npmignore
+++ b/packages/neutrino-middleware-eslint/.npmignore
@@ -1,2 +1,3 @@
 /test/
+eslintrc.js
 yarn.lock

--- a/packages/neutrino-preset-airbnb-base/.npmignore
+++ b/packages/neutrino-preset-airbnb-base/.npmignore
@@ -1,2 +1,3 @@
 /test/
+eslintrc.js
 yarn.lock


### PR DESCRIPTION
Since they're only used for testing (added by #358).