### PR TITLE
Serialize fork payload to support regex and simple functions

### DIFF
--- a/packages/fork/index.js
+++ b/packages/fork/index.js
@@ -2,6 +2,7 @@ const { gray } = require('chalk');
 const { fork } = require('child_process');
 const { join } = require('path');
 const { createInterface } = require('readline');
+const serialize = require('serialize-javascript');
 
 module.exports = (neutrino, options = {}) => {
   global.interactive = false;
@@ -32,7 +33,7 @@ module.exports = (neutrino, options = {}) => {
         stdout.on('line', message => console.log(gray(`[${namespace}]`), message));
         stderr.on('line', message => console.error(gray(`[${namespace}]`), message));
         child.on('message', ([type, args]) => neutrino.emit(`${namespace}:${type}`, ...args));
-        child.send([middleware, neutrino.options.args]);
+        child.send(serialize([middleware, neutrino.options.args]));
 
         return child;
       });

--- a/packages/fork/neutrino-child.js
+++ b/packages/fork/neutrino-child.js
@@ -20,7 +20,9 @@ const runnable = (command, middleware, args) => cond([
   [T, () => execute(middleware, args)]
 ])(command);
 
-process.on('message', ([rawMiddleware, args]) => {
+process.on('message', (payload) => {
+  const [rawMiddleware, args] = eval(`(${payload})`); // eslint-disable-line no-eval
+
   process.on('unhandledRejection', (err) => {
     if (!args.quiet) {
       console.error('');

--- a/packages/fork/package.json
+++ b/packages/fork/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "chalk": "^2.3.0",
-    "ramda": "^0.25.0"
+    "ramda": "^0.25.0",
+    "serialize-javascript": "^1.4.0"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10244,6 +10244,10 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
+serialize-javascript@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"


### PR DESCRIPTION
This should fix #666.

I need a close look at this, because we are changing up how the payload is serialized, and not to mention, we have to eval it on the other side.