### PR TITLE
Add font, image options.

### DIFF
--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -160,6 +160,29 @@ module.exports = {
         async: true
       },
 
+      // Sets Webpack's `output.publicPath` and
+      // `devServer.publicPath` settings. Useful if you want to
+      // serve assets from a non-root location (e.g. `/assets/`)
+      publicPath: './',
+
+      // Change options for @neutrinojs/style-loader
+      style: {
+        // Disabling options.hot will also disable style.hot
+        hot: true
+      },
+
+      // Change options for @neutrinojs/font-loader
+      font: {},
+
+      // Change options for @neutrinojs/image-loader
+      image: {},
+
+      // Change options for @neutrinojs/minify
+      minify: {},
+
+      // Change options for `webpack-manifest-plugin`
+      manifest: {},
+
       // Change options related to generating the HTML document
       // See @neutrinojs/html-template for the defaults
       // used by the Web preset
@@ -207,6 +230,20 @@ module.exports = {
 
       // Example: disable Hot Module Replacement
       hot: false,
+
+      // Example: disable image-loader, style-loader, font-loader,
+      // font-loader, webpack-manifest-plugin
+      image: false,
+      style: false,
+      font: false,
+      image: false,
+      manifest: false,
+
+      // Example: Remove console and debugger from output
+      minify: {
+        removeConsole: true,
+        removeDebugger: true,
+      },
 
       // Example: change the page title
       html: {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -159,6 +159,29 @@ module.exports = {
         async: true
       },
 
+      // Sets Webpack's `output.publicPath` and
+      // `devServer.publicPath` settings. Useful if you want to
+      // serve assets from a non-root location (e.g. `/assets/`)
+      publicPath: './',
+
+      // Change options for @neutrinojs/style-loader
+      style: {
+        // Disabling options.hot will also disable style.hot
+        hot: true
+      },
+
+      // Change options for @neutrinojs/font-loader
+      font: {},
+
+      // Change options for @neutrinojs/image-loader
+      image: {},
+
+      // Change options for @neutrinojs/minify
+      minify: {},
+
+      // Change options for `webpack-manifest-plugin`
+      manifest: {},
+
       // Change options related to generating the HTML document
       // See @neutrinojs/html-template for the defaults
       // used by the Web preset
@@ -206,6 +229,20 @@ module.exports = {
 
       // Example: disable Hot Module Replacement
       hot: false,
+
+      // Example: disable image-loader, style-loader, font-loader,
+      // font-loader, webpack-manifest-plugin
+      image: false,
+      style: false,
+      font: false,
+      image: false,
+      manifest: false,
+
+      // Example: Remove console and debugger from output
+      minify: {
+        removeConsole: true,
+        removeDebugger: true,
+      },
 
       // Example: change the page title
       html: {
@@ -298,6 +335,7 @@ _Note: Some plugins are only available in certain environments. To override them
 | `clean` | Removes the `build` directory prior to building. From `@neutrinojs/clean`. | `build` command |
 | `minify` | Minifies source code using `BabiliWebpackPlugin`. From `@neutrinojs/minify`. | `NODE_ENV production` |
 | `module-concat` | Concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser. | `NODE_ENV production` |
+| `manifest` | Create a manifest file, via webpack-manifest-plugin. | `build` command |
 
 ### Override configuration
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -39,7 +39,9 @@ module.exports = (neutrino, opts = {}) => {
     minify: {},
     manifest: {},
     babel: {},
-    targets: {}
+    targets: {},
+    font: {},
+    image: {}
   }, opts);
 
   if (typeof options.devServer.proxy === 'string') {
@@ -89,9 +91,19 @@ module.exports = (neutrino, opts = {}) => {
 
   neutrino.use(env, options.env);
   neutrino.use(htmlLoader);
-  neutrino.use(styleLoader, options.style);
-  neutrino.use(fontLoader);
-  neutrino.use(imageLoader);
+
+  if (options.style) {
+    neutrino.use(styleLoader, options.style);
+  }
+
+  if (options.font) {
+    neutrino.use(fontLoader, options.font);
+  }
+
+  if (options.image) {
+    neutrino.use(imageLoader, options.image);
+  }
+
   neutrino.use(compileLoader, {
     include: [
       neutrino.options.source,


### PR DESCRIPTION
Adds a couple more options, allows exclusion with `false`.

Related: what do you think about grouping these under `options.loaders`?

```
  const options = merge({
    env: [],
    hot: true,
    html: {},
    publicPath: './',
    devServer: {
      hot: opts.hot !== false
    },
    polyfills: {
      async: true
    },
    minify: {},
    manifest: {},
    babel: {},
    targets: {},
    loaders: {
      html: {},
      font: {},
      image: {},
      style: {
        hot: opts.hot !== false
      }
    }
  }, opts);
```

Might not be necessary, but could clear up confusion (e.g. `options.html` vs `options.loaders.html`)