### PR TITLE
Extract text on build, not production

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -38,7 +38,7 @@ module.exports = (neutrino, opts = {}) => {
     style: {
       hot: opts.hot !== false,
       extract: (opts.style && opts.style.extract) ||
-        (process.env.NODE_ENV === 'production' && {})
+        (neutrino.options.command === 'build' && {})
     },
     manifest: opts.html === false ? {} : false,
     clean: opts.clean !== false && {


### PR DESCRIPTION
This seems like a better default to me.

In my case I ran `neutrino build --options.env.NODE_ENV = development` and expected to see my css extracted, but not minified/optimized.