### PR TITLE
Set name defaults for file/url-loader

### DIFF
--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,28 +1,32 @@
 const merge = require('deepmerge');
 
-module.exports = ({ config }, options = {}) => {
-  const { limit } = merge({ limit: '10000' }, options);
+module.exports = (neutrino, options = {}) => {
+  const isBuild = neutrino.options.command === 'build';
   const urlLoader = require.resolve('url-loader');
   const fileLoader = require.resolve('file-loader');
+  const { limit, name } = merge({
+    limit: 10000,
+    name: isBuild ? '[name].[hash].[ext]' : '[name].[ext]'
+  }, options);
 
-  config.module
+  neutrino.config.module
     .rule('woff')
     .test(/\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit, mimetype: 'application/font-woff' }, options.woff || {}));
+      .options(merge({ limit, name, mimetype: 'application/font-woff' }, options.woff || {}));
 
-  config.module
+  neutrino.config.module
     .rule('ttf')
     .test(/\.ttf(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit, mimetype: 'application/octet-stream' }, options.ttf || {}));
+      .options(merge({ limit, name, mimetype: 'application/octet-stream' }, options.ttf || {}));
 
-  config.module
+  neutrino.config.module
     .rule('eot')
     .test(/\.eot(\?v=\d+\.\d+\.\d+)?$/)
     .use('file')
       .loader(fileLoader)
-      .when(options.eot, use => use.options(options.eot));
+      .options(merge({ name }, options.eot || {}));
 };

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -13,19 +13,19 @@ module.exports = (neutrino, options = {}) => {
     .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit, name }, options.svg));
+      .options(merge({ limit, name }, options.svg || {}));
 
   neutrino.config.module
     .rule('img')
     .test(/\.(png|jpg|jpeg|gif)(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit, name }, options.img));
+      .options(merge({ limit, name }, options.img || {}));
 
   neutrino.config.module
     .rule('ico')
     .test(/\.ico(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit, name }, options.ico));
+      .options(merge({ limit, name }, options.ico || {}));
 };

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -1,27 +1,31 @@
 const merge = require('deepmerge');
 
-module.exports = ({ config }, options = {}) => {
-  const { limit } = merge({ limit: 8192 }, options);
+module.exports = (neutrino, options = {}) => {
+  const isBuild = neutrino.options.command === 'build';
   const urlLoader = require.resolve('url-loader');
+  const { limit, name } = merge({
+    limit: 8192,
+    name: isBuild ? '[name].[hash].[ext]' : '[name].[ext]'
+  }, options);
 
-  config.module
+  neutrino.config.module
     .rule('svg')
     .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit }, options.svg || {}));
+      .options(merge({ limit, name }, options.svg));
 
-  config.module
+  neutrino.config.module
     .rule('img')
     .test(/\.(png|jpg|jpeg|gif)(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit }, options.img || {}));
+      .options(merge({ limit, name }, options.img));
 
-  config.module
+  neutrino.config.module
     .rule('ico')
     .test(/\.ico(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(urlLoader)
-      .options(merge({ limit }, options.ico || {}));
+      .options(merge({ limit, name }, options.ico));
 };


### PR DESCRIPTION
This provides predictable paths for when using dev-server.
This makes for easier use in a server-side context, and makes things more consistent with how js is named and rev'd.