### PR TITLE
Optionally pass resolve.modules to web, node presets

### DIFF
--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -277,7 +277,12 @@ module.exports = {
             }
           }]
         ]
-      }
+      },
+
+      // Example: add paths to `resolve.modules`
+      modules: [
+        neutrino.options.source,
+      ]
     }]
   ]
 };

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -181,7 +181,7 @@ if (module.hot) {
 }
 
 createServer((req, res) => {
-  res.end(app('example'));  
+  res.end(app('example'));
 }).listen(/* */);
 ```
 
@@ -196,7 +196,7 @@ if (module.hot) {
 }
 
 createServer((req, res) => {
-  res.end(app('example'));  
+  res.end(app('example'));
 }).listen(/* */);
 ```
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -262,6 +262,11 @@ module.exports = {
       html: {
         title: 'Epic Web App'
       }
+
+      // Example: add paths to `resolve.modules`
+      modules: [
+        neutrino.options.source,
+      ]
     }]
   ]
 };

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -277,7 +277,12 @@ module.exports = {
             }
           }]
         ]
-      }
+      },
+
+      // Example: add paths to `resolve.modules`
+      modules: [
+        neutrino.options.source,
+      ]
     }]
   ]
 };

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -181,7 +181,7 @@ if (module.hot) {
 }
 
 createServer((req, res) => {
-  res.end(app('example'));  
+  res.end(app('example'));
 }).listen(/* */);
 ```
 
@@ -196,7 +196,7 @@ if (module.hot) {
 }
 
 createServer((req, res) => {
-  res.end(app('example'));  
+  res.end(app('example'));
 }).listen(/* */);
 ```
 

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -96,6 +96,9 @@ module.exports = (neutrino, opts = {}) => {
           // Add monorepo node_modules to webpack module resolution
           modules.add(join(__dirname, '../../node_modules'));
         })
+        .when(options.modules, modules => {
+          options.modules.map(module => modules.add(module));
+        })
         .end()
       .extensions
         .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -262,6 +262,11 @@ module.exports = {
       html: {
         title: 'Epic Web App'
       }
+
+      // Example: add paths to `resolve.modules`
+      modules: [
+        neutrino.options.source,
+      ]
     }]
   ]
 };

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -149,6 +149,9 @@ module.exports = (neutrino, opts = {}) => {
           // Add monorepo node_modules to webpack module resolution
           modules.add(join(__dirname, '../../node_modules'));
         })
+        .when(options.modules, modules => {
+          options.modules.map(module => modules.add(module));
+        })
         .end()
       .extensions
         .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))


### PR DESCRIPTION
This was the last bit of my standard neutrino setup that I couldn't do w/o tapping into the neutrino api, so I thought it would be nice to include.

If we wanted the option name more explicit, perhaps `resolveModules`?

Related: https://github.com/mozilla-neutrino/neutrino-dev/pull/541