### PR TITLE
Revert broken changes, do not join.

### DIFF
--- a/packages/imagemin/index.js
+++ b/packages/imagemin/index.js
@@ -27,22 +27,19 @@ module.exports = (neutrino, opts = {}) => {
     rules: ['svg', 'img']
   }, opts);
 
-  const tests = options.rules.map((ruleId) => {
-    const test = neutrino.regexFromExtensions([ruleId]);
-
+  const test = options.rules.map((ruleId) => {
     neutrino.config.module
       .rule(ruleId)
-      .test(test)
       .use(options.useId)
         .loader(imageminLoader)
         .options(options.imagemin);
 
-    return test;
+    return neutrino.config.module.rule(ruleId).get('test');
   });
 
   options.plugin = merge({
     imageminOptions: options.imagemin,
-    test: tests
+    test
   }, options.plugin);
 
   neutrino.config

--- a/packages/imagemin/index.js
+++ b/packages/imagemin/index.js
@@ -36,7 +36,7 @@ module.exports = (neutrino, opts = {}) => {
 
     return neutrino.config.module.rule(ruleId).get('test');
   })
-  .filter(test => !!test);
+  .filter(Boolean);
 
   options.plugin = merge({
     imageminOptions: options.imagemin,

--- a/packages/imagemin/index.js
+++ b/packages/imagemin/index.js
@@ -35,7 +35,8 @@ module.exports = (neutrino, opts = {}) => {
         .options(options.imagemin);
 
     return neutrino.config.module.rule(ruleId).get('test');
-  });
+  })
+  .filter(test => !!test);
 
   options.plugin = merge({
     imageminOptions: options.imagemin,


### PR DESCRIPTION
@eliperelman changes introduced here broke things a bit: https://github.com/mozilla-neutrino/neutrino-dev/commit/9380f02e983e05e2780bb0a5a14e490d4a45891a#diff-3813a5588840cf846f7dfcf2cc0bc30b

This MW basically assumes you're using `image-loader`, or something else that would define image rules. Those pre-existing rule ids are what is configurable via `options.rules`.

For that reason, I was intentionally omitting the `.test`, as we can assume it already exists in that rule.

I'm then mapping the value of the actual test, so I can pass it all to the plugin's `test` option.

Your changes were using `options.rules` as extensions, and calling `.test`, which ended up passing something like `/(\.svg|\.img)$/`

Note:
I _was_ `join`ing those rules on a pipe for a regex string, which I didn't need to because `ImageminWebpackPlugin`'s test option can be an array.

**TL;DR**

This PR reverts those changes with the exception of the unnecessary `join('|')`. If you have other ideas or preferences how to do this, I'm happy to make changes.