### PR TITLE
Update to the newest version of html-webpack-template

### DIFF
--- a/packages/neutrino-middleware-html-template/package.json
+++ b/packages/neutrino-middleware-html-template/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "deepmerge": "^1.5.2",
     "html-webpack-plugin": "^2.30.1",
-    "html-webpack-template": "^6.0.1"
+    "html-webpack-template": "^5.6.0"
   },
   "devDependencies": {
     "webpack": "^3.6.0"


### PR DESCRIPTION
Counter-intuitively the most recent version of the package is actually 5.6.0, rather than 6.0.0 or 6.0.1 due to a publishing error. See:
https://github.com/jaketrent/html-webpack-template/issues/59

Version 5.6.0 is also the version one gets when running `yarn add html-webpack-template`.