### PR TITLE
Remove reliance on babel environments, make babel options merging consistent

### DIFF
--- a/docs/packages/compile-loader/README.md
+++ b/docs/packages/compile-loader/README.md
@@ -132,22 +132,17 @@ const { merge } = require('@neutrinojs/compile-loader');
 // Decorators generally need to be enabled *before* other
 // syntax which exists in both normal plugins, and
 // development environment plugins.
-const decorators = require.resolve('babel-plugin-transform-decorators-legacy');
-const classes = require.resolve('babel-plugin-transform-class-properties');
-
-// Now tap into the existing Babel options and merge our
+// Tap into the existing Babel options and merge our
 // decorator options *before* the rest of the existing
 // Babel options
 config.module
   .rule('compile')
     .use('babel')
       .tap(options => merge({
-        plugins: [decorators, classes],
-        env: {
-          development: {
-            plugins: [decorators, classes]
-          }
-        }
+        plugins: [
+          require.resolve('babel-plugin-transform-decorators-legacy'),
+          require.resolve('babel-plugin-transform-class-properties')
+        ]
       }, options));
 ```
 

--- a/packages/compile-loader/README.md
+++ b/packages/compile-loader/README.md
@@ -132,22 +132,17 @@ const { merge } = require('@neutrinojs/compile-loader');
 // Decorators generally need to be enabled *before* other
 // syntax which exists in both normal plugins, and
 // development environment plugins.
-const decorators = require.resolve('babel-plugin-transform-decorators-legacy');
-const classes = require.resolve('babel-plugin-transform-class-properties');
-
-// Now tap into the existing Babel options and merge our
+// Tap into the existing Babel options and merge our
 // decorator options *before* the rest of the existing
 // Babel options
 config.module
   .rule('compile')
     .use('babel')
       .tap(options => merge({
-        plugins: [decorators, classes],
-        env: {
-          development: {
-            plugins: [decorators, classes]
-          }
-        }
+        plugins: [
+          require.resolve('babel-plugin-transform-decorators-legacy'),
+          require.resolve('babel-plugin-transform-class-properties')
+        ]
       }, options));
 ```
 

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -62,15 +62,9 @@ module.exports = (neutrino, opts = {}) => {
     );
   }
 
-  try {
-    const pkg = neutrino.options.packageJson;
-    const hasSourceMap = (pkg.dependencies && 'source-map-support' in pkg.dependencies) ||
-      (pkg.devDependencies && 'source-map-support' in pkg.devDependencies);
-
-    if (hasSourceMap) {
-      neutrino.use(banner);
-    }
-  } catch (ex) {} // eslint-disable-line
+  const pkg = neutrino.options.packageJson;
+  const hasSourceMap = (pkg.dependencies && 'source-map-support' in pkg.dependencies) ||
+    (pkg.devDependencies && 'source-map-support' in pkg.devDependencies);
 
   neutrino.use(compileLoader, {
     include: [
@@ -85,9 +79,10 @@ module.exports = (neutrino, opts = {}) => {
     .forEach(key => neutrino.config.entry(key).add(neutrino.options.mains[key]));
 
   neutrino.config
+    .when(hasSourceMap, () => neutrino.use(banner))
+    .devtool('source-map')
     .target(options.target)
     .context(neutrino.options.root)
-    .devtool('source-map')
     .output
       .library(options.name)
       .filename('[name].js')

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -1,5 +1,6 @@
-const web = require('@neutrinojs/web');
+const compileLoader = require('@neutrinojs/compile-loader');
 const loaderMerge = require('@neutrinojs/loader-merge');
+const web = require('@neutrinojs/web');
 const { join } = require('path');
 const merge = require('deepmerge');
 
@@ -8,35 +9,26 @@ const MODULES = join(__dirname, 'node_modules');
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
     hot: true,
-    babel: {
-      plugins: [
-        [
-          require.resolve('babel-plugin-transform-react-jsx'),
-          { pragma: 'h' }
-        ],
-        [
-          require.resolve('babel-plugin-jsx-pragmatic'),
-          {
-            module: 'preact',
-            export: 'h',
-            import: 'h'
-          }
-        ],
-        require.resolve('babel-plugin-transform-object-rest-spread'),
-        process.env.NODE_ENV !== 'development' ?
-          [require.resolve('babel-plugin-transform-class-properties'), { spec: true }] :
-          {}
-      ],
-      env: {
-        development: {
-          plugins: [
-            [require.resolve('babel-plugin-transform-class-properties'), { spec: true }],
-            require.resolve('babel-plugin-transform-es2015-classes')
-          ]
-        }
-      }
-    }
+    babel: {}
   }, opts);
+
+  Object.assign(options, {
+    babel: compileLoader.merge({
+      plugins: [
+        [require.resolve('babel-plugin-transform-react-jsx'), { pragma: 'h' }],
+        [require.resolve('babel-plugin-jsx-pragmatic'), {
+          module: 'preact',
+          export: 'h',
+          import: 'h'
+        }],
+        require.resolve('babel-plugin-transform-object-rest-spread'),
+        [require.resolve('babel-plugin-transform-class-properties'), { spec: true }],
+        process.env.NODE_ENV === 'development'
+          ? require.resolve('babel-plugin-transform-es2015-classes')
+          : {}
+      ]
+    }, options.babel)
+  });
 
   neutrino.use(web, options);
 

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://neutrino.js.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "dependencies": {
+    "@neutrinojs/compile-loader": "^7.3.2",
     "@neutrinojs/loader-merge": "^7.3.2",
     "@neutrinojs/web": "^7.3.2",
     "babel-plugin-jsx-pragmatic": "^1.0.2",

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -54,18 +54,15 @@ module.exports = (neutrino, opts = {}) => {
         'lib' :
         neutrino.options.output;
 
-      try {
-        const pkg = neutrino.options.packageJson;
-        const hasSourceMap = (pkg.dependencies && 'source-map-support' in pkg.dependencies) ||
-          (pkg.devDependencies && 'source-map-support' in pkg.devDependencies);
-
-        hasSourceMap && neutrino.use(banner);
-      } catch (ex) {} // eslint-disable-line
+      const pkg = neutrino.options.packageJson;
+      const hasSourceMap = (pkg.dependencies && 'source-map-support' in pkg.dependencies) ||
+        (pkg.devDependencies && 'source-map-support' in pkg.devDependencies);
 
       neutrino.use(react, options);
 
       neutrino.config
         .when(options.externals, config => config.externals([nodeExternals(options.externals)]))
+        .when(hasSourceMap, () => neutrino.use(banner))
         .devtool('source-map')
         .performance
           .hints('error')

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -29,20 +29,19 @@ module.exports = (neutrino, opts = {}) => {
           }
         ],
         require.resolve('babel-plugin-transform-object-rest-spread'),
-        ...(process.env.NODE_ENV !== 'development' ?
-          [[require.resolve('babel-plugin-transform-class-properties'), { spec: true }]] :
-          [])
+        ...(
+          process.env.NODE_ENV === 'development'
+            ? [
+              ...(options.hot ? [require.resolve('react-hot-loader/babel')] : null),
+              [require.resolve('babel-plugin-transform-class-properties'), { spec: true }],
+              require.resolve('babel-plugin-transform-es2015-classes')
+            ]
+            : [
+              [require.resolve('babel-plugin-transform-class-properties'), { spec: true }]
+            ]
+        )
       ],
-      presets: [require.resolve('babel-preset-react')],
-      env: {
-        development: {
-          plugins: [
-            ...(options.hot ? [require.resolve('react-hot-loader/babel')] : []),
-            [require.resolve('babel-plugin-transform-class-properties'), { spec: true }],
-            require.resolve('babel-plugin-transform-es2015-classes')
-          ]
-        }
-      }
+      presets: [require.resolve('babel-preset-react')]
     }, options.babel)
   });
 


### PR DESCRIPTION
Fixes #542. This PR does the following:

- [x] Remove usages of babel option `env`. This makes merging babel configuration from userland a little easier by not making the user updating the options in potentially 2 different places. We fixed this for the test middleware, and this PR fixes it for the build middleware.
- [x] Use `compile-loader` to merge babel options from higher-level middleware. This was already being done by the react middleware, but the preact middleware wasn't doing this properly. @edmorley brought this to my attention at https://github.com/mozilla-neutrino/neutrino-dev/pull/483#issuecomment-346186495, but I didn't understand the problem at the time. This should now be fixed. Thanks @edmorley!
- [x] I removed a couple `try` blocks that were leftovers from #534. They weren't hurting anything, but it just added a potential point of confusion in the future.