### PR TITLE
options.devServer.publicPath default should operate on passed opts

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -21,7 +21,7 @@ const { optimize } = require('webpack');
 const MODULES = join(__dirname, 'node_modules');
 
 module.exports = (neutrino, opts = {}) => {
-  const publicPath = './';
+  const publicPath = opts.publicPath || './';
   const options = merge({
     publicPath,
     env: [],


### PR DESCRIPTION
So you don't have to set both `publicPath` _and_ `devServer.publicPath`