### PR TITLE
Docs: Remove leftover babel-polyfill references

### DIFF
--- a/docs/customization/README.md
+++ b/docs/customization/README.md
@@ -186,7 +186,7 @@ module.exports = {
     }],
 
     ['neutrino-preset-react', {
-      polyfills: { babel: false },
+      polyfills: { async: false },
       html: { title: 'Epic React App' }
     }],
 

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -172,7 +172,7 @@ module.exports = {
     'neutrino-preset-airbnb-base',
     
     // array format
-    ['neutrino-preset-react', { polyfills: { babel: false } }],
+    ['neutrino-preset-react', { polyfills: { async: false } }],
     
     // function format
     (neutrino) => {

--- a/docs/presets/neutrino-preset-web/README.md
+++ b/docs/presets/neutrino-preset-web/README.md
@@ -157,9 +157,7 @@ module.exports = {
 
       polyfills: {
         // Enables fast-async polyfill. Set to false to disable
-        async: true,
-        // Enables babel-polyfill. Set to false to disable
-        babel: true
+        async: true
       },
 
       // Change options related to generating the HTML document

--- a/packages/neutrino-preset-web/README.md
+++ b/packages/neutrino-preset-web/README.md
@@ -157,9 +157,7 @@ module.exports = {
 
       polyfills: {
         // Enables fast-async polyfill. Set to false to disable
-        async: true,
-        // Enables babel-polyfill. Set to false to disable
-        babel: true
+        async: true
       },
 
       // Change options related to generating the HTML document


### PR DESCRIPTION
Since the option was removed in #315.