### PR TITLE
Merge test babel config in root config to deal with JSX pragma plugin precedence

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -83,13 +83,11 @@ module.exports = (neutrino, opts = {}) => {
 
     neutrino.config.when(usingBabel, () => {
       neutrino.use(loaderMerge('compile', 'babel'), {
-        env: {
-          test: {
-            retainLines: true,
-            presets: [require.resolve('babel-preset-jest')],
-            plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
-          }
-        }
+        retainLines: true,
+        presets: [require.resolve('babel-preset-jest')],
+        plugins: [
+          require.resolve('babel-plugin-transform-es2015-modules-commonjs')
+        ]
       });
     });
 

--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -48,11 +48,7 @@ module.exports = (neutrino, opts = {}) => {
 
   if (neutrino.config.module.rules.has('compile')) {
     neutrino.use(loaderMerge('compile', 'babel'), {
-      env: {
-        test: {
-          plugins: [require.resolve('babel-plugin-istanbul')]
-        }
-      }
+      plugins: [require.resolve('babel-plugin-istanbul')]
     });
   }
 

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -14,11 +14,7 @@ module.exports = (neutrino, opts = {}) => {
 
     neutrino.config.when(usingBabel, () => {
       neutrino.use(loaderMerge('compile', 'babel'), {
-        env: {
-          test: {
-            plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
-          }
-        }
+        plugins: [require.resolve('babel-plugin-transform-es2015-modules-commonjs')]
       });
     });
 


### PR DESCRIPTION
The command `neutrino test --coverage` command was blowing up when used with the jest preset. Doing a bisect revealed the culprit as #455. After digging it, it seems that the Babel pragma plugins add some import code, which is expected, but jest (and the other test middleware) adds its plugin for imports in the `test` env, which is lower precedence than the root configuration for Babel.

To be honest, since we are controlling adding to the babel configuration to occur only during the test event, using the Babel `test` env is really just a novelty. I have removed the environment here from the test runners.

We may want to consider removing all Babel environments and replacing them with `.when` merges, just to avoid things like this in the future, and to give us a single piece of config to update. Same for our users.