### PR TITLE
Support extract-text for styles via options.extract

### DIFF
--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -2,13 +2,12 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
-  const isBuild = neutrino.options.command === 'start';
   const options = merge({
     styleUseId: 'style',
     hot: true,
     extract: {
       plugin: {
-        filename: isBuild ? '[name].css' : '[name].[contenthash].css'
+        filename: neutrino.options.command === 'build' ? '[name].[contenthash].css' : '[name].css'
       }
     }
   }, opts);

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -1,10 +1,66 @@
-module.exports = ({ config }, options = {}) => config.module
-  .rule(options.ruleId || 'style')
-    .test(/\.css$/)
-      .use(options.styleUseId || 'style')
-        .loader(require.resolve('style-loader'))
-        .when(options.style, use => use.options(options.style))
-        .end()
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const merge = require('deepmerge');
+
+module.exports = (neutrino, opts = {}) => {
+  const isBuild = neutrino.options.command === 'start';
+  const options = merge({
+    styleUseId: 'style',
+    hot: true,
+    extract: {
+      plugin: {
+        filename: isBuild ? '[name].css' : '[name].[contenthash].css'
+      }
+    }
+  }, opts);
+
+  neutrino.config.module
+    .rule(options.ruleId || 'style')
+      .test(/\.css$/)
+      .use(options.styleUseId)
+         .loader(require.resolve('style-loader'))
+         .when(options.style, use => use.options(options.style))
+         .end()
       .use(options.cssUseId || 'css')
         .loader(require.resolve('css-loader'))
         .when(options.css, use => use.options(options.css));
+
+  if (options.extract) {
+    const styleRule = neutrino.config.module.rule('style');
+    const styleEntries = styleRule.uses.entries();
+    const useKeys = Object.keys(styleEntries).filter(key => key !== options.styleUseId);
+
+    options.extract.loader = Object.assign({
+      use: useKeys.map(key => ({
+        loader: styleEntries[key].get('loader'),
+        options: styleEntries[key].get('options')
+      })),
+      fallback: {
+        loader: styleEntries[options.styleUseId].get('loader'),
+        options: styleEntries[options.styleUseId].get('options')
+      }
+    }, options.extract.loader || {});
+
+    styleRule
+      .uses
+        .clear()
+        .end()
+      .when(options.hot, (rule) => {
+        rule.use(options.hotUseId || 'hot')
+          .loader(require.resolve('css-hot-loader'))
+          .when(options.hot !== true, use => use.options(options.hot));
+      });
+
+    ExtractTextPlugin
+      .extract(options.extract.loader)
+      .forEach(({ loader, options }) => {
+        styleRule
+          .use(loader)
+            .loader(loader)
+            .options(options);
+      });
+
+    neutrino.config
+      .plugin('extract')
+        .use(ExtractTextPlugin, [options.extract.plugin]);
+  }
+};

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -16,7 +16,10 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
+    "css-hot-loader": "^1.3.3",
     "css-loader": "^0.28.7",
+    "deepmerge": "^2.0.1",
+    "extract-text-webpack-plugin": "^3.0.2",
     "style-loader": "^0.18.2"
   },
   "peerDependencies": {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -24,6 +24,9 @@ module.exports = (neutrino, opts = {}) => {
     env: [],
     hot: true,
     html: {},
+    style: {
+      hot: opts.hot !== false
+    },
     devServer: {
       hot: opts.hot !== false
     },
@@ -69,7 +72,7 @@ module.exports = (neutrino, opts = {}) => {
 
   neutrino.use(env, options.env);
   neutrino.use(htmlLoader);
-  neutrino.use(styleLoader);
+  neutrino.use(styleLoader, options.style);
   neutrino.use(fontLoader);
   neutrino.use(imageLoader);
   neutrino.use(htmlTemplate, options.html);


### PR DESCRIPTION
Notes:

- This extracts _by default_, so if you don't want to, you need to pass `options.extract = false`
- Currently, other style rule loaders (e.g. https://github.com/barraponto/neutrino-middleware-postcss) would need to come _before_ this one for the extraction to work.