### PR TITLE
Fix broken regex

### DIFF
--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -155,7 +155,7 @@ class Api {
 
   // regexFromExtensions :: Array extensions -> RegExp
   regexFromExtensions(extensions = this.options.extensions) {
-    return new RegExp(`\.(${extensions.join('|')})$`); // eslint-disable-line no-useless-escape
+    return new RegExp(String.raw`\.(${extensions.join('|')})$`);
   }
 
   // emit :: Any -> IO

--- a/packages/neutrino/src/api.js
+++ b/packages/neutrino/src/api.js
@@ -155,7 +155,7 @@ class Api {
 
   // regexFromExtensions :: Array extensions -> RegExp
   regexFromExtensions(extensions = this.options.extensions) {
-    return new RegExp(`.(${extensions.join('|')})$`);
+    return new RegExp(`\.(${extensions.join('|')})$`); // eslint-disable-line no-useless-escape
   }
 
   // emit :: Any -> IO


### PR DESCRIPTION
Almost lost my mind trying to figure out why `.scss` were importing without adding a test…

Easy to see why this got missed, as eslint warns of a "useless" escape inside a template literal, but being a regex string, it has meaning.