### PR TITLE
Web: Remove console, debugger in production

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -30,7 +30,13 @@ module.exports = (neutrino, opts = {}) => {
     polyfills: {
       async: true
     },
-    babel: {}
+    babel: {},
+    minify: {
+      minify: {
+        removeConsole: true,
+        removeDebugger: true
+      }
+    }
   }, opts);
 
   Object.assign(options, {
@@ -138,7 +144,7 @@ module.exports = (neutrino, opts = {}) => {
     })
     .when(process.env.NODE_ENV === 'production', () => {
       neutrino.use(chunk);
-      neutrino.use(minify);
+      neutrino.use(minify, options.minify);
       neutrino.config.plugin('module-concat')
         .use(optimize.ModuleConcatenationPlugin);
     })


### PR DESCRIPTION
Since we only use minify in production, removing console and debugger seems like good defaults in a web context.