### PR TITLE
Allow using Jest and Mocha presets without Babel

### DIFF
--- a/packages/neutrino-preset-mocha/src/index.js
+++ b/packages/neutrino-preset-mocha/src/index.js
@@ -5,27 +5,26 @@ const loaderMerge = require('neutrino-middleware-loader-merge');
 
 module.exports = (neutrino, opts = {}) => {
   neutrino.on('test', ({ files }) => {
+    const usingBabel = neutrino.config.module.rules.has('compile');
     const options = merge.all([
       { reporter: 'spec', ui: 'tdd', bail: true },
       opts,
       files.length ? { recursive: true } : {}
     ]);
 
-    neutrino.use(loaderMerge('compile', 'babel'), {
-      env: {
-        test: {
-          plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
+    neutrino.config.when(usingBabel, () => {
+      neutrino.use(loaderMerge('compile', 'babel'), {
+        env: {
+          test: {
+            plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
+          }
         }
-      }
+      });
     });
 
-    const babelOptions = omit(
-      ['cacheDirectory'],
-      neutrino.config.module
-        .rule('compile')
-        .use('babel')
-        .get('options')
-    );
+    const babelOptions = usingBabel
+      ? omit(['cacheDirectory'], neutrino.config.module.rule('compile').use('babel').get('options'))
+      : {};
 
     return mocha(options, babelOptions, files);
   });


### PR DESCRIPTION
Fixes #374.

Currently Jest and Mocha presets will fail if they are used with middleware that doesn't define compilation rules. This PR fixes that.