### PR TITLE
Update auto-changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "version": "yarn changelog --package && git add CHANGELOG.md"
   },
   "devDependencies": {
-    "auto-changelog": "^1.1.0",
+    "auto-changelog": "^1.2.1",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
     "eslint-config-prettier": "^2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,9 +530,9 @@ auto-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-1.1.0.tgz#93b864dc7ee01a326281775d5c75ca0a751e5961"
 
-auto-changelog@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.1.0.tgz#4f042b3b05d0dbdf247daf7436bd41803bbf6598"
+auto-changelog@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.2.1.tgz#4004c94e70d8ac48115af6bd7d13336ee004ef75"
   dependencies:
     babel-polyfill "^6.26.0"
     commander "^2.9.0"


### PR DESCRIPTION
Version `1.2.1` has improved parsing logic, so the merge commits in this repo should now get parsed correctly and get treated as merges in the changelog.

Note that this PR does not update the changelog itself, as that is handled by your `version` script. You can see an example of the new changelog that will be produced [here](https://github.com/CookPete/neutrino-dev/blob/updated-changelog/CHANGELOG.md), compared the current one [here](https://github.com/mozilla-neutrino/neutrino-dev/blob/master/CHANGELOG.md).