### PR TITLE
Use custom externals with react-components build

### DIFF
--- a/packages/react-components/.neutrinorc.js
+++ b/packages/react-components/.neutrinorc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  use: [
+    ['index.js', { externals: false }],
+    (neutrino) => {
+      neutrino.config
+        .performance
+          .hints('warning')
+          .end()
+        .externals([
+          'normalize.css',
+          'react',
+          'react-addons-css-transition-group',
+          'react-dom',
+          'prop-types'
+        ]);
+    }
+  ]
+};

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -7,14 +7,14 @@ const { readdirSync } = require('fs');
 
 const MODULES = join(__dirname, 'node_modules');
 
-module.exports = (neutrino, options = {}) => {
-  const reactOptions = merge({
+module.exports = (neutrino, opts = {}) => {
+  const options = merge({
     html: process.env.NODE_ENV === 'development' && {
       title: 'React Preview'
     },
     manifest: process.env.NODE_ENV === 'development',
-    externals: {}
-  }, options);
+    externals: opts.externals !== false && {}
+  }, opts);
 
   neutrino.config.resolve.modules
     .add(MODULES)
@@ -33,7 +33,7 @@ module.exports = (neutrino, options = {}) => {
     process.env.NODE_ENV === 'development',
     () => {
       neutrino.options.mains.index = 'stories'; // eslint-disable-line no-param-reassign
-      neutrino.use(react, reactOptions);
+      neutrino.use(react, options);
     },
     () => {
       const components = join(neutrino.options.source, options.components || 'components');
@@ -62,14 +62,14 @@ module.exports = (neutrino, options = {}) => {
         hasSourceMap && neutrino.use(banner);
       } catch (ex) {} // eslint-disable-line
 
-      neutrino.use(react, reactOptions);
+      neutrino.use(react, options);
 
       neutrino.config
+        .when(options.externals, config => config.externals([nodeExternals(options.externals)]))
         .devtool('source-map')
         .performance
           .hints('error')
           .end()
-        .externals([nodeExternals(options.externals)])
         .output
           .filename('[name].js')
           .library('[name]')

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -12,7 +12,7 @@
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/react-components",
   "license": "MPL-2.0",
   "scripts": {
-    "build": "neutrino build --use ./index.js --options.config.performance.hints warning"
+    "build": "neutrino build"
   },
   "devDependencies": {
     "react": "^16.0.0",


### PR DESCRIPTION
Looks like the travis logs have this message when building react-components:

```
{ Error: ENOENT: no such file or directory, scandir 'node_modules'
    at Object.fs.readdirSync (fs.js:924:18)
    at readDir (/home/travis/build/mozilla-neutrino/neutrino-dev/node_modules/webpack-node-externals/index.js:12:19)
    at nodeExternals (/home/travis/build/mozilla-neutrino/neutrino-dev/node_modules/webpack-node-externals/index.js:95:65)
    at neutrino.config.when (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/react-components/index.js:72:21)
    at module.exports.when (/home/travis/build/mozilla-neutrino/neutrino-dev/node_modules/webpack-chain/src/ChainedMap.js:130:7)
    at module.exports (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/react-components/index.js:32:19)
    at Api.use (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/src/api.js:188:7)
    at Api.use (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/src/api.js:192:12)
    at middleware.forEach.middleware (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/bin/base.js:25:40)
    at Array.forEach (<anonymous>)
    at module.exports (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/bin/base.js:25:14)
    at module.exports (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/bin/build.js:9:10)
    at cond (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/bin/neutrino.js:125:29)
    at /home/travis/build/mozilla-neutrino/neutrino-dev/node_modules/ramda/src/cond.js:47:30
    at /home/travis/build/mozilla-neutrino/neutrino-dev/node_modules/ramda/src/internal/_arity.js:10:19
    at Promise.all.then (/home/travis/build/mozilla-neutrino/neutrino-dev/packages/neutrino/bin/neutrino.js:130:5)
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: 'node_modules' }
```

Hopefully using a manual `externals` value with resolve this in travis.