### PR TITLE
stylelint middleware

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -53,6 +53,7 @@
   * [start-server](./packages/start-server/README.md)
   * [style-loader](./packages/style-loader/README.md)
   * [style-minify](./packages/style-minify/README.md)
+  * [stylelint](./packages/stylelint/README.md)
 * [v6 Documentation](https://github.com/mozilla-neutrino/neutrino-dev/tree/docs-v6/docs)
 * [v5 Documentation](https://github.com/mozilla-neutrino/neutrino-dev/tree/docs-v5/docs)
 * [v4 Documentation](https://github.com/mozilla-neutrino/neutrino-dev/tree/docs-v4/docs)

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -1,0 +1,65 @@
+# Neutrino stylelint Middleware
+
+`@neutrinojs/stylelint` is Neutrino middleware for linting styles using stylelint.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
+
+## Requirements
+
+- Node.js v6 LTS, v8, v9
+- Yarn v1.2.1+, or npm v5.4+
+- Neutrino v8
+
+## Installation
+
+`@neutrinojs/stylelint` can be installed via the Yarn or npm clients.
+
+#### Yarn
+
+```bash
+❯ yarn add @neutrinojs/stylelint
+```
+
+#### npm
+
+```bash
+❯ npm install --save @neutrinojs/stylelint
+```
+
+## Usage
+
+`@neutrinojs/stylelint` can be consumed from the Neutrino API, middleware, or presets. Require this package
+and plug it into Neutrino:
+
+```js
+// Using function middleware format
+const stylelint = require('@neutrinojs/stylelint');
+
+// Usage shows default values
+neutrino.use(stylelint, {
+  pluginId: 'stylelint',
+  files: '**/*.+(css|scss|sass|less)',
+  context: neutrino.options.source,
+  failOnError: neutrino.options.command !== 'start'
+});
+```
+Options are passed to `stylelint-webpack-plugin`. See the [stylelint Node API](https://stylelint.io/user-guide/node-api/#options) for all available options.
+
+## Information
+
+By default this middleware will show errors and warnings in the console during development, and will cause a failure when
+creating a build bundle.
+
+## Contributing
+
+This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
+containing all resources for developing Neutrino and its core presets and middleware. Follow the
+[contributing guide](https://neutrino.js.org/contributing) for details.
+
+[npm-image]: https://img.shields.io/npm/v/@neutrinojs/stylelint.svg
+[npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/stylelint.svg
+[npm-url]: https://npmjs.org/package/@neutrinojs/stylelint
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -52,6 +52,75 @@ Options are passed to `stylelint-webpack-plugin`. See the [stylelint Node API](h
 By default this middleware will show errors and warnings in the console during development, and will cause a failure when
 creating a build bundle.
 
+## stylelint CLI
+
+_This is the recommended way to perform a one-off lint in a Neutrino project._
+
+You can also have Neutrino invoke stylelint for you if you wish to perform a one-time lint. This avoids needing to install
+stylelint manually, creating a `.stylelint.js` file, or having to manage includes and ignores. As long as the stylelint
+middleware is loaded, you have access to a command to run stylelint from the command line.
+
+This middleware registers a command named `stylelint` which programmatically calls stylelint and prints the results to
+the console.
+
+```bash
+❯ neutrino stylelint
+```
+
+```bash
+❯ neutrino stylelint --fix
+```
+
+## stylelintrc Config
+
+If you cannot or do not wish to use Neutrino to execute one-off linting, you can still use stylelint manually.
+
+`@neutrinojs/stylelint` also provides a method for getting the stylelint configuration suitable for use in a stylelintrc
+file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
+editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
+providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
+merged together for your development environment, without the need for copying, duplication, or loss of organization and
+separation.
+
+This middleware registers another command named `stylelintrc` which returns a stylelint configuration object suitable for
+consumption by the stylelint CLI. Use the Neutrino API's `call` method to invoke this command:
+
+_Example: Create a .stylelintrc.js file in the root of the project, using `.neutrinorc.js` middleware._
+
+```js
+// .stylelintrc.js
+const { Neutrino } = require('neutrino');
+
+// Specify middleware to Neutrino prior to calling stylelintrc.
+// Even if using .neutrinorc.js, you must specify it when using
+// the API
+module.exports = Neutrino()
+  .use('.neutrinorc.js')
+  .call('stylelintrc');
+```
+
+_Example: Create a .stylelintrc.js file in the root of the project, using specified middleware._
+
+```js
+// .stylelintrc.js
+const { Neutrino } = require('neutrino');
+
+module.exports = Neutrino()
+  .use('@neutrinojs/stylelint', {
+    config: {
+      rules: { 'max-empty-lines': 2 }
+    }
+  })
+  .call('stylelint');
+```
+
+If you are able, only use a `.stylelint.js` file for editor hints, and use the Neutrino `stylelint` command for one-off linting
+or fixes. **Loading stylelint configuration from `.stylelint.js` that is not `.neutrinorc.js` or uses configuration that
+differs from `.neutrinorc.js` could lead to unintended consequences such as linting not failing or passing when expected,
+or working differently when running different commands. Closely evaluate whether you _actually_ need to make these rule
+changes in `.stylelint.js` over `.neutrinorc.js`.**
+
 ## Contributing
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo

--- a/packages/stylelint/.npmignore
+++ b/packages/stylelint/.npmignore
@@ -1,0 +1,2 @@
+/test/
+eslintrc.js

--- a/packages/stylelint/.npmignore
+++ b/packages/stylelint/.npmignore
@@ -1,2 +1,1 @@
 /test/
-eslintrc.js

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -1,6 +1,6 @@
-# Neutrino ESLint Middleware
+# Neutrino stylelint Middleware
 
-`@neutrinojs/eslint` is Neutrino middleware for linting source code using ESLint and eslint-loader.
+`@neutrinojs/stylelint` is Neutrino middleware for linting styles using stylelint.
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][npm-downloads]][npm-url]
@@ -14,185 +14,49 @@
 
 ## Installation
 
-`@neutrinojs/eslint` can be installed via the Yarn or npm clients.
+`@neutrinojs/stylelint` can be installed via the Yarn or npm clients.
 
 #### Yarn
 
 ```bash
-❯ yarn add @neutrinojs/eslint
+❯ yarn add @neutrinojs/stylelint
 ```
 
 #### npm
 
 ```bash
-❯ npm install --save @neutrinojs/eslint
+❯ npm install --save @neutrinojs/stylelint
 ```
 
 ## Usage
 
-`@neutrinojs/eslint` can be consumed from the Neutrino API, middleware, or presets. Require this package
+`@neutrinojs/stylelint` can be consumed from the Neutrino API, middleware, or presets. Require this package
 and plug it into Neutrino:
 
 ```js
 // Using function middleware format
-const eslint = require('@neutrinojs/eslint');
+const stylelint = require('@neutrinojs/stylelint');
 
 // Usage shows default values
-neutrino.use(eslint, {
-  test: /\.(js|jsx)$/,
-  include: [], /* Should specify either include or exclude */
-  exclude: [], /* Should specify either include or exclude */
-  eslint: {
-    cwd: neutrino.options.root,
-    useEslintrc: false,
-    root: true,
-    extensions: neutrino.options.extensions,
-    plugins: ['babel'],
-    baseConfig: {},
-    envs: ['es6'],
-    parser: 'babel-eslint',
-    parserOptions: {
-      ecmaVersion: 2017,
-      sourceType: 'module',
-      ecmaFeatures: {
-        objectLiteralDuplicateProperties: false,
-        generators: true,
-        impliedStrict: true
-      }
-    },
-    settings: {},
-    globals: ['process'],
-    rules: {}
+neutrino.use(stylelint, {
+  pluginId: 'stylelint',
+  plugin: {
+    files: '**/*.+(css|scss|sass|less)',
+    context: neutrino.options.source,
+    failOnError: neutrino.options.command !== 'start'
   }
 });
 ```
 
-- `test`: Test which files should be linted.
-- `include`: An array of paths to include in linting. Maps to webpack's [`Rule.include`](https://webpack.js.org/configuration/module/#rule-include)
-- `exclude`: An array of paths to exclude from linting. Maps to webpack's [`Rule.exclude`](https://webpack.js.org/configuration/module/#rule-exclude)
-- `eslint`: An ESLint CLIEngine configuration object for configuring ESLint. Use this to configure rules, plugins, and other [ESLint options](http://eslint.org/docs/user-guide/configuring).
-
-## Customization
-
-`@neutrinojs/eslint` creates some conventions to make overriding the configuration easier once you are ready to
-make changes.
-
-### Rules
-
-The following is a list of rules and their identifiers which can be overridden:
-
-| Name | Description | Environments and Commands |
-| --- | --- | --- |
-| `lint` | By default, lints JS and JSX files from included directories using ESLint. Contains a single loader named `eslint`. | all |
+- `stylelint`: An stylelint configuration object.
+  - Use this to configure rules, plugins, and other [stylelint options](https://stylelint.io/user-guide/configuration).
+  - This option is _not set_ by default, causing stylelint to search for a [config file](https://stylelint.io/user-guide/configuration/#loading-the-configuration-object).
+- `plugin`: Options passed to `stylelint-webpack-plugin`. See the [stylelint Node API](https://stylelint.io/user-guide/node-api/#options) for all available options.
 
 ## Information
 
 By default this middleware will show errors and warnings in the console during development, and will cause a failure when
 creating a build bundle.
-
----
-
-If you want your preset or middleware to also extend from another **ESLint configuration or preset** that you have made
-a dependency, you must use `baseConfig.extends` rather than just `extends`. This is a limitation of ESLint, not this
-middleware.
-
----
-
-This middleware only configures a target environment for `es6`, leaving other build middleware free to add their own
-target environments. If your middleware puts restrictions on which environments it is capable of running, please
-document that clearly in your middleware.
-
-## eslint CLI
-
-_This is the recommended way to perform a one-off lint in a Neutrino project._
-
-You can also have Neutrino invoke ESLint for you if you wish to perform a one-time lint. This avoids needing to install
-ESLint manually, creating a `.eslintrc.js` file, or having to manage includes and ignores. As long as the ESLint
-middleware is loaded, you have access to a command to run ESLint from the command line.
-
-This middleware registers a command named `lint` which programmatically calls ESLint and prints the results to
-the console.
-
-```bash
-❯ neutrino lint
-```
-
-```bash
-❯ neutrino lint --fix
-```
-
-## eslintrc Config
-
-If you cannot or do not wish to use Neutrino to execute one-off linting, you can still use ESLint manually.
-
-`@neutrinojs/eslint` also provides a method for getting the ESLint configuration suitable for use in an eslintrc
-file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
-editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
-middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
-providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
-merged together for your development environment, without the need for copying, duplication, or loss of organization and
-separation.
-
-This middleware registers another command named `eslintrc` which returns an ESLint configuration object suitable for
-consumption by the ESLint CLI. Use the Neutrino API's `call` method to invoke this command:
-
-_Example: Create a .eslintrc.js file in the root of the project, using `.neutrinorc.js` middleware._
-
-```js
-// .eslintrc.js
-const { Neutrino } = require('neutrino');
-
-// Specify middleware to Neutrino prior to calling eslintrc.
-// Even if using .neutrinorc.js, you must specify it when using
-// the API
-module.exports = Neutrino()
-  .use('.neutrinorc.js')
-  .call('eslintrc');
-```
-
-_Example: Create a .eslintrc.js file in the root of the project, using specified middleware._
-
-```js
-// .eslintrc.js
-const { Neutrino } = require('neutrino');
-
-module.exports = Neutrino()
-  .use('@neutrinojs/eslint', {
-    eslint: {
-      rules: { semi: 'off' }
-    }
-  })
-  .call('eslintrc');
-```
-
-If you are able, only use a `.eslintrc.js` file for editor hints, and use the Neutrino `lint` command for one-off linting
-or fixes. **Loading ESLint configuration from `.eslintrc.js` that is not `.neutrinorc.js` or uses configuration that
-differs from `.neutrinorc.js` could lead to unintended consequences such as linting not failing or passing when expected,
-or working differently when running different commands. Closely evaluate whether you _actually_ need to make these rule
-changes in `.eslintrc.js` over `.neutrinorc.js`.**
-
-Projects may face a problem when their editor or IDE lints all files and highlights errors that were normally excluded
-from source, i.e. Neutrino's `include` and `exclude` options. This is because the ESLint CLI does not have a way to
-specify included and excluded files from configuration. If you still wish to use ESLint's CLI for linting, consider
-setting [CLI flags](http://eslint.org/docs/user-guide/command-line-interface#options) or using an
-[eslintignore](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) to choose which files to
-include or exclude from linting.
-
-Unfortunately ESLint does not provide the possibility to configure ignored paths from Neutrino configuration and exclude them
-from linting. Projects authors should define this manually in their project root directory in a `.eslintignore` file. This
-is one of the main reasons to prefer using the `lint` CLI command with this middleware, as it avoids a lot of manual
-configuration and boilerplate.
-
-`.eslintignore` file:
-
-```
-/build
-/*.*
-```
-
-ESLint will exclude built files and any files in the root directory (e.g. custom Neutrino configuration) but `src` and
-`test` folders will be still checked. `node_modules` are ignored by default in ESLint. More information can be found
-in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).
 
 ## Contributing
 
@@ -200,8 +64,8 @@ This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrin
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
 [contributing guide](https://neutrino.js.org/contributing) for details.
 
-[npm-image]: https://img.shields.io/npm/v/@neutrinojs/eslint.svg
-[npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/eslint.svg
-[npm-url]: https://npmjs.org/package/@neutrinojs/eslint
+[npm-image]: https://img.shields.io/npm/v/@neutrinojs/stylelint.svg
+[npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/stylelint.svg
+[npm-url]: https://npmjs.org/package/@neutrinojs/stylelint
 [spectrum-image]: https://withspectrum.github.io/badge/badge.svg
 [spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -1,0 +1,207 @@
+# Neutrino ESLint Middleware
+
+`@neutrinojs/eslint` is Neutrino middleware for linting source code using ESLint and eslint-loader.
+
+[![NPM version][npm-image]][npm-url]
+[![NPM downloads][npm-downloads]][npm-url]
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
+
+## Requirements
+
+- Node.js v6.10+
+- Yarn or npm client
+- Neutrino v8
+
+## Installation
+
+`@neutrinojs/eslint` can be installed via the Yarn or npm clients.
+
+#### Yarn
+
+```bash
+❯ yarn add @neutrinojs/eslint
+```
+
+#### npm
+
+```bash
+❯ npm install --save @neutrinojs/eslint
+```
+
+## Usage
+
+`@neutrinojs/eslint` can be consumed from the Neutrino API, middleware, or presets. Require this package
+and plug it into Neutrino:
+
+```js
+// Using function middleware format
+const eslint = require('@neutrinojs/eslint');
+
+// Usage shows default values
+neutrino.use(eslint, {
+  test: /\.(js|jsx)$/,
+  include: [], /* Should specify either include or exclude */
+  exclude: [], /* Should specify either include or exclude */
+  eslint: {
+    cwd: neutrino.options.root,
+    useEslintrc: false,
+    root: true,
+    extensions: neutrino.options.extensions,
+    plugins: ['babel'],
+    baseConfig: {},
+    envs: ['es6'],
+    parser: 'babel-eslint',
+    parserOptions: {
+      ecmaVersion: 2017,
+      sourceType: 'module',
+      ecmaFeatures: {
+        objectLiteralDuplicateProperties: false,
+        generators: true,
+        impliedStrict: true
+      }
+    },
+    settings: {},
+    globals: ['process'],
+    rules: {}
+  }
+});
+```
+
+- `test`: Test which files should be linted.
+- `include`: An array of paths to include in linting. Maps to webpack's [`Rule.include`](https://webpack.js.org/configuration/module/#rule-include)
+- `exclude`: An array of paths to exclude from linting. Maps to webpack's [`Rule.exclude`](https://webpack.js.org/configuration/module/#rule-exclude)
+- `eslint`: An ESLint CLIEngine configuration object for configuring ESLint. Use this to configure rules, plugins, and other [ESLint options](http://eslint.org/docs/user-guide/configuring).
+
+## Customization
+
+`@neutrinojs/eslint` creates some conventions to make overriding the configuration easier once you are ready to
+make changes.
+
+### Rules
+
+The following is a list of rules and their identifiers which can be overridden:
+
+| Name | Description | Environments and Commands |
+| --- | --- | --- |
+| `lint` | By default, lints JS and JSX files from included directories using ESLint. Contains a single loader named `eslint`. | all |
+
+## Information
+
+By default this middleware will show errors and warnings in the console during development, and will cause a failure when
+creating a build bundle.
+
+---
+
+If you want your preset or middleware to also extend from another **ESLint configuration or preset** that you have made
+a dependency, you must use `baseConfig.extends` rather than just `extends`. This is a limitation of ESLint, not this
+middleware.
+
+---
+
+This middleware only configures a target environment for `es6`, leaving other build middleware free to add their own
+target environments. If your middleware puts restrictions on which environments it is capable of running, please
+document that clearly in your middleware.
+
+## eslint CLI
+
+_This is the recommended way to perform a one-off lint in a Neutrino project._
+
+You can also have Neutrino invoke ESLint for you if you wish to perform a one-time lint. This avoids needing to install
+ESLint manually, creating a `.eslintrc.js` file, or having to manage includes and ignores. As long as the ESLint
+middleware is loaded, you have access to a command to run ESLint from the command line.
+
+This middleware registers a command named `lint` which programmatically calls ESLint and prints the results to
+the console.
+
+```bash
+❯ neutrino lint
+```
+
+```bash
+❯ neutrino lint --fix
+```
+
+## eslintrc Config
+
+If you cannot or do not wish to use Neutrino to execute one-off linting, you can still use ESLint manually.
+
+`@neutrinojs/eslint` also provides a method for getting the ESLint configuration suitable for use in an eslintrc
+file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
+editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
+providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
+merged together for your development environment, without the need for copying, duplication, or loss of organization and
+separation.
+
+This middleware registers another command named `eslintrc` which returns an ESLint configuration object suitable for
+consumption by the ESLint CLI. Use the Neutrino API's `call` method to invoke this command:
+
+_Example: Create a .eslintrc.js file in the root of the project, using `.neutrinorc.js` middleware._
+
+```js
+// .eslintrc.js
+const { Neutrino } = require('neutrino');
+
+// Specify middleware to Neutrino prior to calling eslintrc.
+// Even if using .neutrinorc.js, you must specify it when using
+// the API
+module.exports = Neutrino()
+  .use('.neutrinorc.js')
+  .call('eslintrc');
+```
+
+_Example: Create a .eslintrc.js file in the root of the project, using specified middleware._
+
+```js
+// .eslintrc.js
+const { Neutrino } = require('neutrino');
+
+module.exports = Neutrino()
+  .use('@neutrinojs/eslint', {
+    eslint: {
+      rules: { semi: 'off' }
+    }
+  })
+  .call('eslintrc');
+```
+
+If you are able, only use a `.eslintrc.js` file for editor hints, and use the Neutrino `lint` command for one-off linting
+or fixes. **Loading ESLint configuration from `.eslintrc.js` that is not `.neutrinorc.js` or uses configuration that
+differs from `.neutrinorc.js` could lead to unintended consequences such as linting not failing or passing when expected,
+or working differently when running different commands. Closely evaluate whether you _actually_ need to make these rule
+changes in `.eslintrc.js` over `.neutrinorc.js`.**
+
+Projects may face a problem when their editor or IDE lints all files and highlights errors that were normally excluded
+from source, i.e. Neutrino's `include` and `exclude` options. This is because the ESLint CLI does not have a way to
+specify included and excluded files from configuration. If you still wish to use ESLint's CLI for linting, consider
+setting [CLI flags](http://eslint.org/docs/user-guide/command-line-interface#options) or using an
+[eslintignore](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) to choose which files to
+include or exclude from linting.
+
+Unfortunately ESLint does not provide the possibility to configure ignored paths from Neutrino configuration and exclude them
+from linting. Projects authors should define this manually in their project root directory in a `.eslintignore` file. This
+is one of the main reasons to prefer using the `lint` CLI command with this middleware, as it avoids a lot of manual
+configuration and boilerplate.
+
+`.eslintignore` file:
+
+```
+/build
+/*.*
+```
+
+ESLint will exclude built files and any files in the root directory (e.g. custom Neutrino configuration) but `src` and
+`test` folders will be still checked. `node_modules` are ignored by default in ESLint. More information can be found
+in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).
+
+## Contributing
+
+This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
+containing all resources for developing Neutrino and its core presets and middleware. Follow the
+[contributing guide](https://neutrino.js.org/contributing) for details.
+
+[npm-image]: https://img.shields.io/npm/v/@neutrinojs/eslint.svg
+[npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/eslint.svg
+[npm-url]: https://npmjs.org/package/@neutrinojs/eslint
+[spectrum-image]: https://withspectrum.github.io/badge/badge.svg
+[spectrum-url]: https://spectrum.chat/neutrino

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -40,18 +40,12 @@ const stylelint = require('@neutrinojs/stylelint');
 // Usage shows default values
 neutrino.use(stylelint, {
   pluginId: 'stylelint',
-  plugin: {
-    files: '**/*.+(css|scss|sass|less)',
-    context: neutrino.options.source,
-    failOnError: neutrino.options.command !== 'start'
-  }
+  files: '**/*.+(css|scss|sass|less)',
+  context: neutrino.options.source,
+  failOnError: neutrino.options.command !== 'start'
 });
 ```
-
-- `stylelint`: An stylelint configuration object.
-  - Use this to configure rules, plugins, and other [stylelint options](https://stylelint.io/user-guide/configuration).
-  - This option is _not set_ by default, causing stylelint to search for a [config file](https://stylelint.io/user-guide/configuration/#loading-the-configuration-object).
-- `plugin`: Options passed to `stylelint-webpack-plugin`. See the [stylelint Node API](https://stylelint.io/user-guide/node-api/#options) for all available options.
+Options are passed to `stylelint-webpack-plugin`. See the [stylelint Node API](https://stylelint.io/user-guide/node-api/#options) for all available options.
 
 ## Information
 

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -8,8 +8,8 @@
 
 ## Requirements
 
-- Node.js v6.10+
-- Yarn or npm client
+- Node.js v6 LTS, v8, v9
+- Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 
 ## Installation

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -52,6 +52,75 @@ Options are passed to `stylelint-webpack-plugin`. See the [stylelint Node API](h
 By default this middleware will show errors and warnings in the console during development, and will cause a failure when
 creating a build bundle.
 
+## stylelint CLI
+
+_This is the recommended way to perform a one-off lint in a Neutrino project._
+
+You can also have Neutrino invoke stylelint for you if you wish to perform a one-time lint. This avoids needing to install
+stylelint manually, creating a `.stylelint.js` file, or having to manage includes and ignores. As long as the stylelint
+middleware is loaded, you have access to a command to run stylelint from the command line.
+
+This middleware registers a command named `stylelint` which programmatically calls stylelint and prints the results to
+the console.
+
+```bash
+❯ neutrino stylelint
+```
+
+```bash
+❯ neutrino stylelint --fix
+```
+
+## stylelintrc Config
+
+If you cannot or do not wish to use Neutrino to execute one-off linting, you can still use stylelint manually.
+
+`@neutrinojs/stylelint` also provides a method for getting the stylelint configuration suitable for use in a stylelintrc
+file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
+editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
+providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
+merged together for your development environment, without the need for copying, duplication, or loss of organization and
+separation.
+
+This middleware registers another command named `stylelintrc` which returns a stylelint configuration object suitable for
+consumption by the stylelint CLI. Use the Neutrino API's `call` method to invoke this command:
+
+_Example: Create a .stylelintrc.js file in the root of the project, using `.neutrinorc.js` middleware._
+
+```js
+// .stylelintrc.js
+const { Neutrino } = require('neutrino');
+
+// Specify middleware to Neutrino prior to calling stylelintrc.
+// Even if using .neutrinorc.js, you must specify it when using
+// the API
+module.exports = Neutrino()
+  .use('.neutrinorc.js')
+  .call('stylelintrc');
+```
+
+_Example: Create a .stylelintrc.js file in the root of the project, using specified middleware._
+
+```js
+// .stylelintrc.js
+const { Neutrino } = require('neutrino');
+
+module.exports = Neutrino()
+  .use('@neutrinojs/stylelint', {
+    config: {
+      rules: { 'max-empty-lines': 2 }
+    }
+  })
+  .call('stylelint');
+```
+
+If you are able, only use a `.stylelint.js` file for editor hints, and use the Neutrino `stylelint` command for one-off linting
+or fixes. **Loading stylelint configuration from `.stylelint.js` that is not `.neutrinorc.js` or uses configuration that
+differs from `.neutrinorc.js` could lead to unintended consequences such as linting not failing or passing when expected,
+or working differently when running different commands. Closely evaluate whether you _actually_ need to make these rule
+changes in `.stylelint.js` over `.neutrinorc.js`.**
+
 ## Contributing
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -1,29 +1,29 @@
 const merge = require('deepmerge');
 const StylelintPlugin = require('stylelint-webpack-plugin');
 
-const getStylelintRcConfig = config => config.plugin('stylelint').get('args')[0].config;
-
 module.exports = (neutrino, opts = {}) => {
-  const getTestForRules = (rules) => rules
-    .map(ruleId => neutrino.config.module.rule(ruleId).get('test'))
-    .filter(Boolean);
-
   const options = merge({
-    pluginid: 'stylelint',
+    pluginId: 'stylelint',
     plugin: {
-      config: neutrino.config.module.rule('lint').use('stylelint').get('options'),
-      files: getTestForRules(['style']),
-      context: neutrino.options.source
-      // temporary fix for HMR issues with stylelint errors
-      // (see JaKXz/stylelint-webpack-plugin#24)
-      // failOnError: false
+      files: '**/*.+(css|scss|sass|less)',
+      context: neutrino.options.source,
+      failOnError: neutrino.options.command !== 'start',
+      quiet: neutrino.options.command === 'start'
     }
   }, opts);
+
+  if (options.stylelint) {
+    options.plugin = merge(options.plugin, {
+      config: options.stylelint
+    })
+  }
+
+  const getStylelintRcConfig = config => config.plugin(options.pluginId).get('args')[0].config;
 
   neutrino.register(
     'stylelintrc',
     () => getStylelintRcConfig(neutrino.config),
-    'Return an object of accumulated ESLint configuration suitable for use by .eslintrc.js'
+    'Return an object of accumulated stylelint configuration suitable for use by .stylelintrc.js'
   );
 
   neutrino.config

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -35,20 +35,6 @@ module.exports = (neutrino, opts = {}) => {
     'Return an object of accumulated stylelint configuration suitable for use by .stylelintrc.js'
   );
 
-  neutrino.register(
-    'lint',
-    (...args) => {
-      const lintCommand = neutrino.commands.lint;
-
-      if (lintCommand) {
-        lintCommand(...args);
-      }
-
-      neutrino.commands.stylelint(...args);
-    },
-    'Perform a one-time lint using stylelint. Apply available automatic fixes with --fix'
-  );
-
   neutrino.config
     .plugin(options.pluginId)
     .use(StylelintPlugin, [options]);

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -1,0 +1,32 @@
+const merge = require('deepmerge');
+const StylelintPlugin = require('stylelint-webpack-plugin');
+
+const getStylelintRcConfig = config => config.plugin('stylelint').get('args')[0].config;
+
+module.exports = (neutrino, opts = {}) => {
+  const getTestForRules = (rules) => rules
+    .map(ruleId => neutrino.config.module.rule(ruleId).get('test'))
+    .filter(Boolean);
+
+  const options = merge({
+    pluginid: 'stylelint',
+    plugin: {
+      config: neutrino.config.module.rule('lint').use('stylelint').get('options'),
+      files: getTestForRules(['style']),
+      context: neutrino.options.source
+      // temporary fix for HMR issues with stylelint errors
+      // (see JaKXz/stylelint-webpack-plugin#24)
+      // failOnError: false
+    }
+  }, opts);
+
+  neutrino.register(
+    'stylelintrc',
+    () => getStylelintRcConfig(neutrino.config),
+    'Return an object of accumulated ESLint configuration suitable for use by .eslintrc.js'
+  );
+
+  neutrino.config
+    .plugin(options.pluginId)
+    .use(StylelintPlugin, [options.plugin]);
+};

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -24,7 +24,9 @@ module.exports = (neutrino, opts = {}) => {
       const files = join(options.context, options.files);
 
       return lint(merge(options, { fix, files }))
-        .then(result => Promise[result.errored ? 'reject' : 'resolve'](result.output));
+        .then(result => result.errored ?
+          Promise.reject(result.output) :
+          Promise.resolve(result.output));
     },
     'Perform a one-time lint using stylelint. Apply available automatic fixes with --fix'
   );

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -1,7 +1,7 @@
 const merge = require('deepmerge');
 const { join } = require('path');
 const StylelintPlugin = require('stylelint-webpack-plugin');
-const { lint } = require('stylelint');
+const { lint, formatters } = require('stylelint');
 
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
@@ -10,7 +10,7 @@ module.exports = (neutrino, opts = {}) => {
     context: neutrino.options.source,
     failOnError: neutrino.options.command !== 'start',
     quiet: neutrino.options.command === 'start',
-    formatter: 'string'
+    formatter: formatters.string
   }, opts);
 
   const getStylelintRcConfig = config => config

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -6,6 +6,7 @@ const { lint, formatters } = require('stylelint');
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
     pluginId: 'stylelint',
+    configBasedir: neutrino.options.root,
     files: '**/*.+(css|scss|sass|less)',
     context: neutrino.options.source,
     formatter: formatters.string

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -8,8 +8,6 @@ module.exports = (neutrino, opts = {}) => {
     pluginId: 'stylelint',
     files: '**/*.+(css|scss|sass|less)',
     context: neutrino.options.source,
-    failOnError: neutrino.options.command !== 'start',
-    quiet: neutrino.options.command === 'start',
     formatter: formatters.string
   }, opts);
 

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@neutrinojs/stylelint",
+  "version": "8.0.11",
+  "description": "Neutrino middleware for linting styles with stylelint",
+  "main": "index.js",
+  "keywords": [
+    "neutrino",
+    "neutrino-middleware",
+    "lint",
+    "stylelint"
+  ],
+  "author": "Tim Kelty <timkelty@gmail.com>",
+  "license": "MPL-2.0",
+  "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/stylelint",
+  "homepage": "https://neutrino.js.org",
+  "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "deepmerge": "^1.5.2",
+    "stylelint": "^8.0.0",
+    "stylelint-webpack-plugin": "^0.9.0"
+  },
+  "peerDependencies": {
+    "neutrino": "^8.0.0"
+  }
+}

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -10,6 +10,9 @@
     "stylelint"
   ],
   "author": "Tim Kelty <timkelty@gmail.com>",
+  "contributors": [
+    "Capi Etheriel <barraponto@gmail.com> (https://barraponto.blog.br)"
+  ],
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/stylelint",
   "homepage": "https://neutrino.js.org",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -20,6 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": "^6.9.0 || ^8 || >=9",
+    "npm": ">=5.4.0",
+    "yarn": ">=1.2.1"
+  },
   "dependencies": {
     "deepmerge": "^1.5.2",
     "stylelint": "^8.0.0",

--- a/packages/stylelint/test/middleware_test.js
+++ b/packages/stylelint/test/middleware_test.js
@@ -33,5 +33,5 @@ test('instantiates with options', t => {
 });
 
 test('exposes stylelintrc config', t => {
-  t.is(typeof Neutrino().use(mw()).call('stylelintrc'), 'object');
+  t.is(typeof Neutrino().use(mw(), options).call('stylelintrc'), 'object');
 });

--- a/packages/stylelint/test/middleware_test.js
+++ b/packages/stylelint/test/middleware_test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { Neutrino } from 'neutrino';
 
 const mw = () => require('..');
-const options = { eslint: { rules: { semi: false } } };
+const options = { stylelint: { rules: { 'rule-empty-line-before': true } } };
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -32,14 +32,6 @@ test('instantiates with options', t => {
   t.notThrows(() => api.config.toConfig());
 });
 
-test('exposes lint command', t => {
-  const api = Neutrino();
-
-  api.use(mw());
-
-  t.is(typeof api.commands.lint, 'function');
-});
-
-test('exposes eslintrc config', t => {
-  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
+test('exposes stylelintrc config', t => {
+  t.is(typeof Neutrino().use(mw()).call('stylelintrc'), 'object');
 });

--- a/packages/stylelint/test/middleware_test.js
+++ b/packages/stylelint/test/middleware_test.js
@@ -1,0 +1,45 @@
+import test from 'ava';
+import { Neutrino } from 'neutrino';
+
+const mw = () => require('..');
+const options = { eslint: { rules: { semi: false } } };
+
+test('loads middleware', t => {
+  t.notThrows(mw);
+});
+
+test('uses middleware', t => {
+  t.notThrows(() => Neutrino().use(mw()));
+});
+
+test('uses with options', t => {
+  t.notThrows(() => Neutrino().use(mw(), options));
+});
+
+test('instantiates', t => {
+  const api = Neutrino();
+
+  api.use(mw());
+
+  t.notThrows(() => api.config.toConfig());
+});
+
+test('instantiates with options', t => {
+  const api = Neutrino();
+
+  api.use(mw(), options);
+
+  t.notThrows(() => api.config.toConfig());
+});
+
+test('exposes lint command', t => {
+  const api = Neutrino();
+
+  api.use(mw());
+
+  t.is(typeof api.commands.lint, 'function');
+});
+
+test('exposes eslintrc config', t => {
+  t.is(typeof Neutrino().use(mw()).call('eslintrc'), 'object');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,10 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-iterate@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.1.tgz#865bf7f8af39d6b0982c60902914ac76bc0108f6"
+
 array-slice@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
@@ -538,6 +542,17 @@ autoprefixer@^6.3.1:
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@^7.1.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.2.tgz#082293b964be00602efacc59aa4aa7df5158bb6e"
+  dependencies:
+    browserslist "^2.10.0"
+    caniuse-lite "^1.0.30000780"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^6.0.14"
     postcss-value-parser "^3.2.3"
 
 ava-init@^0.2.0:
@@ -1501,6 +1516,10 @@ backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
+bail@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.2.tgz#f7d6c1731630a9f9f0d4d35ed1f962e2074a1764"
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -1796,6 +1815,13 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000744"
     electron-to-chromium "^1.3.24"
 
+browserslist@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
+  dependencies:
+    caniuse-lite "^1.0.30000780"
+    electron-to-chromium "^1.3.28"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1999,6 +2025,10 @@ caniuse-lite@^1.0.30000744:
   version "1.0.30000750"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000750.tgz#38ad19aa4c6d88da38e8900d3666b4e3bbb65c22"
 
+caniuse-lite@^1.0.30000780:
+  version "1.0.30000783"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz#9b5499fb1b503d2345d12aa6b8612852f4276ffd"
+
 capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
@@ -2019,6 +2049,10 @@ caw@^1.0.1:
     is-obj "^1.0.0"
     object-assign "^3.0.0"
     tunnel-agent "^0.4.0"
+
+ccount@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -2079,6 +2113,22 @@ change-case@^3.0.1:
 char-spinner@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/char-spinner/-/char-spinner-1.0.1.tgz#e6ea67bd247e107112983b7ab0479ed362800081"
+
+character-entities-html4@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
+
+character-entities-legacy@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz#f40779df1a101872bb510a3d295e1fccf147202f"
+
+character-entities@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.1.tgz#f76871be5ef66ddb7f8f8e3478ecc374c27d6dca"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz#942835f750e4ec61a308e60c2ef8cc1011202efc"
 
 cheerio@0.22.0:
   version "0.22.0"
@@ -2247,6 +2297,13 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
+clone-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.0.tgz#eae0a2413f55c0942f818c229fefce845d7f3b1c"
+  dependencies:
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -2325,6 +2382,10 @@ codecov@^3.0.0:
     argv "0.0.2"
     request "2.81.0"
     urlgrey "0.4.4"
+
+collapse-white-space@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.0"
@@ -3117,7 +3178,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
+debug@3.1.0, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -3349,6 +3410,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -3468,7 +3536,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dot-prop@^4.1.0:
+dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
@@ -3555,6 +3623,10 @@ ejs@^2.3.1, ejs@^2.3.4:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.24:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
+
+electron-to-chromium@^1.3.28:
+  version "1.3.28"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -4147,6 +4219,12 @@ execa@^0.8.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  dependencies:
+    clone-regexp "^1.0.0"
 
 executable@^1.0.0:
   version "1.1.0"
@@ -5065,6 +5143,21 @@ globby@^6.0.0, globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+
 glogg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.0.tgz#7fe0f199f57ac906cf512feead8f90ee4a284fc5"
@@ -5466,7 +5559,7 @@ html-webpack-template@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/html-webpack-template/-/html-webpack-template-6.1.0.tgz#d96ffdab53131adfa672f981988607807966ad97"
 
-htmlparser2@^3.9.1:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -5624,7 +5717,7 @@ ignore@^3.3.3:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.6.tgz#b6f3196b38ed92f0c86e52f6f79b7fc4c8266c8d"
 
-ignore@^3.3.6:
+ignore@^3.3.5, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -5868,6 +5961,21 @@ is-absolute@^0.1.5:
   dependencies:
     is-relative "^0.1.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.1.tgz#c77079cc91d4efac775be1034bf2d243f95e6f08"
+
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-array-buffer-x@^1.0.13:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz#4b0b10427b64aa3437767adf4fc07702c59b2371"
@@ -5888,7 +5996,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -5921,6 +6029,10 @@ is-cwebp-readable@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.1.tgz#f5fb6a94996ad9e8e3761fbfbd091f1fca8c4e82"
 
 is-directory@^0.3.1:
   version "0.3.1"
@@ -6029,6 +6141,10 @@ is-glob@^4.0.0:
 is-gzip@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
 
 is-index-x@^1.0.0:
   version "1.1.0"
@@ -6224,6 +6340,10 @@ is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz#8b520c85fae7a253382d4b02652e045576e13bb8"
+
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
@@ -6265,6 +6385,14 @@ is-utf8@^0.2.0, is-utf8@^0.2.1:
 is-valid-glob@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
+
+is-whitespace-character@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz#9ae0176f3282b65457a1992cdb084f8a5f833e3b"
+
+is-word-character@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -6879,6 +7007,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+known-css-properties@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.4.1.tgz#baaaf704e5f8a5f10e0e221212aae3ea738ea372"
+
 last-call-webpack-plugin@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-2.1.2.tgz#ad80c6e310998294d2ed2180a68e9589e4768c44"
@@ -7388,6 +7520,10 @@ lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
+longest-streak@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
+
 longest@^1.0.0, longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -7482,6 +7618,14 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+markdown-escapes@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
+
+markdown-table@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
+
 matcher@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.0.0.tgz#aaf0c4816eb69b92094674175625f3466b0e3e19"
@@ -7504,6 +7648,10 @@ math-sign-x@^3.0.0:
   dependencies:
     is-nan-x "^1.0.1"
     to-number-x "^2.0.0"
+
+mathml-tag-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz#8d41268168bf86d1102b98109e28e531e7a34578"
 
 max-safe-integer@^1.0.1:
   version "1.0.1"
@@ -7531,6 +7679,13 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdast-util-compact@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz#cdb5f84e2b6a2d3114df33bd05d9cb32e3c4083a"
+  dependencies:
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit "^1.1.0"
 
 mdn-data@^1.0.0:
   version "1.0.0"
@@ -8019,6 +8174,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-selector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
 
 normalize-space-x@^3.0.0:
   version "3.0.0"
@@ -8745,6 +8904,17 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-entities@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-github-repo-url@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
@@ -8887,6 +9057,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.14"
@@ -9044,6 +9220,20 @@ postcss-filter-plugins@^2.0.0:
     postcss "^5.0.4"
     uniqid "^4.0.0"
 
+postcss-html@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.11.0.tgz#03a3ff3116f8a0fe0d46316ea21893d4db4b63af"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    remark "^8.0.0"
+    unist-util-find-all-after "^1.0.1"
+
+postcss-less@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-1.1.3.tgz#6930525271bfe38d5793d33ac09c1a546b87bb51"
+  dependencies:
+    postcss "^5.2.16"
+
 postcss-load-config@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-1.2.0.tgz#539e9afc9ddc8620121ebf9d8c3673e0ce50d28a"
@@ -9066,6 +9256,10 @@ postcss-load-plugins@^2.3.0:
   dependencies:
     cosmiconfig "^2.1.1"
     object-assign "^4.1.0"
+
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
 
 postcss-merge-idents@^2.1.5:
   version "2.1.7"
@@ -9198,11 +9392,44 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
+postcss-reporter@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-5.0.0.tgz#a14177fd1342829d291653f2786efd67110332c3"
+  dependencies:
+    chalk "^2.0.1"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    postcss "^6.0.8"
+
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+
+postcss-safe-parser@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz#b753eff6c7c0aea5e8375fbe4cde8bf9063ff142"
+  dependencies:
+    postcss "^6.0.6"
+
+postcss-scss@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.2.tgz#ff45cf3354b879ee89a4eb68680f46ac9bb14f94"
+  dependencies:
+    postcss "^6.0.3"
+
 postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
   dependencies:
     flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz#4f875f4afb0c96573d5cf4d74011aee250a7e865"
+  dependencies:
+    dot-prop "^4.1.1"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
@@ -9252,7 +9479,7 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
-postcss@^6.0.8:
+postcss@^6.0.14, postcss@^6.0.3, postcss@^6.0.6, postcss@^6.0.8:
   version "6.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
   dependencies:
@@ -9485,6 +9712,10 @@ querystringify@0.0.x:
 querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
 ramda@^0.25.0:
   version "0.25.0"
@@ -9833,6 +10064,53 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
+remark-parse@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-4.0.0.tgz#99f1f049afac80382366e2e0d0bd55429dd45d8b"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-stringify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-4.0.0.tgz#4431884c0418f112da44991b4e356cfe37facd87"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-8.0.0.tgz#287b6df2fe1190e263c1d15e486d3fa835594d6d"
+  dependencies:
+    remark-parse "^4.0.0"
+    remark-stringify "^4.0.0"
+    unified "^6.0.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -9855,7 +10133,7 @@ repeat-string@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-0.2.2.tgz#c7a8d3236068362059a7e4651fc6884e8b1fb4ae"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.5.4:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -9876,7 +10154,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-replace-ext@^1.0.0:
+replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
@@ -10025,6 +10303,10 @@ resolve-from@^2.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve@1.1.7, resolve@1.1.x:
   version "1.1.7"
@@ -10586,6 +10868,10 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
+specificity@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
+
 split2@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
@@ -10653,6 +10939,10 @@ start-server-webpack-plugin@^2.2.0:
 stat-mode@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
+
+state-toggle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
 
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
@@ -10749,6 +11039,15 @@ string_decoder@~1.0.3:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.1.tgz#b150ec2d72ac4c1b5f324b51fb6b28c9cdff058c"
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 stringify-object@^3.2.0:
   version "3.2.1"
@@ -10860,11 +11159,73 @@ style-loader@^0.19.0:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+
 stylelint-processor-html@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-processor-html/-/stylelint-processor-html-1.0.0.tgz#6892b6b2855a45f0291cd845191d6908130a2918"
   dependencies:
     htmlparser2 "^3.9.1"
+
+stylelint-webpack-plugin@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/stylelint-webpack-plugin/-/stylelint-webpack-plugin-0.9.0.tgz#acc27351751dfa0113ad0eb8919946dcfc0922e2"
+  dependencies:
+    arrify "^1.0.1"
+    minimatch "^3.0.3"
+    object-assign "^4.1.0"
+    ramda "^0.24.1"
+
+stylelint@^8.0.0:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-8.3.1.tgz#424c822f32c88e85025b55d72c7b98355e3fa6de"
+  dependencies:
+    autoprefixer "^7.1.2"
+    balanced-match "^1.0.0"
+    chalk "^2.0.1"
+    cosmiconfig "^3.1.0"
+    debug "^3.0.0"
+    execall "^1.0.0"
+    file-entry-cache "^2.0.0"
+    get-stdin "^5.0.1"
+    globby "^7.0.0"
+    globjoin "^0.1.4"
+    html-tags "^2.0.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    known-css-properties "^0.4.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    mathml-tag-names "^2.0.1"
+    meow "^3.7.0"
+    micromatch "^2.3.11"
+    normalize-selector "^0.2.0"
+    pify "^3.0.0"
+    postcss "^6.0.6"
+    postcss-html "^0.11.0"
+    postcss-less "^1.1.0"
+    postcss-media-query-parser "^0.2.3"
+    postcss-reporter "^5.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^3.0.1"
+    postcss-scss "^1.0.2"
+    postcss-selector-parser "^3.1.0"
+    postcss-value-parser "^3.3.0"
+    resolve-from "^4.0.0"
+    specificity "^0.3.1"
+    string-width "^2.1.0"
+    style-search "^0.1.0"
+    sugarss "^1.0.0"
+    svg-tags "^1.0.0"
+    table "^4.0.1"
+
+sugarss@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-1.0.1.tgz#be826d9003e0f247735f92365dc3fd7f1bae9e44"
+  dependencies:
+    postcss "^6.0.14"
 
 sum-up@^1.0.1:
   version "1.0.3"
@@ -11321,12 +11682,24 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz#7aefbb7808df9d669f6da2e438cac8c46ada7684"
+
 trim-x@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/trim-x/-/trim-x-3.0.0.tgz#24efdcd027b748bbfc246a0139ad1749befef024"
   dependencies:
     trim-left-x "^3.0.0"
     trim-right-x "^3.0.0"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -11419,6 +11792,25 @@ umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
 
+unherit@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.0.tgz#6b9aaedfbf73df1756ad9e316dd981885840cd7d"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.0.0:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-function "^1.0.4"
+    x-is-string "^0.1.0"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -11465,6 +11857,38 @@ unique-temp-dir@^1.0.0:
     mkdirp "^0.5.1"
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
+
+unist-util-find-all-after@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.1.tgz#4e5512abfef7e0616781aecf7b1ed751c00af908"
+  dependencies:
+    unist-util-is "^2.0.0"
+
+unist-util-is@^2.0.0, unist-util-is@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+
+unist-util-modify-children@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz#66d7e6a449e6f67220b976ab3cb8b5ebac39e51d"
+  dependencies:
+    array-iterate "^1.0.0"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
+
+unist-util-visit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
+  dependencies:
+    unist-util-is "^2.1.1"
 
 universalify@^0.1.0:
   version "0.1.1"
@@ -11678,6 +12102,25 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.2.tgz#d3675c59c877498e492b4756ff65e4af1a752255"
+
+vfile-message@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.0.tgz#a6adb0474ea400fa25d929f1d673abea6a17e359"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"
@@ -12152,6 +12595,14 @@ ws@1.1.2:
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
+x-is-function@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/x-is-function/-/x-is-function-1.0.4.tgz#5d294dc3d268cbdd062580e0c5df77a391d1fa1e"
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Most of what's here is adapted from https://github.com/barraponto/neutrino-middleware-stylelint 👏 

Curious if @mozilla-neutrino/core-contributors think this should be in core, or just maintained by community. If the consensus is the latter, I'm happy to PR @barraponto's package.

`stylelint` felt like a commonly used enough tool that it could be a good case for a core middleware.

Related: https://github.com/mozilla-neutrino/neutrino-dev/issues/612