### PR TITLE
Reformat readme headings, favor spectrum over slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,11 +44,11 @@ externally.
 ## Support
 
 Neutrino team members and contributors are here to help you! Should you need assistance or have questions in using
-Neutrino or its core presets, please consider asking on our Slack channel, Stack Overflow, or other channel rather than
+Neutrino or its core presets, please consider asking on our Spectrum channel, Stack Overflow, or other channel rather than
 filing issues. We would prefer to keep our GitHub issues clear for bugs, feature requests, discussions, and
 relevant information related to its development.
 
-[Join our Slack channel!](https://neutrino-slack.herokuapp.com/)
+[![Join the Neutrino community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/neutrino)
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build Status][travis-image]][travis-url]
 [![Codacy][codacy-image]][codacy-url]
 [![codecov][codecov-image]][codecov-url]
-[![Join Slack][slack-image]][slack-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 [https://github.com/mozilla-neutrino/neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev)
 
@@ -43,8 +43,8 @@ community.
 [npm-url]: https://npmjs.org/package/neutrino
 [travis-image]: https://travis-ci.org/mozilla-neutrino/neutrino-dev.svg?branch=master
 [travis-url]: https://travis-ci.org/mozilla-neutrino/neutrino-dev
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino
 [codacy-image]: https://api.codacy.com/project/badge/Grade/8717707007704c929de39ec20b7b0542
 [codacy-url]: https://www.codacy.com/app/Neutrino/neutrino-dev?utm_source=github.com&utm_medium=referral&utm_content=mozilla-neutrino/neutrino-dev&utm_campaign=badger
 [codecov-image]: https://codecov.io/gh/mozilla-neutrino/neutrino-dev/branch/master/graph/badge.svg

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 [![Build Status][travis-image]][travis-url]
 [![Codacy][codacy-image]][codacy-url]
 [![codecov][codecov-image]][codecov-url]
-[![Join Slack][slack-image]][slack-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 [https://github.com/mozilla-neutrino/neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev)
 
@@ -34,8 +34,8 @@ for details on installation, getting started, usage, and customizing.
 [npm-url]: https://npmjs.org/package/neutrino
 [travis-image]: https://travis-ci.org/mozilla-neutrino/neutrino-dev.svg?branch=master
 [travis-url]: https://travis-ci.org/mozilla-neutrino/neutrino-dev
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino
 [codacy-image]: https://api.codacy.com/project/badge/Grade/8717707007704c929de39ec20b7b0542
 [codacy-url]: https://www.codacy.com/app/Neutrino/neutrino-dev?utm_source=github.com&utm_medium=referral&utm_content=mozilla-neutrino/neutrino-dev&utm_campaign=badger
 [codecov-image]: https://codecov.io/gh/mozilla-neutrino/neutrino-dev/branch/master/graph/badge.svg

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -44,11 +44,11 @@ externally.
 ## Support
 
 Neutrino team members and contributors are here to help you! Should you need assistance or have questions in using
-Neutrino or its core presets, please consider asking on our Slack channel, Stack Overflow, or other channel rather than
+Neutrino or its core presets, please consider asking on our Spectrum channel, Stack Overflow, or other channel rather than
 filing issues. We would prefer to keep our GitHub issues clear for bugs, feature requests, discussions, and
 relevant information related to its development.
 
-[Join our Slack channel!](https://neutrino-slack.herokuapp.com/)
+[![Join the Neutrino community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/neutrino)
 
 ## Guidelines
 

--- a/docs/middleware/neutrino-middleware-banner/README.md
+++ b/docs/middleware/neutrino-middleware-banner/README.md
@@ -1,7 +1,10 @@
 # Neutrino Banner Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-banner` is Neutrino middleware for injecting string content into source code files.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -94,5 +97,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-banner.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-banner.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-banner
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-chunk/README.md
+++ b/docs/middleware/neutrino-middleware-chunk/README.md
@@ -1,7 +1,10 @@
 # Neutrino Chunk Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-chunk` is Neutrino middleware for optimizing Webpack bundles via `CommonsChunkPlugin`.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -71,5 +74,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-chunk.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-chunk.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-chunk
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-clean/README.md
+++ b/docs/middleware/neutrino-middleware-clean/README.md
@@ -1,7 +1,10 @@
 # Neutrino Clean Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-clean` is Neutrino middleware for removing directories before building.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -85,5 +88,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-clean.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-clean.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-clean
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-compile-loader/README.md
+++ b/docs/middleware/neutrino-middleware-compile-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Compile Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-compile-loader` is Neutrino middleware for compiling source code with Babel.
+
+[![NPM version][npm-image]]
+[npm-url][![NPM downloads][npm-downloads]]
+[npm-url][![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -131,5 +134,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-compile-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-compile-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-copy/README.md
+++ b/docs/middleware/neutrino-middleware-copy/README.md
@@ -1,7 +1,10 @@
 # Neutrino Copy Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-copy` is Neutrino middleware for copying files during building.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -91,5 +94,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-copy.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-copy.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-copy
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-dev-server/README.md
+++ b/docs/middleware/neutrino-middleware-dev-server/README.md
@@ -1,7 +1,10 @@
 # Neutrino Dev Server Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-dev-server` is Neutrino middleware for starting a Webpack Dev Server for fast development cycles.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -136,5 +139,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-dev-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-dev-server.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-dev-server
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-env/README.md
+++ b/docs/middleware/neutrino-middleware-env/README.md
@@ -1,9 +1,12 @@
 # Neutrino Environment Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-env` is Neutrino middleware for injecting environment variable definitions into
 source code at `process.env`. You can use this to make a custom environment variable (e.g. an API server backend to
 use) available inside your project. Always injects `process.env.NODE_ENV`, unless overridden.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -83,5 +86,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-env.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-env.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-env
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-eslint/README.md
+++ b/docs/middleware/neutrino-middleware-eslint/README.md
@@ -1,7 +1,10 @@
 # Neutrino ESLint Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-eslint` is Neutrino middleware for linting source code using ESLint and eslint-loader.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -199,5 +202,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-eslint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-eslint.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-eslint
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-font-loader/README.md
+++ b/docs/middleware/neutrino-middleware-font-loader/README.md
@@ -1,5 +1,8 @@
 # Neutrino Font Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 `neutrino-middleware-font-loader` is Neutrino middleware for loading and importing font files from modules.
 
@@ -96,5 +99,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-font-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-font-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-font-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-hot/README.md
+++ b/docs/middleware/neutrino-middleware-hot/README.md
@@ -1,8 +1,11 @@
 # Neutrino Hot Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-hot` is Neutrino middleware for enabled Hot Module Replacement with Webpack's
 `HotModuleReplacementPlugin`. This middleware is usually only added during development.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -68,5 +71,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-hot.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-hot.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-hot
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-html-loader/README.md
+++ b/docs/middleware/neutrino-middleware-html-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino HTML Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-html-loader` is Neutrino middleware for loading and importing HTML files from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -85,5 +88,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-html-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-html-template/README.md
+++ b/docs/middleware/neutrino-middleware-html-template/README.md
@@ -1,8 +1,11 @@
 # Neutrino HTML Template Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-html-template` is Neutrino middleware for automatically creating HTML files for configured
 entry-points.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -112,5 +115,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-template.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-template.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-html-template
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-image-loader/README.md
+++ b/docs/middleware/neutrino-middleware-image-loader/README.md
@@ -1,5 +1,8 @@
 # Neutrino Image Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 `neutrino-middleware-image-loader` is Neutrino middleware for loading and importing image files from modules.
 
@@ -96,5 +99,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-image-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-image-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-image-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-loader-merge/README.md
+++ b/docs/middleware/neutrino-middleware-loader-merge/README.md
@@ -1,8 +1,11 @@
 # Neutrino Loader Merge Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-loader-merge` is Neutrino middleware for easily performing a deep merge of options into
 a named rule and named loader in a Neutrino configuration.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -73,5 +76,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-loader-merge.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-loader-merge.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-loader-merge
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-minify/README.md
+++ b/docs/middleware/neutrino-middleware-minify/README.md
@@ -1,9 +1,12 @@
 # Neutrino Minify Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-minify` is Neutrino middleware for minifying source code using
 [`BabelMinifyWebpackPlugin`](https://www.npmjs.com/package/babel-minify-webpack-plugin). This middleware is usually only
 added during production builds.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -90,5 +93,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-minify.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-minify
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-pwa/README.md
+++ b/docs/middleware/neutrino-middleware-pwa/README.md
@@ -1,8 +1,11 @@
 # Neutrino PWA Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-pwa` is Neutrino middleware for augmenting a Neutrino web application with Progressive Web
 Application capabilities. This middleware is usually only added during production builds.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -120,5 +123,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-pwa.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-pwa.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-pwa
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-start-server/README.md
+++ b/docs/middleware/neutrino-middleware-start-server/README.md
@@ -1,8 +1,11 @@
 # Neutrino Start Server Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-start-server` is Neutrino middleware for starting a Node.js server for a file upon
 completion of a build.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -92,5 +95,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-start-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-start-server.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-start-server
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/middleware/neutrino-middleware-style-loader/README.md
+++ b/docs/middleware/neutrino-middleware-style-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Style Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-style-loader` is Neutrino middleware for loading and importing stylesheets from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -88,5 +91,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-style-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-style-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-style-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-airbnb-base/README.md
+++ b/docs/presets/neutrino-preset-airbnb-base/README.md
@@ -1,8 +1,11 @@
-# Neutrino Airbnb Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url] 
+# Neutrino Airbnb Base Preset
 
 `neutrino-preset-airbnb-base` is a Neutrino preset that supports linting JavaScript projects with Airbnb's base ESLint
 config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url] 
 
 ## Features
 
@@ -10,6 +13,9 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 - Modern Babel knowledge supporting ES modules, JSX (when used with React preset), Web and Node.js apps
 - Highly visible during development, fails compilation when building for production
 - Easily extensible to customize your project as needed
+
+_Note: If you are building a React project, you should probably use 
+[`neutrino-preset-airbnb`](https://www.npmjs.com/package/neutrino-preset-airbnb) instead._
 
 ## Requirements
 
@@ -317,5 +323,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-airbnb-base.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-airbnb-base.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-airbnb-base
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-jest/README.md
+++ b/docs/presets/neutrino-preset-jest/README.md
@@ -1,7 +1,10 @@
 # Neutrino Jest Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-jest` is a Neutrino preset that supports testing JavaScript projects with the Jest test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -323,5 +326,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-jest.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-jest.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-jest
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-karma/README.md
+++ b/docs/presets/neutrino-preset-karma/README.md
@@ -1,7 +1,10 @@
 # Neutrino Karma Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-karma` is a Neutrino preset that supports testing web applications using the Karma test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -201,5 +204,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-karma.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-karma.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-karma
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-mocha/README.md
+++ b/docs/presets/neutrino-preset-mocha/README.md
@@ -1,7 +1,10 @@
 # Neutrino Mocha Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-mocha` is a Neutrino preset that supports testing JavaScript projects with the Mocha test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -213,5 +216,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-mocha.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-mocha.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-mocha
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-node/README.md
+++ b/docs/presets/neutrino-preset-node/README.md
@@ -1,7 +1,10 @@
 # Neutrino Node.js Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-node` is a Neutrino preset that supports building Node.js applications.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -338,5 +341,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-node.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-node.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-node
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-react/README.md
+++ b/docs/presets/neutrino-preset-react/README.md
@@ -1,7 +1,10 @@
 # Neutrino React Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-react` is a Neutrino preset that supports building React web applications.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -277,5 +280,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-react.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-react.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-react
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/presets/neutrino-preset-web/README.md
+++ b/docs/presets/neutrino-preset-web/README.md
@@ -1,7 +1,10 @@
 # Neutrino Web Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-web` is a Neutrino preset that supports building generic applications for the web.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -327,5 +330,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-web.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-web.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-web
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-banner/README.md
+++ b/packages/neutrino-middleware-banner/README.md
@@ -1,7 +1,10 @@
 # Neutrino Banner Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-banner` is Neutrino middleware for injecting string content into source code files.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -94,5 +97,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-banner.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-banner.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-banner
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-chunk/README.md
+++ b/packages/neutrino-middleware-chunk/README.md
@@ -1,7 +1,10 @@
 # Neutrino Chunk Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-chunk` is Neutrino middleware for optimizing Webpack bundles via `CommonsChunkPlugin`.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -71,5 +74,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-chunk.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-chunk.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-chunk
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-clean/README.md
+++ b/packages/neutrino-middleware-clean/README.md
@@ -1,7 +1,10 @@
 # Neutrino Clean Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-clean` is Neutrino middleware for removing directories before building.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -85,5 +88,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-clean.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-clean.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-clean
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-compile-loader/README.md
+++ b/packages/neutrino-middleware-compile-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Compile Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-compile-loader` is Neutrino middleware for compiling source code with Babel.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -131,5 +134,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-compile-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-compile-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-copy/README.md
+++ b/packages/neutrino-middleware-copy/README.md
@@ -1,7 +1,10 @@
 # Neutrino Copy Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-copy` is Neutrino middleware for copying files during building.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -91,5 +94,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-copy.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-copy.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-copy
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-dev-server/README.md
+++ b/packages/neutrino-middleware-dev-server/README.md
@@ -1,7 +1,10 @@
 # Neutrino Dev Server Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-dev-server` is Neutrino middleware for starting a Webpack Dev Server for fast development cycles.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -136,5 +139,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-dev-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-dev-server.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-dev-server
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-env/README.md
+++ b/packages/neutrino-middleware-env/README.md
@@ -1,9 +1,12 @@
 # Neutrino Environment Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-env` is Neutrino middleware for injecting environment variable definitions into
 source code at `process.env`. You can use this to make a custom environment variable (e.g. an API server backend to
 use) available inside your project. Always injects `process.env.NODE_ENV`, unless overridden.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -83,5 +86,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-env.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-env.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-env
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-eslint/README.md
+++ b/packages/neutrino-middleware-eslint/README.md
@@ -1,7 +1,10 @@
 # Neutrino ESLint Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-eslint` is Neutrino middleware for linting source code using ESLint and eslint-loader.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -199,5 +202,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-eslint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-eslint.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-eslint
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-font-loader/README.md
+++ b/packages/neutrino-middleware-font-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Font Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-font-loader` is Neutrino middleware for loading and importing font files from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -96,5 +99,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-font-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-font-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-font-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-hot/README.md
+++ b/packages/neutrino-middleware-hot/README.md
@@ -1,8 +1,11 @@
 # Neutrino Hot Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-hot` is Neutrino middleware for enabled Hot Module Replacement with Webpack's
 `HotModuleReplacementPlugin`. This middleware is usually only added during development.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -68,5 +71,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-hot.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-hot.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-hot
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-html-loader/README.md
+++ b/packages/neutrino-middleware-html-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino HTML Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-html-loader` is Neutrino middleware for loading and importing HTML files from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -85,5 +88,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-html-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-html-template/README.md
+++ b/packages/neutrino-middleware-html-template/README.md
@@ -1,8 +1,11 @@
 # Neutrino HTML Template Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-html-template` is Neutrino middleware for automatically creating HTML files for configured
 entry-points.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -112,5 +115,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-html-template.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-html-template.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-html-template
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-image-loader/README.md
+++ b/packages/neutrino-middleware-image-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Image Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-image-loader` is Neutrino middleware for loading and importing image files from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -96,5 +99,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-image-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-image-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-image-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-loader-merge/README.md
+++ b/packages/neutrino-middleware-loader-merge/README.md
@@ -1,8 +1,11 @@
 # Neutrino Loader Merge Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-loader-merge` is Neutrino middleware for easily performing a deep merge of options into
 a named rule and named loader in a Neutrino configuration.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -73,5 +76,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-loader-merge.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-loader-merge.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-loader-merge
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-minify/README.md
+++ b/packages/neutrino-middleware-minify/README.md
@@ -1,9 +1,12 @@
 # Neutrino Minify Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-minify` is Neutrino middleware for minifying source code using
 [`BabelMinifyWebpackPlugin`](https://www.npmjs.com/package/babel-minify-webpack-plugin). This middleware is usually only
 added during production builds.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -90,5 +93,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-minify.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-minify
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-pwa/README.md
+++ b/packages/neutrino-middleware-pwa/README.md
@@ -1,8 +1,11 @@
 # Neutrino PWA Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-pwa` is Neutrino middleware for augmenting a Neutrino web application with Progressive Web
 Application capabilities. This middleware is usually only added during production builds.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -120,5 +123,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-pwa.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-pwa.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-pwa
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-start-server/README.md
+++ b/packages/neutrino-middleware-start-server/README.md
@@ -1,8 +1,11 @@
 # Neutrino Start Server Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-start-server` is Neutrino middleware for starting a Node.js server for a file upon
 completion of a build.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -93,5 +96,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-start-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-start-server.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-start-server
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-middleware-style-loader/README.md
+++ b/packages/neutrino-middleware-style-loader/README.md
@@ -1,7 +1,10 @@
 # Neutrino Style Loader Middleware
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-middleware-style-loader` is Neutrino middleware for loading and importing stylesheets from modules.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Requirements
 
@@ -88,5 +91,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-middleware-style-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-middleware-style-loader.svg
 [npm-url]: https://npmjs.org/package/neutrino-middleware-style-loader
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-airbnb-base/README.md
+++ b/packages/neutrino-preset-airbnb-base/README.md
@@ -1,8 +1,11 @@
-# Neutrino Airbnb Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url] 
+# Neutrino Airbnb Base Preset
 
 `neutrino-preset-airbnb-base` is a Neutrino preset that supports linting JavaScript projects with Airbnb's base ESLint
 config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url] 
 
 ## Features
 
@@ -10,6 +13,9 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 - Modern Babel knowledge supporting ES modules, JSX (when used with React preset), Web and Node.js apps
 - Highly visible during development, fails compilation when building for production
 - Easily extensible to customize your project as needed
+
+_Note: If you are building a React project, you should probably use 
+[`neutrino-preset-airbnb`](https://www.npmjs.com/package/neutrino-preset-airbnb) instead._
 
 ## Requirements
 
@@ -317,5 +323,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-airbnb-base.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-airbnb-base.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-airbnb-base
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-jest/README.md
+++ b/packages/neutrino-preset-jest/README.md
@@ -1,7 +1,10 @@
 # Neutrino Jest Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-jest` is a Neutrino preset that supports testing JavaScript projects with the Jest test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -322,5 +325,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-jest.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-jest.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-jest
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-karma/README.md
+++ b/packages/neutrino-preset-karma/README.md
@@ -1,7 +1,10 @@
 # Neutrino Karma Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-karma` is a Neutrino preset that supports testing web applications using the Karma test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -201,5 +204,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-karma.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-karma.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-karma
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-mocha/README.md
+++ b/packages/neutrino-preset-mocha/README.md
@@ -1,7 +1,10 @@
 # Neutrino Mocha Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-mocha` is a Neutrino preset that supports testing JavaScript projects with the Mocha test runner.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -213,5 +216,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-mocha.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-mocha.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-mocha
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-node/README.md
+++ b/packages/neutrino-preset-node/README.md
@@ -1,7 +1,10 @@
 # Neutrino Node.js Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-node` is a Neutrino preset that supports building Node.js applications.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -338,5 +341,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-node.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-node.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-node
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-react/README.md
+++ b/packages/neutrino-preset-react/README.md
@@ -1,7 +1,10 @@
 # Neutrino React Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-react` is a Neutrino preset that supports building React web applications.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -277,5 +280,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-react.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-react.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-react
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino-preset-web/README.md
+++ b/packages/neutrino-preset-web/README.md
@@ -1,7 +1,10 @@
 # Neutrino Web Preset
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
 
 `neutrino-preset-web` is a Neutrino preset that supports building generic applications for the web.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -327,5 +330,5 @@ containing all resources for developing Neutrino and its core presets and middle
 [npm-image]: https://img.shields.io/npm/v/neutrino-preset-web.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino-preset-web.svg
 [npm-url]: https://npmjs.org/package/neutrino-preset-web
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/neutrino/README.md
+++ b/packages/neutrino/README.md
@@ -3,7 +3,9 @@
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of Webpack with the simplicity of presets.
 
-[![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads]][npm-url] [![Join Slack][slack-image]][slack-url]
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ---
 
@@ -25,5 +27,5 @@ for details on installation, getting started, usage, and customizing.
 [npm-image]: https://img.shields.io/npm/v/neutrino.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino.svg
 [npm-url]: https://npmjs.org/package/neutrino
-[slack-image]: https://neutrino-slack.herokuapp.com/badge.svg
-[slack-url]: https://neutrino-slack.herokuapp.com/
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino


### PR DESCRIPTION
Tried out spectrum and really like the discussion format. We will try favoring this over slack since it is much more open and beginner friendly than slack. It will also let me remove the external Heroku service I have running that lets newcomers join slack.

I've also reformatted the readme headings to avoid things like this in the future:

![npm](https://cldup.com/gDKg7nhWUc.png)
![twitter](https://cldup.com/0Ys18UxE5S.png)