### PR TITLE
Make --debug set copy-webpack-plugin's 'debug' option

### DIFF
--- a/packages/neutrino-middleware-copy/index.js
+++ b/packages/neutrino-middleware-copy/index.js
@@ -1,10 +1,13 @@
 const CopyPlugin = require('copy-webpack-plugin');
 const merge = require('deepmerge');
 
-module.exports = ({ config }, opts = {}) => {
-  const { patterns, options } = merge({ patterns: [], options: {} }, opts);
+module.exports = (neutrino, opts = {}) => {
+  const { patterns, options } = merge({
+    patterns: [],
+    options: { debug: neutrino.options.debug }
+  }, opts);
 
-  config
+  neutrino.config
     .plugin(options.pluginId || 'copy')
     .use(CopyPlugin, [patterns, options]);
 };


### PR DESCRIPTION
Setting copy-webpack-plugin's `debug` option to `true` increases the log level from `warning` to `info`:
https://github.com/webpack-contrib/copy-webpack-plugin#available-options

Which gives output of form:

```
[copy-webpack-plugin] processing from: '**/*' to: 'static'
[copy-webpack-plugin] begin globbing '...\src\static\**\*' with a context of '...\src\static'
[copy-webpack-plugin] determined that '.../src/static/foo.txt' should write to 'static/foo.txt'
[copy-webpack-plugin] reading ...\src\static\foo.txt to write to assets
[copy-webpack-plugin] writing 'static/foo.txt' to compilation assets from '...\src\static\foo.txt'
```

Refs #389.