### PR TITLE
Support multiple configurations from neutrinorc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 const { Neutrino } = require('./packages/neutrino');
 
-const api = Neutrino();
-
-module.exports = api.call('eslintrc');
+module.exports = Neutrino()
+  .use('.neutrinorc.js') // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/neutrino-middleware-eslint/eslintrc.js
+++ b/packages/neutrino-middleware-eslint/eslintrc.js
@@ -1,6 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-const api = Neutrino({ cwd: __dirname });
-
-// eslint-disable-next-line global-require
-module.exports = api.call('eslintrc', [require('.')]);
+module.exports = Neutrino({ root: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/neutrino-middleware-eslint/test/middleware_test.js
+++ b/packages/neutrino-middleware-eslint/test/middleware_test.js
@@ -47,5 +47,6 @@ test('exposes lint command', t => {
 test('exposes eslintrc config', t => {
   const api = Neutrino();
 
-  t.is(typeof api.call('eslintrc', [mw()]), 'object');
+  api.use(mw());
+  t.is(typeof api.call('eslintrc'), 'object');
 });

--- a/packages/neutrino-preset-airbnb-base/eslintrc.js
+++ b/packages/neutrino-preset-airbnb-base/eslintrc.js
@@ -1,6 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-const api = Neutrino({ cwd: __dirname });
-
-// eslint-disable-next-line global-require
-module.exports = api.call('eslintrc', [require('.')]);
+module.exports = Neutrino({ root: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/neutrino-preset-airbnb-base/test/airbnb_test.js
+++ b/packages/neutrino-preset-airbnb-base/test/airbnb_test.js
@@ -47,5 +47,6 @@ test('exposes lint command', t => {
 test('exposes eslintrc config', t => {
   const api = Neutrino();
 
-  t.is(typeof api.call('eslintrc', [mw()]), 'object');
+  api.use(mw());
+  t.is(typeof api.call('eslintrc'), 'object');
 });

--- a/packages/neutrino/bin/build.js
+++ b/packages/neutrino/bin/build.js
@@ -2,7 +2,11 @@ const { Neutrino, build } = require('../src');
 const merge = require('deepmerge');
 const ora = require('ora');
 
-module.exports = (middleware, args) => {
+const timeout = setTimeout(Function.prototype, 10000);
+
+process.on('message', ([middleware, args]) => {
+  clearTimeout(timeout);
+
   const spinner = args.quiet ? null : ora('Building project').start();
   const options = merge({
     args,
@@ -15,10 +19,10 @@ module.exports = (middleware, args) => {
   }, args.options);
   const api = Neutrino(options);
 
-  api.register('build', build);
-
   return api
-    .run('build', middleware)
+    .register('build', build)
+    .use(middleware)
+    .run('build')
     .fork((errors) => {
       if (!args.quiet) {
         spinner.fail('Building project failed');
@@ -37,4 +41,4 @@ module.exports = (middleware, args) => {
         }, stats.compilation.compiler.options.stats || {})));
       }
     });
-};
+});

--- a/packages/neutrino/bin/inspect.js
+++ b/packages/neutrino/bin/inspect.js
@@ -7,8 +7,11 @@ const envs = {
   start: 'development',
   test: 'test'
 };
+const timeout = setTimeout(Function.prototype, 10000);
 
-module.exports = (middleware, args) => {
+process.on('message', ([middleware, args]) => {
+  clearTimeout(timeout);
+
   const commandName = args._[0];
   const options = merge({
     args,
@@ -21,10 +24,10 @@ module.exports = (middleware, args) => {
   }, args.options);
   const api = Neutrino(options);
 
-  api.register('inspect', inspect);
-
   return api
-    .run('inspect', middleware)
+    .register('inspect', inspect)
+    .use(middleware)
+    .run('inspect')
     .fork((err) => {
       if (!args.quiet) {
         console.error(err);
@@ -32,4 +35,4 @@ module.exports = (middleware, args) => {
 
       process.exit(1);
     }, console.log);
-};
+});

--- a/packages/neutrino/bin/neutrino
+++ b/packages/neutrino/bin/neutrino
@@ -5,16 +5,10 @@
 process.noDeprecation = true;
 
 const yargs = require('yargs');
-const {
-  cond, equals, map, T
-} = require('ramda');
-const exists = require('file-exists');
-const build = require('./build');
-const inspect = require('./inspect');
-const start = require('./start');
-const test = require('./test');
-const execute = require('./execute');
-const { req } = require('../src/utils');
+const { map, pipe } = require('ramda');
+const { join } = require('path');
+const { fork } = require('child_process');
+const { req, toArray, normalizeConfig } = require('../src/utils');
 
 const cwd = process.cwd();
 const args = yargs
@@ -73,20 +67,36 @@ const args = yargs
   .argv;
 
 const rc = '.neutrinorc.js';
+const hasRc = () => {
+  try {
+    require.resolve(join(process.cwd(), rc));
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+const coreCommands = ['build', 'start', 'test', 'inspect'];
+const mergeConfig = ({ config }) => config.merge(args.options.config);
 const cmd = args.inspect ? 'inspect' : args._[0];
-const middleware = [...new Set([
-  ...(exists.sync(rc, { root: process.cwd() }) ? [rc] : []),
-  ...args.use
-])];
+const rawConfigs = hasRc() ?
+  toArray(req('.neutrinorc.js', process.cwd())) :
+  [[...new Set(args.use)]];
 
-if (!middleware.length) {
+if (!rawConfigs.length) {
   throw new Error('No middleware was found. Specify middleware with --use or create a .neutrinorc.js file.');
 }
 
-// Merge CLI config options as last piece of middleware, e.g. options.config.devServer.port 4000
-if (args.options) {
-  middleware.push(({ config }) => config.merge(args.options.config));
-}
+const configs = map(pipe(
+  normalizeConfig,
+  // Merge CLI config options as last piece of middleware, e.g. options.config.devServer.port 4000
+  (config) => {
+    if (args.options) {
+      config.use.push(mergeConfig);
+    }
+
+    return config;
+  }
+), rawConfigs);
 
 process.on('unhandledRejection', (err) => {
   if (!args.quiet) {
@@ -102,13 +112,24 @@ const promises = map((moduleId) => {
 
   return typeof module === 'function' ? module() : module;
 }, args.require);
+const processes = [];
+
+process.on('SIGINT', (...args) => {
+  processes.forEach(process => process.kill(...args));
+});
 
 Promise
   .all(promises)
-  .then(() => cond([
-    [equals('build'), () => build(middleware, args)],
-    [equals('start'), () => start(middleware, args)],
-    [equals('test'), () => test(middleware, args)],
-    [equals('inspect'), () => inspect(middleware, args)],
-    [T, () => execute(middleware, args)]
-  ])(cmd));
+  .then(() => {
+    configs.forEach((middleware) => {
+      const script = join(__dirname, coreCommands.includes(cmd) ? `./${cmd}` : './execute');
+      const child = fork(script);
+
+      child.on('exit', (code) => {
+        process.exit(code);
+        processes.forEach(process => process !== child && process.kill(code));
+      });
+      child.send([middleware, args]);
+      processes.push(child);
+    });
+  });

--- a/packages/neutrino/bin/start.js
+++ b/packages/neutrino/bin/start.js
@@ -2,7 +2,11 @@ const { Neutrino, start } = require('../src');
 const merge = require('deepmerge');
 const ora = require('ora');
 
-module.exports = (middleware, args) => {
+const timeout = setTimeout(Function.prototype, 10000);
+
+process.on('message', ([middleware, args]) => {
+  clearTimeout(timeout);
+
   const spinner = args.quiet ? null : ora('Building project').start();
   const options = merge({
     args,
@@ -15,10 +19,10 @@ module.exports = (middleware, args) => {
   }, args.options);
   const api = Neutrino(options);
 
-  api.register('start', start);
-
   return api
-    .run('start', middleware)
+    .register('start', start)
+    .use(middleware)
+    .run('start')
     .fork((errors) => {
       if (!args.quiet) {
         spinner.fail('Building project failed');
@@ -54,4 +58,4 @@ module.exports = (middleware, args) => {
         });
       }
     });
-};
+});

--- a/packages/neutrino/bin/test.js
+++ b/packages/neutrino/bin/test.js
@@ -1,7 +1,11 @@
 const { Neutrino, test } = require('../src');
 const merge = require('deepmerge');
 
-module.exports = (middleware, args) => {
+const timeout = setTimeout(Function.prototype, 10000);
+
+process.on('message', ([middleware, args]) => {
+  clearTimeout(timeout);
+
   const options = merge({
     args,
     command: args._[0],
@@ -13,10 +17,10 @@ module.exports = (middleware, args) => {
   }, args.options);
   const api = Neutrino(options);
 
-  api.register('test', test);
-
   return api
-    .run('test', middleware)
+    .register('test', test)
+    .use(middleware)
+    .run('test')
     .fork((err) => {
       if (err) {
         Array.isArray(err) ? err.forEach(err => err && console.error(err)) : console.error(err);
@@ -28,4 +32,4 @@ module.exports = (middleware, args) => {
       // Force exit once we get here.
       process.exit(0);
     });
-};
+});

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -3,11 +3,9 @@ const merge = require('deepmerge');
 const Future = require('fluture');
 const mitt = require('mitt');
 const {
-  cond, defaultTo, is, map, omit, pipe, prop
+  defaultTo, is, map, omit, prop
 } = require('ramda');
 const { normalizePath, toArray, req } = require('./utils');
-
-const rc = '.neutrinorc.js';
 
 // getRoot :: Object -> String
 const getRoot = prop('root');
@@ -80,94 +78,118 @@ const mergeOptions = (options, newOptions) => {
 };
 /* eslint-enable no-param-reassign */
 
-// Api :: Object? -> Object
-const Api = pipe(getOptions, (options) => {
-  const listeners = {};
-  const api = merge(mitt(listeners), {
-    listeners,
-    options,
-    commands: {},
-    config: new Config(),
+class Api {
+  constructor(options) {
+    this.options = getOptions(options);
+    this.listeners = {};
+    this.emitter = mitt(this.listeners);
+    this.commands = {};
+    this.config = new Config();
+    this.configs = [this.config];
+  }
 
-    // emitForAll :: String -> payload -> Promise
-    emitForAll: (eventName, payload) => Promise
-      .all((api.listeners[eventName] || []).map(f => f(payload))),
+  emit(...args) {
+    return this.emitter.emit(...args);
+  }
 
-    // register :: String commandName -> Function handler -> ()
-    register: (commandName, handler) => (api.commands[commandName] = handler),
+  on(...args) {
+    return this.emitter.on(...args);
+  }
 
-    // require :: String moduleId -> a
-    require: (moduleId, root = api.options.root) => req(moduleId, root),
+  off(...args) {
+    return this.emitter.off(...args);
+  }
 
-    // use :: a middleware -> Object options -> IO ()
-    use: (middleware, options) => cond([
+  // emitForAll :: String eventName -> Any payload -> Promise
+  emitForAll(eventName, payload) {
+    const events = this.listeners[eventName] || [];
+
+    return Promise.all(events.map(f => f(payload)));
+  }
+
+  // register :: String commandName -> Function handler -> Api
+  register(commandName, handler) {
+    this.commands[commandName] = handler;
+    return this;
+  }
+
+  // require :: String moduleId -> Any
+  require(moduleId, root = this.options.root) {
+    return req(moduleId, root);
+  }
+
+  // use :: Any middleware -> Object options -> IO Api
+  use(middleware, options) {
+    if (is(Function, middleware)) {
       // If middleware is a function, invoke it with the provided options
-      [is(Function), () => middleware(api, options)],
-
+      middleware(this, options);
+    } else if (is(String, middleware)) {
       // If middleware is a string, it's a module to require. Require it, then run the results back
       // through .use() with the provided options
-      [is(String), () => api.use(api.require(middleware, api.options.root), options)],
-
+      this.use(this.require(middleware, this.options.root), options);
+    } else if (is(Array, middleware)) {
       // If middleware is an array, it's a pair of some other middleware type and options
-      [is(Array), () => api.use(...middleware)],
-
+      this.use(...middleware);
+    } else if (is(Object, middleware)) {
       // If middleware is an object, it could contain other middleware in its "use" property.
       // Run every item in "use" prop back through .use(), plus set any options.
       // The value of "env" will also be consumed as middleware, which will potentially load more middleware and
       // options
-      [is(Object), () => {
-        if (middleware.options) {
-          api.options = mergeOptions(api.options, middleware.options);
+      if (middleware.options) {
+        this.options = mergeOptions(this.options, middleware.options);
+      }
+
+      if (middleware.env) {
+        const envMiddleware = Object
+          .keys(middleware.env)
+          .map((key) => {
+            const envValue = this.options.env[key] || process.env[key];
+            const env = middleware.env[key][envValue];
+
+            if (!env) {
+              return null;
+            }
+
+            if (!is(Object, env) || !env.options) {
+              return env;
+            }
+
+            this.options = mergeOptions(this.options, env.options);
+
+            return omit(['options'], env);
+          });
+
+        if (middleware.use) {
+          map(use => this.use(use), middleware.use);
         }
 
-        if (middleware.env) {
-          const envMiddleware = Object
-            .keys(middleware.env)
-            .map((key) => {
-              const envValue = api.options.env[key] || process.env[key];
-              const env = middleware.env[key][envValue];
+        map(env => this.use(env), envMiddleware.filter(Boolean));
+      } else if (middleware.use) {
+        map(use => this.use(use), middleware.use);
+      }
+    }
 
-              if (!env) {
-                return null;
-              }
+    return this;
+  }
 
-              if (!is(Object, env) || !env.options) {
-                return env;
-              }
+  // call :: String commandName -> IO Any
+  call(commandName) {
+    return this.commands[commandName](this.config.toConfig(), this);
+  }
 
-              api.options = mergeOptions(api.options, env.options);
+  // run :: String commandName -> Future
+  run(commandName) {
+    const emitForAll = this.emitForAll.bind(this);
 
-              return omit(['options'], env);
-            });
-
-          if (middleware.use) {
-            map(api.use, middleware.use);
-          }
-
-          map(api.use, envMiddleware.filter(Boolean));
-        } else if (middleware.use) {
-          map(api.use, middleware.use);
-        }
-      }]
-    ])(middleware),
-
-    // call :: String commandName -> Array middleware -> IO a
-    call: (commandName, middleware = [rc]) => {
-      map(api.use, middleware);
-      return api.commands[commandName](api.config.toConfig(), api);
-    },
-
-    // run :: String commandName -> Array middleware -> Future
-    run: (commandName, middleware = [rc]) => Future
-      // Require and use all middleware
-      .try(() => map(api.use, middleware))
+    return Future
+      .of(true)
       // Trigger all pre-events for the current command
-      .chain(() => Future.encaseP2(api.emitForAll, `pre${commandName}`, api.options.args))
+      .chain(() => Future.encaseP2(emitForAll, `pre${commandName}`, this.options.args))
       // Trigger generic pre-event
-      .chain(() => Future.encaseP2(api.emitForAll, 'prerun', api.options.args))
+      .chain(() => Future.encaseP2(emitForAll, 'prerun', this.options.args))
       // Execute the command
       .chain(() => {
-        const result = api.commands[commandName](api.config.toConfig(), api);
+        const result = this.commands[commandName](this.config.toConfig(), this);
 
         return Future.isFuture(result) ?
           result :
@@ -175,16 +197,14 @@ const Api = pipe(getOptions, (options) => {
       })
       // Trigger all post-command events, resolving with the value of the command execution
       .chain(value => Future
-        .encaseP2(api.emitForAll, commandName, api.options.args)
+        .encaseP2(emitForAll, commandName, this.options.args)
         .chain(() => Future.of(value)))
       // Trigger generic post-event, resolving with the value of the command execution
       .chain(value => Future
-        .encaseP2(api.emitForAll, 'run', api.options.args)
+        .encaseP2(emitForAll, 'run', this.options.args)
         .chain(() => Future.of(value)))
-      .mapRej(toArray)
-  });
+      .mapRej(toArray);
+  }
+}
 
-  return api;
-});
-
-module.exports = Api;
+module.exports = options => new Api(options);

--- a/packages/neutrino/src/utils.js
+++ b/packages/neutrino/src/utils.js
@@ -1,5 +1,5 @@
 const {
-  cond, curry, identity, of, T
+  cond, curry, identity, is, map, objOf, of, T
 } = require('ramda');
 const { List } = require('immutable-ext');
 const { isAbsolute, join } = require('path');
@@ -35,9 +35,16 @@ const req = (moduleId, root) => {
   return require(path); // eslint-disable-line
 };
 
+// normalizeConfig :: Array Any -> Array Object
+const normalizeConfig = map(cond([
+  [is(Object), identity],
+  [T, objOf('use')]
+]));
+
 module.exports = {
   createPaths,
   normalizePath,
   toArray,
-  req
+  req,
+  normalizeConfig
 };


### PR DESCRIPTION
**This is a WIP!**

Breaking change! This will allow us to finally support multiple configs from `.neutrinorc.js` by exporting an array.

```js
module.exports = [
  {
    use: ['neutrino-preset-react']
  },
  {
    options: {
      source: 'server'
    },
    use: ['neutrino-preset-node']
  }
];
```

This works by spawning a new process for each configuration. I tried going down 2 other routes but faced difficulties that were near impossible to overcome in a good way.

Wanted to get this out there for feedback.

Fixes #308.