### PR TITLE
Add missing babel-plugin-transform-react-jsx to preact preset

### DIFF
--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "deepmerge": "^1.5.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi there, nice project! While trying to play with preact.js I ran into this issue.

```
➜  test-neutrino yarn start
yarn run v1.3.2
$ neutrino start

{ Error: Cannot find module 'babel-plugin-transform-react-jsx'
    at Function.Module._resolveFilename (module.js:542:15)
    at Function.resolve (internal/module.js:18:19)
    at module.exports (/Users/marcio/workspace/javascript/test-neutrino/node_modules/@neutrinojs/preact/index.js:18:18)
```

The project was scaffolded with `yarn create @neutrinojs/project test-neutrino` and I selected preact as framework and karma as testing lib . This is the package.json

```
{
  "name": "test-neutrino",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "scripts": {
    "build": "neutrino build",
    "start": "neutrino start",
    "test": "neutrino test"
  },
  "dependencies": {
    "preact": "^8.2.6",
    "preact-compat": "^3.17.0"
  },
  "devDependencies": {
    "@neutrinojs/karma": "^8.0.11",
    "@neutrinojs/preact": "^8.0.11",
    "neutrino": "^8.0.11"
  }
}
```

I noticed the preact preset was missing the babel-plugin-transform-react-jsx and added it.