### PR TITLE
Remove json from being in options.extensions, update docs on extensions accordingly

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -217,7 +217,7 @@ middleware to determine when to augment the configuration with certain functiona
 ### `options.extensions`
 
 Informs interested middleware the preferred list of module extensions to support.
-By default, `options.extensions` is set to `['js', 'jsx', 'vue', 'ts', 'mjs', 'json’]`.
+By default, `options.extensions` is set to `['js', 'jsx', 'vue', 'ts', 'mjs']`.
 
 ## Neutrino API
 
@@ -711,6 +711,6 @@ without any parameters which fallback to `neutrino.options.extensions`.
 // resolves to /\.(vue|js)$/
 neutrino.regexFromExtensions(['vue', 'js']);
 
-// defaults neutrino.options.extensions which resolves to /\.(js|jsx|vue|ts|mjs|json)$/
+// defaults neutrino.options.extensions which resolves to /\.(js|jsx|vue|ts|mjs)$/
 neutrino.regexFromExtensions();
 ```

--- a/docs/creating-presets.md
+++ b/docs/creating-presets.md
@@ -330,11 +330,11 @@ module.exports = {
 ### `options.extensions`
 
 Set the preferred list of module extensions to inform interested middleware. If the option is not set,
-Neutrino defaults it to `['js', 'jsx', 'vue', 'ts', 'mjs', 'json’]`.
+Neutrino defaults it to `['js', 'jsx', 'vue', 'ts', 'mjs']`.
 
 ```js
 module.exports = neutrino => {
-  // if not specified, defaults to ['js', 'jsx', 'vue', 'ts', 'mjs', 'json’]
+  // if not specified, defaults to ['js', 'jsx', 'vue', 'ts', 'mjs']
   neutrino.options.extensions;
 
   // overwrites the default list
@@ -343,7 +343,7 @@ module.exports = neutrino => {
 
 module.exports = {
   options: {
-    // extends the default list to ['js', 'jsx', 'vue', 'ts', 'mjs', ‘json’, 'elm']
+    // extends the default list to ['js', 'jsx', 'vue', 'ts', 'mjs', 'elm']
     extensions: ['elm']
   }
 };

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -415,7 +415,7 @@ The following is a list of rules and their identifiers which can be overridden:
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `compile` | Compiles JS files from the `src` directory using Babel. Contains a single loader named `babel` | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.js` extensions. Contains a single loader named `worker`. | all |
+| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 
@@ -436,14 +436,14 @@ By following the [customization guide](../../customization) and knowing the rule
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
-_Example: Allow importing modules with a `.mjs` extension._
+_Example: Allow importing modules with a `.esm` extension._
 
 ```js
 module.exports = {
   use: [
     ['@neutrinojs/library', { /* ... */ }],
     (neutrino) => {
-      neutrino.config.resolve.extensions.add('.mjs')
+      neutrino.config.resolve.extensions.add('.esm')
     }
   ]
 };

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -328,13 +328,13 @@ By following the [customization guide](../../customization) and knowing the rule
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
-_Example: Allow importing modules with a `.mjs` extension._
+_Example: Allow importing modules with a `.esm` extension._
 
 ```js
 module.exports = {
   use: [
     '@neutrinojs/node',
-    (neutrino) => neutrino.config.resolve.extensions.add('.mjs')
+    (neutrino) => neutrino.config.resolve.extensions.add('.esm')
   ]
 };
 ```

--- a/docs/packages/react-components/README.md
+++ b/docs/packages/react-components/README.md
@@ -16,7 +16,7 @@ Minimal code is needed to generate stories previewer.
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
-- Support for importing web workers with `.worker.js` file extensions
+- Support for importing web workers with `.worker.*` file extensions
 - Extends from [@neutrinojs/web](../web)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -328,7 +328,7 @@ The following is a list of rules and their identifiers which can be overridden:
 | `img`, `svg`, `ico` | Allows import image files from modules. Each contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
 | `woff`, `ttf` | Allows importing WOFF and TTF font files from modules. Each contains a single loader named `url`. From `@neutrinojs/font-loader`. | all |
 | `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.js` extensions. Contains a single loader named `worker`. | all |
+| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -415,7 +415,7 @@ The following is a list of rules and their identifiers which can be overridden:
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `compile` | Compiles JS files from the `src` directory using Babel. Contains a single loader named `babel` | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.js` extensions. Contains a single loader named `worker`. | all |
+| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 
@@ -436,14 +436,14 @@ By following the [customization guide](https://neutrino.js.org/customization) an
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
-_Example: Allow importing modules with a `.mjs` extension._
+_Example: Allow importing modules with a `.esm` extension._
 
 ```js
 module.exports = {
   use: [
     ['@neutrinojs/library', { /* ... */ }],
     (neutrino) => {
-      neutrino.config.resolve.extensions.add('.mjs')
+      neutrino.config.resolve.extensions.add('.esm')
     }
   ]
 };

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -103,7 +103,7 @@ module.exports = (neutrino, opts = {}) => {
         .add(NEUTRINO_MODULES)
         .end()
       .extensions
-        .merge(neutrino.options.extensions.map(ext => `.${ext}`))
+        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
         .end()
       .end()
     .resolveLoader

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -18,7 +18,7 @@ class Api {
 
   // getOptions :: Object? -> IO Object
   getOptions(opts = {}) {
-    let moduleExtensions = new Set(['js', 'jsx', 'vue', 'ts', 'mjs', 'json']);
+    let moduleExtensions = new Set(['js', 'jsx', 'vue', 'ts', 'mjs']);
     const options = merge.all([
       {
         env: {

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -328,13 +328,13 @@ By following the [customization guide](https://neutrino.js.org/customization) an
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
-_Example: Allow importing modules with a `.mjs` extension._
+_Example: Allow importing modules with a `.esm` extension._
 
 ```js
 module.exports = {
   use: [
     '@neutrinojs/node',
-    (neutrino) => neutrino.config.resolve.extensions.add('.mjs')
+    (neutrino) => neutrino.config.resolve.extensions.add('.esm')
   ]
 };
 ```

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -103,7 +103,7 @@ module.exports = (neutrino, opts = {}) => {
         .add(NEUTRINO_MODULES)
         .end()
       .extensions
-        .merge(neutrino.options.extensions.map(ext => `.${ext}`))
+        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
         .end()
       .end()
     .resolveLoader

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -16,7 +16,7 @@ Minimal code is needed to generate stories previewer.
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
-- Support for importing web workers with `.worker.js` file extensions
+- Support for importing web workers with `.worker.*` file extensions
 - Extends from [@neutrinojs/web](https://neutrino.js.org/presets/@neutrinojs/web)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -328,7 +328,7 @@ The following is a list of rules and their identifiers which can be overridden:
 | `img`, `svg`, `ico` | Allows import image files from modules. Each contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
 | `woff`, `ttf` | Allows importing WOFF and TTF font files from modules. Each contains a single loader named `url`. From `@neutrinojs/font-loader`. | all |
 | `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.js` extensions. Contains a single loader named `worker`. | all |
+| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -124,7 +124,7 @@ module.exports = (neutrino, opts = {}) => {
         .add(NEUTRINO_MODULES)
         .end()
       .extensions
-        .merge(neutrino.options.extensions.map(ext => `.${ext}`))
+        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
         .end()
       .end()
     .resolveLoader


### PR DESCRIPTION
This fixes issues with the babel compiler trying to parse JSON as JS, and prevents ESLint from trying to lint JSON files. As a result, we need to add `json` to webpack extensions where relevant, which this PR also does. I've updated the docs accordingly.