### PR TITLE
Web: Handle booleans for options.minify, options.style, options.style.extract

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -75,9 +75,9 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   Object.assign(options, {
-    style: options.style && merge({
+    style: options.style && merge(options.style, {
       extract: options.style.extract === true ? {} : options.style.extract
-    }, options.style),
+    }),
     minify: options.minify && merge(options.minify, {
       babel: options.minify.babel === true ? {} : options.minify.babel,
       style: options.minify.style === true ? {} : options.minify.style,

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -44,7 +44,7 @@ module.exports = (neutrino, opts = {}) => {
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
     },
-    minify: {
+    minify: process.env.NODE_ENV === 'production' && {
       babel: {},
       style: {},
       image: false
@@ -76,11 +76,14 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   Object.assign(options, {
-    minify: {
+    style: options.style && merge({
+      extract: options.style.extract === true ? {} : options.style.extract
+    }, options.style),
+    minify: options.minify && merge(options.minify, {
       babel: options.minify.babel === true ? {} : options.minify.babel,
       style: options.minify.style === true ? {} : options.minify.style,
       image: options.minify.image === true ? {} : options.minify.image
-    },
+    }),
     babel: compileLoader.merge({
       plugins: [
         ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
@@ -206,10 +209,10 @@ module.exports = (neutrino, opts = {}) => {
       neutrino.use(chunk);
 
       config
-        .when(options.minify, () => neutrino.use(minify, options.minify))
         .plugin('module-concat')
           .use(optimize.ModuleConcatenationPlugin);
     })
+    .when(options.minify, () => neutrino.use(minify, options.minify))
     .when(neutrino.options.command === 'build', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
       neutrino.use(copy, {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -44,7 +44,7 @@ module.exports = (neutrino, opts = {}) => {
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
     },
-    minify: process.env.NODE_ENV === 'production' && {
+    minify: {
       babel: {},
       style: {},
       image: false
@@ -209,10 +209,10 @@ module.exports = (neutrino, opts = {}) => {
       neutrino.use(chunk);
 
       config
+        .when(options.minify, () => neutrino.use(minify, options.minify))
         .plugin('module-concat')
           .use(optimize.ModuleConcatenationPlugin);
     })
-    .when(options.minify, () => neutrino.use(minify, options.minify))
     .when(neutrino.options.command === 'build', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
       neutrino.use(copy, {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -37,8 +37,7 @@ module.exports = (neutrino, opts = {}) => {
     },
     style: {
       hot: opts.hot !== false,
-      extract: (opts.style && opts.style.extract) ||
-        (process.env.NODE_ENV === 'production' && {})
+      extract: process.env.NODE_ENV === 'production'
     },
     manifest: opts.html === false ? {} : false,
     clean: opts.clean !== false && {


### PR DESCRIPTION
This allows users to completely disable `@neutrinojs/minify`, `@neutrinojs/style` by passing `false` to their respective options.

Also included is the coercion of `options.style.extract` to `{}`, when passed `true`.