### PR TITLE
Fix logic of fork middleware after regression from CLI help improvement

### DIFF
--- a/packages/fork/neutrino-child.js
+++ b/packages/fork/neutrino-child.js
@@ -40,7 +40,7 @@ process.on('message', ([rawMiddleware, args]) => {
     middleware.use.push(({ config }) => config.merge(args.options.config));
   }
 
-  const api = runnable(command, middleware, args);
+  const api = runnable(command, [middleware], args);
 
   api.on('*', (type, ...args) => {
     process.send([type, args]);

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -267,9 +267,8 @@ class Api {
   // run :: String commandName -> Future
   run(commandName) {
     const emitForAll = this.emitForAll.bind(this);
-    const command = this.commands[commandName];
 
-    return Future((reject, resolve) => (command ?
+    return Future((reject, resolve) => (this.commands[commandName] ?
       resolve() :
       reject(new Error(`A command with the name "${commandName}" was not registered`))
     ))
@@ -279,7 +278,7 @@ class Api {
     .chain(() => Future.encaseP2(emitForAll, 'prerun', this.options.args))
     // Execute the command
     .chain(() => {
-      const result = command(this.config.toConfig(), this);
+      const result = this.commands[commandName](this.config.toConfig(), this);
 
       return Future.isFuture(result) ?
         result :


### PR DESCRIPTION
Fixes #588.

This regression occurred because of the changes in 77d239a81154a6cba31f06a8d9e3bea6592d6e85 which moved handling middleware prior to registering commands.