### PR TITLE
fix: Use cheap-module-eval-source-map for faster recompilation

### DIFF
--- a/packages/neutrino-preset-web/index.js
+++ b/packages/neutrino-preset-web/index.js
@@ -131,7 +131,7 @@ module.exports = (neutrino, opts = {}) => {
       .use(loaderMerge('lint', 'eslint'), {
         envs: ['browser', 'commonjs']
       }))
-    .when(process.env.NODE_ENV === 'development', config => config.devtool('source-map'))
+    .when(process.env.NODE_ENV === 'development', config => config.devtool('cheap-module-eval-source-map'))
     .when(neutrino.options.command === 'start', (config) => {
       neutrino.use(devServer, options.devServer);
       config.when(options.hot, () => neutrino.use(hot));


### PR DESCRIPTION
https://webpack.js.org/guides/build-performance/ suggests to use `cheap-module-eval-source-map` to improve incremental build speed. This reduces recompilation times by a magnitude on bigger projects.