### PR TITLE
Output logging messages when using watch instead of devServer

### DIFF
--- a/packages/neutrino/bin/start.js
+++ b/packages/neutrino/bin/start.js
@@ -33,6 +33,13 @@ module.exports = (middleware, args) => {
 
       if (!compiler.options.devServer) {
         spinner.succeed('Build completed');
+        const building = ora('Performing initial build');
+
+        compiler.plugin('done', () => building.succeed('Build completed'));
+        compiler.plugin('compile', () => {
+          building.text = 'Source changed, re-compiling';
+          building.start();
+        });
       } else {
         const { devServer } = compiler.options;
         const url = `${devServer.https ? 'https' : 'http'}://${devServer.public}:${devServer.port}`;


### PR DESCRIPTION
Fixes #375.

So, incremental building actually works, it just doesn't show a new console message every time like the dev server currently does. This PR should fix that.