### PR TITLE
Ignore gitbook-plugin-github from automatic renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   "reviewers": [
     "mozilla-neutrino/core-contributors"
   ],
-  "pinVersions": false
+  "pinVersions": false,
+  "excludedPackageNames": [
+    "gitbook-plugin-github"
+  ]
 }


### PR DESCRIPTION
We don't update this version because it's incompatible with the plugins I wrote for it. (I think).