### PR TITLE
Make --debug set Jest verbose option from false to true

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -58,7 +58,8 @@ function normalizeJestOptions(opts, neutrino, usingBabel) {
         BABEL_OPTIONS: usingBabel
           ? omit(['cacheDirectory'], neutrino.config.module.rule('compile').use('babel').get('options'))
           : {}
-      }
+      },
+      verbose: neutrino.options.debug
     },
     opts
   ]);


### PR DESCRIPTION
Should result in output that looks like the below, assuming there is more than one test. 

```
 PASS  test/simple_test.js
  simple
    ✓ should be sane (5ms)
    ✓ should be sane1
    ✓ should be sane2 (1ms)
    ✓ should be sane3
    ✓ should be sane4 (1ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.682s
Ran all test suites.
```

#### Test
I tested this by creating a test project, adding neutrino, neutrino-preset-jest, and neutrino-preset-node and then adding 5 tests. The output is above. I verified that it worked with the following test command:
` "neutrino test --debug --use neutrino-preset-node neutrino-preset-jest`

I also tested that it worked by turning debug on in a .neutrinorc.js file

#### Note
I looked for a 'debug' option as well in the jest documention like #389 mentioned, but didn't see one. For debugging, it looks like jest has only ["verbose"](https://facebook.github.io/jest/docs/en/configuration.html#verbose-boolean)


Refs: #389 

Sorry for closing the previous and opening a new one. I had my git user info all incorrect on this user. 
