### PR TITLE
Add debugging to CNP using the debug flag

### DIFF
--- a/packages/create-project/bin/create-project.js
+++ b/packages/create-project/bin/create-project.js
@@ -11,9 +11,10 @@ const dir = resolve(__dirname, '../commands/init');
 env.register(require.resolve(dir), 'create-project');
 
 const cli = yargs.command('<project-directory>')
-  .option('debug', { describe: 'Run in debug mode' })
+  .option('debug', { description: 'Run in debug mode' })
   .demandCommand(1, 'Only <project-directory> is required')
   .help()
+  .wrap(null)
   .argv;
 const directory = isAbsolute(cli._[0]) ? cli._[0] : join(process.cwd(), cli._[0]);
 const name = basename(directory);

--- a/packages/create-project/bin/create-project.js
+++ b/packages/create-project/bin/create-project.js
@@ -11,6 +11,7 @@ const dir = resolve(__dirname, '../commands/init');
 env.register(require.resolve(dir), 'create-project');
 
 const cli = yargs.command('<project-directory>')
+  .option('debug', { describe: 'Run in debug mode' })
   .demandCommand(1, 'Only <project-directory> is required')
   .help()
   .argv;

--- a/packages/create-project/bin/create-project.js
+++ b/packages/create-project/bin/create-project.js
@@ -20,5 +20,5 @@ const name = basename(directory);
 env.run('create-project', {
   directory,
   name,
-  stdio: 'ignore'
+  stdio: cli.debug ? 'inherit' : 'ignore'
 }, done);


### PR DESCRIPTION
There is no way to debug the CNP when something goes wrong. This PR will push everything to `stdout` when the debug flag is set. We saw it happen in #608.