### PR TITLE
Add neutrino.options.source to modules.resolve

### DIFF
--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -101,6 +101,7 @@ module.exports = (neutrino, opts = {}) => {
         .add(neutrino.options.node_modules)
         .add(MODULES)
         .add(NEUTRINO_MODULES)
+        .add(neutrino.options.source)
         .end()
       .extensions
         .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -125,6 +125,7 @@ module.exports = (neutrino, opts = {}) => {
         .add(neutrino.options.node_modules)
         .add(MODULES)
         .add(NEUTRINO_MODULES)
+        .add(neutrino.options.source)
         .end()
       .extensions
         .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))


### PR DESCRIPTION
Anyone else find it odd that `neutrino.options.source` isn't in our resolve paths?

Could be a good reason for it, but it is always one of the first things I add to a neutrino setup. I generally perfer to import that way vs a relative path with `./`.

Fine if we don't want it in core, just thought I'd bring it up if others feel the same.