### PR TITLE
Make --debug set clean-webpack-plugin's 'verbose' option

### DIFF
--- a/packages/neutrino-middleware-clean/index.js
+++ b/packages/neutrino-middleware-clean/index.js
@@ -6,5 +6,5 @@ module.exports = (neutrino, options = {}) => {
 
   neutrino.config
     .plugin(options.pluginId || 'clean')
-    .use(CleanPlugin, [paths, { root, verbose: false }]);
+    .use(CleanPlugin, [paths, { root, verbose: neutrino.options.debug }]);
 };


### PR DESCRIPTION
This gives output of form:

```
clean-webpack-plugin: C:\Users\Ed\src\treeherder\build has been removed.
```

See:
https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional

Refs #389.