### PR TITLE
Allow style-loader to accept loaders

### DIFF
--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -67,7 +67,14 @@ module.exports = (neutrino, opts = {}) => {
         importLoaders: options.css.importLoaders + options.loaders.length
       }),
       useId: options.cssUseId
-    }, ...options.loaders];
+    }, ...options.loaders]
+    .map((loader, index) => {
+      const obj = typeof loader === 'object' ? loader : { loader };
+
+      return Object.assign(obj, {
+        useId: obj.useId || `${options.cssUseId}-${index}`
+      });
+    });
 
     loaders.forEach(loader => {
       styleRule

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -56,18 +56,21 @@ module.exports = (neutrino, opts = {}) => {
 
   rules.forEach(options => {
     const styleRule = neutrino.config.module.rule(options.ruleId);
-    const loaders = [{
-      loader: require.resolve('style-loader'),
-      options: options.style,
-      useId: options.styleUseId
-    },
-    {
-      loader: require.resolve('css-loader'),
-      options: Object.assign(options.css, {
-        importLoaders: options.css.importLoaders + options.loaders.length
-      }),
-      useId: options.cssUseId
-    }, ...options.loaders]
+    const loaders = [
+      {
+        loader: require.resolve('style-loader'),
+        options: options.style,
+        useId: options.styleUseId
+      },
+      {
+        loader: require.resolve('css-loader'),
+        options: Object.assign(options.css, {
+          importLoaders: options.css.importLoaders + options.loaders.length
+        }),
+        useId: options.cssUseId
+      },
+      ...options.loaders
+    ]
     .map((loader, index) => {
       const obj = typeof loader === 'object' ? loader : { loader };
 

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -24,6 +24,7 @@ module.exports = (neutrino, opts = {}) => {
     modules: true,
     modulesSuffix: '-modules',
     modulesTest: cssModulesTest,
+    loaders: [],
     extractId: 'extract',
     extract: {
       plugin: {
@@ -52,16 +53,25 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   rules.forEach(options => {
-    neutrino.config.module
-      .rule(options.ruleId)
-        .test(options.test)
-        .use(options.styleUseId)
-           .loader(require.resolve('style-loader'))
-           .when(options.style, use => use.options(options.style))
-           .end()
-        .use(options.cssUseId)
-          .loader(require.resolve('css-loader'))
-          .when(options.css, use => use.options(options.css));
+    options.loaders.unshift({
+      loader: require.resolve('style-loader'),
+      options: options.style,
+      useId: options.styleUseId
+    },
+    {
+      loader: require.resolve('css-loader'),
+      options: options.css,
+      useId: options.cssUseId
+    });
+
+    options.loaders.forEach(loader => {
+      neutrino.config.module
+        .rule(options.ruleId)
+          .test(options.test)
+          .use(loader.useId)
+            .loader(loader.loader)
+            .when(loader.options, use => use.options(loader.options));
+    });
 
     if (options.extract) {
       const styleRule = neutrino.config.module.rule(options.ruleId);


### PR DESCRIPTION
This adds a `loaders` option to `style-loader`, in which users may pass their own custom css loaders (postcss, sass, etc)

## Why?

- CSS loaders can be tricky to configure correctly, especially when factoring in `extract-text`, css modules, hot-reloading, and css-loader's `importLoaders` option.
- Prevents the need for community-sourced middlewares that do nothing more than add a loader to the `style` rule (e.g. https://github.com/barraponto/neutrino-middleware-postcss, https://github.com/kopacki/neutrino-dev/blob/master/packages/neutrino-preset-sass/src/index.js)

## Example usage

```
module.exports = {
  use: [
    [
      '@neutrinojs/web',
      {
        style: {
          loaders: [

            // No options, auto-generated useId (css-*)
            require.resolve('postcss-loader'),

            // With options, specified useId
            {
              useId: 'postcss',
              loader: require.resolve('postcss-loader'),
              options: {}
            }
          ]
        }
      }
    ],
  ]
};
```
- The result is the loaders added in order: style, css, sass-loader, postcss-loader.
- css-loaders's `importLoaders` has been set properly, taking into account the # loaders your have, and `options.modules`.
- Everything still works with extract-text, and HMR :)


Related: https://github.com/mozilla-neutrino/neutrino-dev/issues/20