### PR TITLE
Roll back deepmerge due to breakage in plugin argument merging

### DIFF
--- a/packages/airbnb-base/package.json
+++ b/packages/airbnb-base/package.json
@@ -16,7 +16,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "@neutrinojs/eslint": "^7.3.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-config-airbnb-base": "^12.0.1",
     "eslint-plugin-import": "^2.7.0"
   },

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -16,7 +16,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "@neutrinojs/eslint": "^7.3.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2"

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "webpack": "^3.6.0"
   },
   "peerDependencies": {

--- a/packages/clean/package.json
+++ b/packages/clean/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "clean-webpack-plugin": "^0.1.17",
-    "deepmerge": "^2.0.0"
+    "deepmerge": "^1.5.2"
   },
   "peerDependencies": {
     "neutrino": "^7.0.0"

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -18,7 +18,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-merge": "^1.1.0",
-    "deepmerge": "^2.0.0"
+    "deepmerge": "^1.5.2"
   },
   "devDependencies": {
     "webpack": "^3.6.0"

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -16,7 +16,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "copy-webpack-plugin": "^4.2.1",
-    "deepmerge": "^2.0.0"
+    "deepmerge": "^1.5.2"
   },
   "peerDependencies": {
     "neutrino": "^7.0.0"

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "chalk": "^2.3.0",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "fs-extra": "^4.0.2",
     "javascript-stringify": "^1.6.0",
     "yargs": "^10.0.3",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "opn": "^5.1.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.4"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -16,7 +16,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "babel-eslint": "^8.0.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint": "^4.11.0",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-babel": "^4.1.2",

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "file-loader": "^1.0.0",
     "url-loader": "^0.6.0"
   },

--- a/packages/html-loader/package.json
+++ b/packages/html-loader/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "html-loader": "^0.5.1"
   },
   "peerDependencies": {

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "html-webpack-plugin": "^2.30.1",
     "html-webpack-template": "^6.1.0"
   },

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "file-loader": "^1.0.0",
     "url-loader": "^0.6.0"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -18,7 +18,7 @@
     "babel-core": "^6.26.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-jest": "^21.0.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-plugin-jest": "^21.3.2",
     "jest-cli": "^21.0.2",
     "ramda": "^0.25.0",

--- a/packages/karma/package.json
+++ b/packages/karma/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@neutrinojs/loader-merge": "^7.3.2",
     "babel-plugin-istanbul": "^4.1.5",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -29,7 +29,7 @@
     "@neutrinojs/minify": "^7.3.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.0",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "fast-async": "^6.3.0",
     "webpack": "^3.6.0",
     "webpack-node-externals": "^1.6.0",

--- a/packages/loader-merge/package.json
+++ b/packages/loader-merge/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0"
+    "deepmerge": "^1.5.2"
   },
   "peerDependencies": {
     "neutrino": "^7.0.0"

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -16,7 +16,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-register": "^6.26.0",
     "change-case": "^3.0.1",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "mocha": "^4.0.0",
     "ramda": "^0.25.0"
   },

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "deep-sort-object": "^1.0.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "fluture": "^7.2.2",
     "immutable": "^3.8.1",
     "immutable-ext": "^1.1.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,7 +23,7 @@
     "@neutrinojs/start-server": "^7.3.2",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-preset-env": "^1.6.0",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "fast-async": "^6.3.0",
     "ramda": "^0.25.0",
     "webpack": "^3.6.0",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "deepmerge": "^2.0.1"
+    "deepmerge": "^1.5.2"
   },
   "peerDependencies": {
     "neutrino": "^7.0.0"

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "offline-plugin": "^4.8.4"
   },
   "peerDependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -21,7 +21,7 @@
     "@blueprintjs/core": "^1.31.0",
     "@neutrinojs/banner": "^7.1.1",
     "@neutrinojs/react": "^7.1.1",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "normalize.css": "^7.0.0",
     "prop-types": "^15.6.0",
     "webpack-node-externals": "^1.6.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-react": "^6.24.0",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-plugin-react": "^7.5.1",
     "react-hot-loader": "^3.1.3"
   },

--- a/packages/standardjs/package.json
+++ b/packages/standardjs/package.json
@@ -17,7 +17,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
     "@neutrinojs/eslint": "^7.3.2",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "css-hot-loader": "^1.3.3",
     "css-loader": "^0.28.7",
-    "deepmerge": "^2.0.1",
+    "deepmerge": "^1.5.2",
     "extract-text-webpack-plugin": "^3.0.2",
     "style-loader": "^0.19.0"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,7 +31,7 @@
     "@neutrinojs/style-loader": "^7.3.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.0",
-    "deepmerge": "^2.0.0",
+    "deepmerge": "^1.5.2",
     "fast-async": "^6.3.0",
     "script-ext-html-webpack-plugin": "^1.8.8",
     "webpack": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,7 +2958,7 @@ deepmerge@^1.5.1, deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
 
-deepmerge@^2.0.0, deepmerge@^2.0.1:
+deepmerge@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 


### PR DESCRIPTION
I was unable to use `neutrino start` for some reason with recent commits. Doing a bisect traced it down to the commits where we upgrade deepmerge. I confirmed the problem was resolved with this PR which reverts back to the previous deepmerge version.