### PR TITLE
fix(Jest): Fix Jest middleware always exit with zero code

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -118,10 +118,9 @@ module.exports = (neutrino, opts = {}) => {
 
       writeFileSync(configFile, `${JSON.stringify(options, null, 2)}\n`);
 
-      jest.runCLI(cliOptions, options.roots || [options.rootDir], result =>
-        (result.numFailedTests || result.numFailedTestSuites ?
-          reject() :
-          resolve()));
+      jest.runCLI(cliOptions, options.roots || [options.rootDir])
+        .then(results => results.success ? resolve() : reject())
+        .catch(error => reject(error));
     });
   });
 };


### PR DESCRIPTION
Closes #632

Since this regression was introduced in v7, I think it should be released as a patch release in v7 and v8 accordingly.

After spending ~30 mins trying to write tests with Ava I gave up and offering my help with #635 