### PR TITLE
Set default X-Dev-Server-Proxy for easier server-side integration

### DIFF
--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -190,8 +190,6 @@ module.exports = {
       html: {},
 
       // Change options related to starting a webpack-dev-server
-      // See @neutrinojs/html-template for the defaults
-      // used by the Web preset
       devServer: {
         // Disabling options.hot will also disable devServer.hot
         hot: options.hot
@@ -254,11 +252,51 @@ module.exports = {
       // Example: change the page title
       html: {
         title: 'Epic Web App'
+      },
+
+      // Example: Proxy webpack-dev-server requests to http://localhost:3000
+      devServer: {
+        proxy: 'http://localhost:3000'
       }
     }]
   ]
 };
 ```
+
+### Dev Server Proxy
+
+If your are integrating Neutrino into an existing app, you may want to set up a proxy for development. See Webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
+
+Optionally, you may pass a url string (instead of an object) to `devServer.proxy`.
+This will proxy **all requests** through the given url, and set some sensible defaults.
+
+For example:
+```js
+['@neutrinojs/web', {
+  devServer: {
+    proxy: 'http://localhost:3000'
+  }
+}
+```
+
+Is equivalent to:
+```js
+['@neutrinojs/web', {
+  devServer: {
+    proxy: {
+      '**': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        headers: {
+          'X-Dev-Server-Proxy': 'http://localhost:3000'
+        }
+      }
+    }
+  }
+}
+```
+
+The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being request through the proxy.
 
 ## Hot Module Replacement
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -265,12 +265,13 @@ module.exports = {
 
 ### Dev Server Proxy
 
-If your are integrating Neutrino into an existing app, you may want to set up a proxy for development. See Webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
+If you are handling requests with a server, you may want to set up a proxy for development. See webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
 
 Optionally, you may pass a url string (instead of an object) to `devServer.proxy`.
 This will proxy **all requests** through the given url, and set some sensible defaults.
 
 For example:
+
 ```js
 ['@neutrinojs/web', {
   devServer: {
@@ -280,6 +281,7 @@ For example:
 ```
 
 Is equivalent to:
+
 ```js
 ['@neutrinojs/web', {
   devServer: {
@@ -296,7 +298,7 @@ Is equivalent to:
 }
 ```
 
-The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being request through the proxy.
+The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being requested through the proxy.
 
 ## Hot Module Replacement
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -190,8 +190,6 @@ module.exports = {
       html: {},
 
       // Change options related to starting a webpack-dev-server
-      // See @neutrinojs/html-template for the defaults
-      // used by the Web preset
       devServer: {
         // Disabling options.hot will also disable devServer.hot
         hot: options.hot
@@ -254,11 +252,51 @@ module.exports = {
       // Example: change the page title
       html: {
         title: 'Epic Web App'
+      },
+
+      // Example: Proxy webpack-dev-server requests to http://localhost:3000
+      devServer: {
+        proxy: 'http://localhost:3000'
       }
     }]
   ]
 };
 ```
+
+### Dev Server Proxy
+
+If your are integrating Neutrino into an existing app, you may want to set up a proxy for development. See Webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
+
+Optionally, you may pass a url string (instead of an object) to `devServer.proxy`.
+This will proxy **all requests** through the given url, and set some sensible defaults.
+
+For example:
+```js
+['@neutrinojs/web', {
+  devServer: {
+    proxy: 'http://localhost:3000'
+  }
+}
+```
+
+Is equivalent to:
+```js
+['@neutrinojs/web', {
+  devServer: {
+    proxy: {
+      '**': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        headers: {
+          'X-Dev-Server-Proxy': 'http://localhost:3000'
+        }
+      }
+    }
+  }
+}
+```
+
+The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being request through the proxy.
 
 ## Hot Module Replacement
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -265,12 +265,13 @@ module.exports = {
 
 ### Dev Server Proxy
 
-If your are integrating Neutrino into an existing app, you may want to set up a proxy for development. See Webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
+If you are handling requests with a server, you may want to set up a proxy for development. See webpack's [`devServer.proxy`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) for all available options.
 
 Optionally, you may pass a url string (instead of an object) to `devServer.proxy`.
 This will proxy **all requests** through the given url, and set some sensible defaults.
 
 For example:
+
 ```js
 ['@neutrinojs/web', {
   devServer: {
@@ -280,6 +281,7 @@ For example:
 ```
 
 Is equivalent to:
+
 ```js
 ['@neutrinojs/web', {
   devServer: {
@@ -296,7 +298,7 @@ Is equivalent to:
 }
 ```
 
-The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being request through the proxy.
+The `X-Dev-Server-Proxy` header can be useful for detecting if your existing app is being requested through the proxy.
 
 ## Hot Module Replacement
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -59,7 +59,10 @@ module.exports = (neutrino, opts = {}) => {
     options.devServer.proxy = {
       '**': {
         target: options.devServer.proxy,
-        changeOrigin: true
+        changeOrigin: true,
+        headers: {
+          'X-Dev-Server-Proxy': options.devServer.proxy
+        }
       }
     };
   }


### PR DESCRIPTION
When using `@neutrinojs/web` with a separate server-side backend, it your backend app will usually need some way of knowing if a request is a dev-server request, or a normal one.

This is so it knows when to look in the `manifest.json` and request the revved file, or to request the un-revved path and load via devServer.

This adds an http header `X-Dev-Server-Proxy`, so you can easily detect from your server-side app.

Example w/ a dumb 'ol php app:

```php
$isDevServer = (bool) $_SERVER['HTTP_X_DEV_SERVER_PROXY'];
```

```html
<script src="<?= $isDevServer ? '/build/index.js' : getManifestAsset('index.js') ?>"></script>
```