### PR TITLE
web/node: Easier targeting via options.targets

### DIFF
--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -240,14 +240,16 @@ module.exports = {
       // Add additional Babel plugins, presets, or env options
       babel: {
         // Override options for babel-preset-env, showing defaults:
-        presetEnv: {
-          targets: { node: '6.10' },
-          modules: false,
-          useBuiltIns: true,
-          // These are excluded when using polyfills.async. Disabling the async polyfill
-          // will remove these from the exclusion list
-          exclude: ['transform-regenerator', 'transform-async-to-generator']
-        }
+        presets: [
+          ['babel-preset-env', {
+            targets: { node: '6.10' },
+            modules: false,
+            useBuiltIns: true,
+            // These are excluded when using polyfills.async. Disabling the async polyfill
+            // will remove these from the exclusion list
+            exclude: ['transform-regenerator', 'transform-async-to-generator']
+          }]
+        ]
       }
     }]
   ]

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -232,18 +232,21 @@ module.exports = {
         async: true
       },
 
+      // Target specific versions via babel-preset-env
+      targets: {
+        node: '6.10'
+      }
+
       // Add additional Babel plugins, presets, or env options
       babel: {
         // Override options for babel-preset-env, showing defaults:
         presetEnv: {
-          targets: {
-            node: '6.10',
-            modules: false,
-            useBuiltIns: true,
-            // These are excluded when using polyfills.async. Disabling the async polyfill
-            // will remove these from the exclusion list
-            exclude: ['transform-regenerator', 'transform-async-to-generator']
-          }
+          targets: { node: '6.10' },
+          modules: false,
+          useBuiltIns: true,
+          // These are excluded when using polyfills.async. Disabling the async polyfill
+          // will remove these from the exclusion list
+          exclude: ['transform-regenerator', 'transform-async-to-generator']
         }
       }
     }]

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -173,19 +173,22 @@ module.exports = {
         hot: options.hot
       },
 
+      // Target specific browsers with babel-preset-env
+      targets: {
+        browsers: [
+          'last 1 Chrome versions',
+          'last 1 Firefox versions'
+        ]
+      }
+
       // Add additional Babel plugins, presets, or env options
       babel: {
-        // Override options for babel-preset-env
+        // Override options for babel-preset-env:
         presets: [
           ['babel-preset-env', {
-            // Passing in targets to babel-preset-env will replace them
-            // instead of merging them
-            targets: {
-              browsers: [
-                'last 1 Chrome versions',
-                'last 1 Firefox versions'
-              ]
-            }
+            modules: false,
+            useBuiltIns: true,
+            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -240,14 +240,16 @@ module.exports = {
       // Add additional Babel plugins, presets, or env options
       babel: {
         // Override options for babel-preset-env, showing defaults:
-        presetEnv: {
-          targets: { node: '6.10' },
-          modules: false,
-          useBuiltIns: true,
-          // These are excluded when using polyfills.async. Disabling the async polyfill
-          // will remove these from the exclusion list
-          exclude: ['transform-regenerator', 'transform-async-to-generator']
-        }
+        presets: [
+          ['babel-preset-env', {
+            targets: { node: '6.10' },
+            modules: false,
+            useBuiltIns: true,
+            // These are excluded when using polyfills.async. Disabling the async polyfill
+            // will remove these from the exclusion list
+            exclude: ['transform-regenerator', 'transform-async-to-generator']
+          }]
+        ]
       }
     }]
   ]

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -232,18 +232,21 @@ module.exports = {
         async: true
       },
 
+      // Target specific versions via babel-preset-env
+      targets: {
+        node: '6.10'
+      }
+
       // Add additional Babel plugins, presets, or env options
       babel: {
         // Override options for babel-preset-env, showing defaults:
         presetEnv: {
-          targets: {
-            node: '6.10',
-            modules: false,
-            useBuiltIns: true,
-            // These are excluded when using polyfills.async. Disabling the async polyfill
-            // will remove these from the exclusion list
-            exclude: ['transform-regenerator', 'transform-async-to-generator']
-          }
+          targets: { node: '6.10' },
+          modules: false,
+          useBuiltIns: true,
+          // These are excluded when using polyfills.async. Disabling the async polyfill
+          // will remove these from the exclusion list
+          exclude: ['transform-regenerator', 'transform-async-to-generator']
         }
       }
     }]

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -42,6 +42,9 @@ module.exports = (neutrino, opts = {}) => {
     hot: true,
     polyfills: {
       async: true
+    },
+    targets: {
+      node: '6.10'
     }
   }, opts);
 
@@ -56,7 +59,7 @@ module.exports = (neutrino, opts = {}) => {
       presets: [
         [require.resolve('babel-preset-env'), {
           debug: neutrino.options.debug,
-          targets: { node: '6.10' },
+          targets: options.targets,
           modules: false,
           useBuiltIns: true,
           exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : []

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -173,19 +173,22 @@ module.exports = {
         hot: options.hot
       },
 
+      // Target specific browsers with babel-preset-env
+      targets: {
+        browsers: [
+          'last 1 Chrome versions',
+          'last 1 Firefox versions'
+        ]
+      }
+
       // Add additional Babel plugins, presets, or env options
       babel: {
-        // Override options for babel-preset-env
+        // Override options for babel-preset-env:
         presets: [
           ['babel-preset-env', {
-            // Passing in targets to babel-preset-env will replace them
-            // instead of merging them
-            targets: {
-              browsers: [
-                'last 1 Chrome versions',
-                'last 1 Firefox versions'
-              ]
-            }
+            modules: false,
+            useBuiltIns: true,
+            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -31,14 +31,16 @@ module.exports = (neutrino, opts = {}) => {
       async: true
     },
     babel: {},
-    browsers: [
-      'last 2 Chrome versions',
-      'last 2 Firefox versions',
-      'last 2 Edge versions',
-      'last 2 Opera versions',
-      'last 2 Safari versions',
-      'last 2 iOS versions'
-    ]
+    targets: {
+      browsers: [
+        'last 2 Chrome versions',
+        'last 2 Firefox versions',
+        'last 2 Edge versions',
+        'last 2 Opera versions',
+        'last 2 Safari versions',
+        'last 2 iOS versions'
+      ]
+    }
   }, opts);
 
   Object.assign(options, {
@@ -53,9 +55,7 @@ module.exports = (neutrino, opts = {}) => {
           modules: false,
           useBuiltIns: true,
           exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : [],
-          targets: {
-            browsers: options.browsers
-          }
+          targets: options.targets
         }]
       ]
     }, options.babel)

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -30,7 +30,15 @@ module.exports = (neutrino, opts = {}) => {
     polyfills: {
       async: true
     },
-    babel: {}
+    babel: {},
+    browsers: [
+      'last 2 Chrome versions',
+      'last 2 Firefox versions',
+      'last 2 Edge versions',
+      'last 2 Opera versions',
+      'last 2 Safari versions',
+      'last 2 iOS versions'
+    ]
   }, opts);
 
   Object.assign(options, {
@@ -46,7 +54,7 @@ module.exports = (neutrino, opts = {}) => {
           useBuiltIns: true,
           exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : [],
           targets: {
-            browsers: []
+            browsers: options.browsers
           }
         }]
       ]
@@ -54,18 +62,6 @@ module.exports = (neutrino, opts = {}) => {
   });
 
   const staticDir = join(neutrino.options.source, 'static');
-  const presetEnvOptions = options.babel.presets[0][1];
-
-  if (!presetEnvOptions.targets.browsers.length) {
-    presetEnvOptions.targets.browsers.push(
-      'last 2 Chrome versions',
-      'last 2 Firefox versions',
-      'last 2 Edge versions',
-      'last 2 Opera versions',
-      'last 2 Safari versions',
-      'last 2 iOS versions'
-    );
-  }
 
   neutrino.use(env, options.env);
   neutrino.use(htmlLoader);


### PR DESCRIPTION
It is currently rather verbose to override the `targets.browsers` option for `babel-preset-env`, and it requires you to overwrite the whole options object rather than just specifying browsers: https://neutrino.js.org/presets/neutrino-preset-web/#preset-options

This PR adds `options.browsers` to be able to specify directly.

Furthermore, when babel-preset-env@7.0 is released (currently at beta.32), this will make it easier for users that want to use a browserslist config file, as the new version of babel-preset-env will look for those automatically. In that case, we can support passing `false` or `undefined` to have babel-preset-env/browserslist do its thing.