### PR TITLE
style-loader: allow overriding options.test/modulesTest overrides with css modules enabled

### DIFF
--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -41,8 +41,7 @@ module.exports = (neutrino, opts = {}) => {
         hotUseId: `${options.hotUseId}${options.modulesSuffix}`,
         extractId: `${options.extractId}${options.modulesSuffix}`,
         css: {
-          modules: options.modules,
-          importLoaders: 1
+          modules: options.modules
         }
       })
     );

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -59,6 +59,7 @@ module.exports = (neutrino, opts = {}) => {
       },
       {
         loader: require.resolve('css-loader'),
+        options: options.css,
         useId: options.cssUseId
       },
       ...options.loaders

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -24,35 +24,28 @@ module.exports = (neutrino, opts = {}) => {
       }
     }
   }, opts);
-
-  Object.assign(options, {
-    test: (input) => {
-      const isCssModule = options.modulesTest.test(input);
-      const isRegularCss = options.test.test(input);
-
-      if (options.modules !== false && isCssModule) {
-        return false;
-      }
-
-      return isRegularCss;
-    }
-  });
-
-  const rules = [options];
+  const rules = [];
 
   if (options.modules) {
-    rules.push(merge(options, {
-      test: options.modulesTest,
-      ruleId: `${options.ruleId}${options.modulesSuffix}`,
-      styleUseId: `${options.styleUseId}${options.modulesSuffix}`,
-      cssUseId: `${options.cssUseId}${options.modulesSuffix}`,
-      hotUseId: `${options.hotUseId}${options.modulesSuffix}`,
-      extractId: `${options.extractId}${options.modulesSuffix}`,
-      css: {
-        modules: options.modules,
-        importLoaders: 1
-      }
-    }));
+    rules.push(
+      merge(options, {
+        exclude: options.modulesTest
+      }),
+      merge(options, {
+        test: options.modulesTest,
+        ruleId: `${options.ruleId}${options.modulesSuffix}`,
+        styleUseId: `${options.styleUseId}${options.modulesSuffix}`,
+        cssUseId: `${options.cssUseId}${options.modulesSuffix}`,
+        hotUseId: `${options.hotUseId}${options.modulesSuffix}`,
+        extractId: `${options.extractId}${options.modulesSuffix}`,
+        css: {
+          modules: options.modules,
+          importLoaders: 1
+        }
+      })
+    );
+  } else {
+    rules.push(options);
   }
 
   rules.forEach(options => {
@@ -83,6 +76,7 @@ module.exports = (neutrino, opts = {}) => {
     loaders.forEach(loader => {
       styleRule
         .test(options.test)
+        .when(options.exclude, rule => rule.exclude.add(options.exclude))
         .use(loader.useId)
           .loader(loader.loader)
           .when(loader.options, use => use.options(loader.options));

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -9,7 +9,9 @@ module.exports = (neutrino, opts = {}) => {
     ruleId: 'style',
     styleUseId: 'style',
     cssUseId: 'css',
-    css: { importLoaders: 0 },
+    css: {
+      importLoaders: opts.loaders ? opts.loaders.length : 0
+    },
     style: {},
     hot: true,
     hotUseId: 'hot',
@@ -57,9 +59,6 @@ module.exports = (neutrino, opts = {}) => {
       },
       {
         loader: require.resolve('css-loader'),
-        options: Object.assign(options.css, {
-          importLoaders: options.css.importLoaders + options.loaders.length
-        }),
         useId: options.cssUseId
       },
       ...options.loaders

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -2,6 +2,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
+  const modules = opts.modules || true;
+  const modulesTest = opts.modulesTest || neutrino.regexFromExtensions(['module.css']);
   const options = merge({
     test: neutrino.regexFromExtensions(['css']),
     ruleId: 'style',
@@ -11,9 +13,10 @@ module.exports = (neutrino, opts = {}) => {
     style: {},
     hot: true,
     hotUseId: 'hot',
-    modules: true,
+    modules,
+    modulesTest,
     modulesSuffix: '-modules',
-    modulesTest: neutrino.regexFromExtensions(['module.css']),
+    exclude: modules && modulesTest,
     loaders: [],
     extractId: 'extract',
     extract: {
@@ -24,15 +27,14 @@ module.exports = (neutrino, opts = {}) => {
       }
     }
   }, opts);
-  const rules = [];
+
+  const rules = [options];
 
   if (options.modules) {
     rules.push(
       merge(options, {
-        exclude: options.modulesTest
-      }),
-      merge(options, {
         test: options.modulesTest,
+        exclude: options.modulesExclude,
         ruleId: `${options.ruleId}${options.modulesSuffix}`,
         styleUseId: `${options.styleUseId}${options.modulesSuffix}`,
         cssUseId: `${options.cssUseId}${options.modulesSuffix}`,
@@ -44,9 +46,7 @@ module.exports = (neutrino, opts = {}) => {
         }
       })
     );
-  } else {
-    rules.push(options);
-  }
+  };
 
   rules.forEach(options => {
     const styleRule = neutrino.config.module.rule(options.ruleId);

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -2,20 +2,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
-  const cssTest = neutrino.regexFromExtensions(['css']);
-  const cssModulesTest = neutrino.regexFromExtensions(['module.css']);
-
   const options = merge({
-    test: (input) => {
-      const isCssModule = cssModulesTest.test(input);
-      const isRegularCss = cssTest.test(input);
-
-      if (opts.modules !== false && isCssModule) {
-        return false;
-      }
-
-      return isRegularCss;
-    },
+    test: neutrino.regexFromExtensions(['css']),
     ruleId: 'style',
     styleUseId: 'style',
     cssUseId: 'css',
@@ -25,7 +13,7 @@ module.exports = (neutrino, opts = {}) => {
     hotUseId: 'hot',
     modules: true,
     modulesSuffix: '-modules',
-    modulesTest: cssModulesTest,
+    modulesTest: neutrino.regexFromExtensions(['module.css']),
     loaders: [],
     extractId: 'extract',
     extract: {
@@ -36,6 +24,19 @@ module.exports = (neutrino, opts = {}) => {
       }
     }
   }, opts);
+
+  Object.assign(options, {
+    test: (input) => {
+      const isCssModule = options.modulesTest.test(input);
+      const isRegularCss = options.test.test(input);
+
+      if (options.modules !== false && isCssModule) {
+        return false;
+      }
+
+      return isRegularCss;
+    }
+  });
 
   const rules = [options];
 


### PR DESCRIPTION
Fixes #603

This PR uses `rule.exclude`, instead of passing `rule.test` a function.
This will allows users to change the tests, while still enabling css modules support:

```
{
        test: /\.s?css$/,
        modulesTest: /\.module\.s?css$/,
}
```