### PR TITLE
 Support building multiple configurations from a single project with fork middleware

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
 const { Neutrino } = require('./packages/neutrino');
 
-module.exports = Neutrino().call('eslintrc');
+module.exports = Neutrino()
+  .use('.neutrinorc.js')
+  .call('eslintrc');

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
   * [env](./packages/env/README.md)
   * [eslint](./packages/eslint/README.md)
   * [font-loader](./packages/font-loader/README.md)
+  * [fork](./packages/fork/README.md)
   * [hot](./packages/hot/README.md)
   * [html-loader](./packages/html-loader/README.md)
   * [html-template](./packages/html-template/README.md)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -50,9 +50,8 @@ middleware and presets to load. These can be an npm package or a relative path t
 ❯ neutrino start --use @neutrinojs/react @neutrinojs/karma
 ```
 
-The Neutrino CLI will still attempt to load any presets and middleware defined in the project's `.neutrinorc.js` file.
-Middleware passed via the CLI `--use` will take precedence over middleware defined in `.neutrinorc.js`, meaning that
-options set by `.neutrinorc.js` middleware can have their values overridden by `--use` middleware.
+**The Neutrino CLI will not attempt to load any presets and middleware defined in the project's `.neutrinorc.js` file
+when passing middleware via `--use`.**
 
 ## `--inspect`
 
@@ -78,7 +77,7 @@ We can capture this inspection to a file, and capture the change by adding a pre
 ❯ neutrino start --inspect --use @neutrinojs/react @neutrinojs/jest override.js > b.config
 ```
 
-Using `git diff a.config b.config`, we get a pretty diff of the configuration change:
+Using `git diff --no-index a.config b.config`, we get a pretty diff of the configuration change:
 
 ```diff
 diff --git a/a.config b/b.config

--- a/docs/packages/fork/README.md
+++ b/docs/packages/fork/README.md
@@ -40,7 +40,7 @@ can be run simultaneously. Some typical use cases:
 - Generate multiple targets when building libraries
 
 _This middleware must be used in conjunction with a `.neutrinorc.js` file to inform Neutrino of which
-middleware should be split into another process. See the [customization docs](https://neutrino.js.org/customization/)
+middleware should be split into another process. See the [customization docs](../../customization/)
 for details on setting up a `.neutrinorc.js` file in your project if you do not already have one._
 
 ## Quickstart
@@ -118,7 +118,7 @@ each running in their own process. Quitting Neutrino will cause all forked proce
 
 ## Paths
 
-Most middleware attempt to follow the standard [Neutrino project layout](https://neutrino.js.org/project-layout)
+Most middleware attempt to follow the standard [Neutrino project layout](../../project-layout)
 to output their compiled output, but building multiple projects at once is bound to cause clashes with
 the directories each project uses. This could lead to:
 
@@ -162,7 +162,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](../../contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/fork.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/fork.svg

--- a/package.json
+++ b/package.json
@@ -53,10 +53,6 @@
     "*.js": [
       "yarn lint --fix",
       "git add"
-    ],
-    "packages/neutrino/bin/neutrino": [
-      "yarn lint --fix",
-      "git add"
     ]
   }
 }

--- a/packages/airbnb-base/eslintrc.js
+++ b/packages/airbnb-base/eslintrc.js
@@ -1,4 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-// eslint-disable-next-line global-require
-module.exports = Neutrino({ cwd: __dirname }).call('eslintrc', [require('.')]);
+module.exports = Neutrino({ cwd: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/airbnb-base/test/airbnb_test.js
+++ b/packages/airbnb-base/test/airbnb_test.js
@@ -41,5 +41,5 @@ test('exposes lint command', t => {
 });
 
 test('exposes eslintrc config', t => {
-  t.is(typeof Neutrino().call('eslintrc', [mw()]), 'object');
+  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
 });

--- a/packages/airbnb/eslintrc.js
+++ b/packages/airbnb/eslintrc.js
@@ -1,4 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-// eslint-disable-next-line global-require
-module.exports = Neutrino({ cwd: __dirname }).call('eslintrc', [require('.')]);
+module.exports = Neutrino({ cwd: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -41,5 +41,5 @@ test('exposes lint command', t => {
 });
 
 test('exposes eslintrc config', t => {
-  t.is(typeof Neutrino().call('eslintrc', [mw()]), 'object');
+  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
 });

--- a/packages/eslint/eslintrc.js
+++ b/packages/eslint/eslintrc.js
@@ -1,4 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-// eslint-disable-next-line global-require
-module.exports = Neutrino({ cwd: __dirname }).call('eslintrc', [require('.')]);
+module.exports = Neutrino({ cwd: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -41,5 +41,5 @@ test('exposes lint command', t => {
 });
 
 test('exposes eslintrc config', t => {
-  t.is(typeof Neutrino().call('eslintrc', [mw()]), 'object');
+  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
 });

--- a/packages/fork/README.md
+++ b/packages/fork/README.md
@@ -1,0 +1,143 @@
+# Neutrino Fork Middleware
+
+`@neutrinojs/fork` is Neutrino middleware for forking the usage of other middleware into separate processes.
+You can combine this with other middleware to configure and build multiple project types from a single project.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
+
+## Requirements
+
+- Node.js v6.10+
+- Yarn or npm client
+- Neutrino v7
+
+## Installation
+
+`@neutrinojs/fork` can be installed via the Yarn or npm clients. Inside your project, make sure you have
+`neutrino` installed and any other Neutrino middleware are development dependencies.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev @neutrinojs/fork
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev @neutrinojs/fork
+```
+
+## Details
+
+`@neutrinojs/fork` operates by defining which middleware you wish to split off into separate processes so they
+can be run simultaneously. Some typical use cases:
+
+- Building a web app and a Node.js app from the same project
+- Build multiple web apps or multiple Node.js apps from the same project
+- Generate multiple targets when building libraries
+
+_This middleware must be used in conjunction with a `.neutrinorc.js` file to inform Neutrino of which
+middleware should be split into another process. See the [customization docs](https://neutrino.js.org/customization/)
+for details on setting up a `.neutrinorc.js` file in your project if you do not already have one._
+
+## Quickstart
+
+After installing Neutrino, your other build middleware, and the fork middleware, open your `.neutrinorc.js` file.
+For this example, let's demonstrate building a React app and Node.js app from the same project using different source
+directories:
+
+```js
+module.exports = {
+  use: [
+    ['@neutrinojs/fork', {
+      configs: {
+        react: '@neutrinojs/react',
+        node: {
+          options: { source: 'server' },
+          use: ['@neutrinojs/node']
+        }
+      }
+    }]
+  ]
+};
+```
+
+Let's examine this `.neutrinorc.js` file and see what is happening:
+
+```js
+module.exports = {
+  // Tell Neutrino to use the following middleware defined
+  // in this array
+  use: [
+    // Use the fork middleware to build configuration
+    // into separate processes.
+    ['@neutrinojs/fork', {
+      // Each process will be defined in "configs".
+      // The key in "configs" will be used to identify
+      // the forked process. For simplicity, we named
+      // these "react" and "node". Therefore, these 2
+      // will spawn 2 separate processes, one for the
+      // "react" config, and one for the "node" config.
+      configs: {
+        // The key in "configs" maps to a middleware value.
+
+        // The "react" config uses "@neutrinojs/react" as
+        // middleware using the string format. By default,
+        // the "react" app's source lives in src/, and builds
+        // to build/
+        react: '@neutrinojs/react',
+
+        // The "node" config uses the object middleware
+        // format to configure Neutrino to build this
+        // project from a different directory than the
+        // "react" app, using server/ instead of src/, and
+        // builds to server-build/
+        node: {
+          options: { source: 'server', output: 'server-build' },
+          use: ['@neutrinojs/node']
+        }
+      }
+    }]
+  ]
+};
+```
+
+Upon starting or building your project, you will now see console messages labeled according to their config ID,
+each running in their own process. Quitting Neutrino will cause all forked processes to exit.
+
+```bash
+❯ yarn start
+[react] ✔ Development server running on: http://localhost:5000
+[node] Listening on :3000
+[node] ✔ Build completed
+[react] ✔ Build completed
+```
+
+## Paths
+
+Most middleware attempt to follow the standard [Neutrino project layout](https://neutrino.js.org/project-layout)
+to output their compiled output, but building multiple projects at once is bound to cause clashes with
+the directories each project uses. This could lead to:
+
+- One target cleaning the output of another target
+- One target replacing a file from the output of another target
+
+This has the potential to lead to difficult bugs. As such, it is recommended to change the source and output directory
+options to avoid this situation altogether, which the example above demonstrates. If you are certain you want from
+and to the same directories, such as when building libraries, ensure you follow any project cleanup instructions
+outlined by your middleware.
+
+## Contributing
+
+This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
+containing all resources for developing Neutrino and its core presets and middleware. Follow the
+[contributing guide](https://neutrino.js.org/contributing) for details.
+
+[npm-image]: https://img.shields.io/npm/v/@neutrinojs/fork.svg
+[npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/fork.svg
+[npm-url]: https://npmjs.org/package/@neutrinojs/fork
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/fork/index.js
+++ b/packages/fork/index.js
@@ -1,0 +1,44 @@
+const { gray } = require('chalk');
+const { fork } = require('child_process');
+const { join } = require('path');
+const { createInterface } = require('readline');
+
+module.exports = (neutrino, opts = {}) => {
+  const options = Object.assign({}, opts, {});
+  const registeredCommand = neutrino.commands[neutrino.options.command];
+
+  global.interactive = false;
+
+  neutrino.register(neutrino.options.command, (config, neutrino) =>
+    // The fork middleware was the only middleware used by Neutrino prior
+    // to running anything. We need to now prevent the default actions from
+    // doing anything else.
+    (Object.keys(config).length !== 0 ?
+      registeredCommand(config, neutrino) :
+      Promise.resolve()));
+
+  neutrino.on('prerun', () => {
+    const children = Object
+      .keys(options.configs)
+      .map((namespace) => {
+        const middleware = options.configs[namespace];
+        const script = join(__dirname, './neutrino-child');
+        const child = fork(script, [], { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] });
+        const stdout = createInterface({ input: child.stdout });
+        const stderr = createInterface({ input: child.stderr });
+
+        child.on('message', ([type, args]) => {
+          neutrino.emit(`${namespace}:${type}`, ...args);
+        });
+        stdout.on('line', message => console.log(gray(`[${namespace}]`), message));
+        stderr.on('line', message => console.error(gray(`[${namespace}]`), message));
+        child.send([middleware, neutrino.options.args]);
+
+        return child;
+      });
+
+    process.on('exit', () => {
+      children.forEach(child => child.kill('SIGINT'));
+    });
+  });
+};

--- a/packages/fork/neutrino-child.js
+++ b/packages/fork/neutrino-child.js
@@ -1,0 +1,48 @@
+const {
+  cond, equals, identity, is, objOf, of, pipe, T
+} = require('ramda');
+const build = require('neutrino/bin/build');
+const execute = require('neutrino/bin/execute');
+const inspect = require('neutrino/bin/inspect');
+const start = require('neutrino/bin/start');
+const test = require('neutrino/bin/test');
+
+const timeout = setTimeout(Function.prototype, 10000);
+const normalizeMiddleware = cond([
+  [is(Object), identity],
+  [T, pipe(of, objOf('use'))]
+]);
+const runnable = (command, middleware, args) => cond([
+  [equals('build'), () => build(middleware, args)],
+  [equals('start'), () => start(middleware, args)],
+  [equals('test'), () => test(middleware, args)],
+  [equals('inspect'), () => inspect(middleware, args)],
+  [T, () => execute(middleware, args)]
+])(command);
+
+process.on('message', ([rawMiddleware, args]) => {
+  process.on('unhandledRejection', (err) => {
+    if (!args.quiet) {
+      console.error('');
+      console.error(err);
+    }
+
+    process.exit(1);
+  });
+
+  clearTimeout(timeout);
+
+  const middleware = normalizeMiddleware(rawMiddleware);
+  const command = args.inspect ? 'inspect' : args._[0];
+
+  // Merge CLI config options as last piece of middleware, e.g. options.config.devServer.port 4000
+  if (args.options) {
+    middleware.use.push(({ config }) => config.merge(args.options.config));
+  }
+
+  const api = runnable(command, middleware, args);
+
+  api.on('*', (type, ...args) => {
+    process.send([type, args]);
+  });
+});

--- a/packages/fork/package.json
+++ b/packages/fork/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@neutrinojs/fork",
+  "version": "7.3.1",
+  "description": "Neutrino middleware for forking the usage of other middleware into separate processes",
+  "main": "index.js",
+  "keywords": [
+    "neutrino",
+    "neutrino-middleware",
+    "fork",
+    "spawn",
+    "process",
+    "multiple",
+    "config"
+  ],
+  "author": "Eli Perelman <eli@eliperelman.com>",
+  "license": "MPL-2.0",
+  "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/fork",
+  "homepage": "https://neutrino.js.org",
+  "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
+  "dependencies": {
+    "chalk": "^2.3.0",
+    "ramda": "^0.25.0"
+  },
+  "peerDependencies": {
+    "neutrino": "^7.0.0"
+  }
+}

--- a/packages/neutrino/bin/base.js
+++ b/packages/neutrino/bin/base.js
@@ -20,10 +20,10 @@ module.exports = ({
   }, args.options);
   const api = Neutrino(options);
 
-  api.register(commandName, commandHandler);
-
-  return api
-    .run(commandName, middleware)
+  api
+    .register(commandName, commandHandler)
+    .use(middleware)
+    .run(commandName)
     .fork(
       (errs) => {
         const errors = Array.isArray(errs) ? errs : [errs];
@@ -55,4 +55,6 @@ module.exports = ({
       },
       successHandler
     );
+
+  return api;
 };

--- a/packages/neutrino/bin/build.js
+++ b/packages/neutrino/bin/build.js
@@ -4,21 +4,33 @@ const { build } = require('../src');
 const base = require('./base');
 
 module.exports = (middleware, args) => {
-  const spinner = args.quiet ? null : ora('Building project').start();
+  const spinner = ora({ text: 'Building project' });
 
   return base({
     middleware,
     args,
     NODE_ENV: 'production',
-    commandHandler: build,
+    commandHandler: (config, neutrino) => {
+      if (!args.quiet) {
+        spinner.enabled = global.interactive;
+        spinner.start();
+      }
+
+      return build(config, neutrino);
+    },
     errorsHandler() {
       if (!args.quiet) {
         spinner.fail('Building project failed');
       }
     },
     successHandler(stats) {
-      if (!args.quiet) {
-        spinner.succeed('Building project completed');
+      if (args.quiet) {
+        return;
+      }
+
+      spinner.succeed('Building project completed');
+
+      if (stats) {
         console.log(stats.toString(merge({
           modules: false,
           colors: true,

--- a/packages/neutrino/bin/execute.js
+++ b/packages/neutrino/bin/execute.js
@@ -3,21 +3,26 @@ const base = require('./base');
 
 module.exports = (middleware, args) => {
   const commandName = args._[0];
-  const spinner = args.quiet ? null : ora(`Running ${commandName}`).start();
+  const spinner = ora({ text: `Running ${commandName}` });
 
   return base({
     middleware,
     args,
     NODE_ENV: 'production',
     commandName: `${commandName}-cli`,
-    commandHandler(config, api) {
-      const command = api.commands[commandName];
+    commandHandler(config, neutrino) {
+      if (!args.quiet) {
+        spinner.enabled = global.interactive;
+        spinner.start();
+      }
+
+      const command = neutrino.commands[commandName];
 
       if (!command) {
         throw new Error(`A command with the name "${commandName}" was not registered`);
       }
 
-      return command(config, api);
+      return command(config, neutrino);
     },
     errorsHandler() {
       if (!args.quiet) {

--- a/packages/neutrino/bin/inspect.js
+++ b/packages/neutrino/bin/inspect.js
@@ -15,7 +15,7 @@ module.exports = (middleware, args) => base({
   commandHandler: inspect,
   commandName: 'inspect',
   successHandler(output) {
-    if (!args.quiet) {
+    if (!args.quiet && output) {
       console.log(output);
     }
   }

--- a/packages/neutrino/bin/neutrino.js
+++ b/packages/neutrino/bin/neutrino.js
@@ -52,6 +52,12 @@ const args = yargs
     default: [],
     global: true
   })
+  .option('--no-tty', {
+    description: 'Disable text terminal interactions',
+    boolean: true,
+    default: false,
+    global: true
+  })
   .command('start', 'Build a project in development mode')
   .command('build', 'Compile the source directory to a bundled build')
   .command('test [files..]', 'Run all suites from the test directory or provided files', {
@@ -69,6 +75,8 @@ const args = yargs
   .command('*')
   .recommendCommands()
   .argv;
+
+global.interactive = !args.noTty && (process.stderr && process.stderr.isTTY) && !process.env.CI;
 
 const command = args._[0];
 

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -4,7 +4,7 @@
   "description": "Create and build JS applications with managed configurations",
   "main": "src/index.js",
   "bin": {
-    "neutrino": "./bin/neutrino"
+    "neutrino": "./bin/neutrino.js"
   },
   "keywords": [
     "neutrino",

--- a/packages/neutrino/test/api_test.js
+++ b/packages/neutrino/test/api_test.js
@@ -199,21 +199,22 @@ test('creates a Webpack config', t => {
 test('throws when trying to call() a non-registered command', t => {
   const api = Neutrino();
 
-  const err = t.throws(() => api.call('non-registered', []));
+  const err = t.throws(() => api.call('non-registered'));
 
   t.true(err.message.includes('was not registered'));
 });
 
 test('fails when trying to run() a non-registered command', async t => {
-  await t.throws(Neutrino().run('non-registered', []).promise());
+  await t.throws(Neutrino().run('non-registered').promise());
 });
 
 test('throws when trying to validate config with no entry point', async t => {
   const api = Neutrino();
 
   api.register('build', build);
+  const result = api.run('build').promise();
 
-  const errors = await t.throws(api.run('build', []).promise());
+  const [err] = await t.throws(result);
 
-  t.true(errors[0].message.includes(`configuration misses the property 'entry'`));
+  t.true(err.message.includes(`configuration misses the property 'entry'`));
 });

--- a/packages/standardjs/eslintrc.js
+++ b/packages/standardjs/eslintrc.js
@@ -1,4 +1,5 @@
 const { Neutrino } = require('../neutrino');
 
-// eslint-disable-next-line global-require
-module.exports = Neutrino({ cwd: __dirname }).call('eslintrc', [require('.')]);
+module.exports = Neutrino({ cwd: __dirname })
+  .use(require('.')) // eslint-disable-line global-require
+  .call('eslintrc');

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -41,5 +41,5 @@ test('exposes lint command', t => {
 });
 
 test('exposes eslintrc config', t => {
-  t.is(typeof Neutrino().call('eslintrc', [mw()]), 'object');
+  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
 });


### PR DESCRIPTION
Addresses #308.

This middleware, along with the associated Neutrino changes, allows forking off the usage of other middleware into multiple processes, allowing simultaneous builds of different target types, and also building multiple library targets from a single build step.