### PR TITLE
Revert "Add optimize option, use in web, node."

### DIFF
--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -40,8 +40,6 @@ const getOptions = (opts = {}) => {
     .keys(options.env)
     .forEach(env => process.env[env] = options.env[env]);
 
-  options.optimize = defaultTo(options.env.NODE_ENV === 'production', options.optimize);
-
   pathOptions.forEach(([path, defaultValue, getNormalizeBase]) => {
     let value = defaultTo(defaultValue, options[path]);
 

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -120,7 +120,7 @@ module.exports = (neutrino, opts = {}) => {
       config.devtool('inline-sourcemap');
       config.output.devtoolModuleFilenameTemplate('[absolute-resource-path]');
     })
-    .when(neutrino.options.optimize, (config) => {
+    .when(neutrino.options.env.NODE_ENV === 'production', (config) => {
       config.plugin('module-concat').use(optimize.ModuleConcatenationPlugin);
     })
     .when(neutrino.options.command === 'build', () => {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -135,7 +135,7 @@ module.exports = (neutrino, opts = {}) => {
       neutrino.use(devServer, options.devServer);
       config.when(options.hot, () => neutrino.use(hot));
     })
-    .when(neutrino.options.optimize, () => {
+    .when(process.env.NODE_ENV === 'production', () => {
       neutrino.use(chunk);
       neutrino.use(minify);
       neutrino.config.plugin('module-concat')


### PR DESCRIPTION
Reverts mozilla-neutrino/neutrino-dev#460

I hadn't thought of what happens when you use this option with the raw middleware like minify from outside a preset where this isn't guarded by the `optimize` option. Backing out until we can discuss.