### PR TITLE
Refactor imagemin plugin to fix minification when used with libraries

### DIFF
--- a/docs/packages/image-minify/README.md
+++ b/docs/packages/image-minify/README.md
@@ -35,31 +35,29 @@ and plug it into Neutrino:
 
 ```js
 // Using function middleware format
-const images = require('@neutrinojs/image-loader');
 const imagemin = require('@neutrinojs/image-minify');
 
 // Use with default options
-neutrino.use(images);
 neutrino.use(imagemin);
 
 // Usage showing default options
 neutrino.use(imagemin, {
   imagemin: {
     plugins: [
+      optipng(),
       gifsicle(),
+      jpegtran(),
       svgo(),
-      pngquant(),
-      mozjpeg(),
       webp()
-    ]
+    ],
+    optipng: {},
+    gifsicle: {},
+    jpegtran: {},
+    svgo: {},
+    pngquant: null,
+    webp: {}
   },
-  plugin: {
-    name: '[path][name].[ext]',
-    test: /\.(png|jpg|jpeg|gif|webp)$/
-  },
-  useId: 'imagemin',
-  rules: ['svg', 'img'],
-  pluginId: 'imagemin',
+  pluginId: 'imagemin'
 });
 ```
 
@@ -75,36 +73,67 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/image-minify', {
-      imagemin: {},
-      plugin: {
-        name: '[path][name].[ext]',
-        test: /\.(png|jpg|jpeg|gif|webp)$/
+      imagemin: {
+        plugins: [
+          optipng(),
+          gifsicle(),
+          jpegtran(),
+          svgo(),
+          webp()
+        ],
+        optipng: {},
+        gifsicle: {},
+        jpegtran: {},
+        svgo: {},
+        pngquant: null,
+        webp: {}
       },
-      rules: ['svg', 'img'],
       pluginId: 'imagemin'
     }]
   ]
 };
 ```
 
-- `imagemin`: Set options for [imagemin](https://github.com/imagemin/imagemin#options).
-- `plugin`: Set options for [imagemin-webpack](https://github.com/itgalaxy/imagemin-webpack#standalone-plugin)'s ImageminWebpackPlugin.
-- `rules`: Specify rules for the application of imagemin.
-- `pluginId`: The imagemin plugin identifier. Override this to add an additional imagemin plugin instance.
+- `imagemin`: Set options for [imagemin](https://github.com/Klathmon/imagemin-webpack-plugin). See below for specific options.
+- `pluginId`: The `imagemin` plugin identifier. Override this to add an additional imagemin plugin instance.
 
 ## Customization
 
 `@neutrinojs/image-minify` creates some conventions to make overriding the configuration easier once you are
 ready to make changes.
 
-### Rules
+### Imagemin Options
 
-The following is a list of rules and their identifiers which can be overridden:
+The `imagemin` option can accept options related to the
+[`ImageminWebpackPlugin`](https://github.com/Klathmon/imagemin-webpack-plugin). Typically this includes an array of
+additional plugins you wish to add beyond the defaults, or setting options for the default plugins this middleware
+uses. This middleware uses all the default settings for `imagemin-webpack-plugin`, and adds the following
+_additional option_:
 
-| Name | Description | Environments and Commands |
-| --- | --- | --- |
-| `img` | Optimize JPEG, PNG, GIF, and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
-| `svg` | Optimize SVG files imported from modules. Contains a single loader named `imagemin`. | all |
+- `imagemin.webp`: Passes the given object to [`imagemin-webp`](https://github.com/imagemin/imagemin-webp). Set to null
+to disable `webp` optimization.
+
+If you wish to add additional plugins, you can pass an instance of the plugin to the `imagemin.plugins` array.
+
+_Example: Use `imagemin-zopfli` with `8bit` option_:
+
+```js
+const zopfli = require('imagemin-zopfli');
+
+module.exports = {
+  use: [
+    ['@neutrinojs/image-minify', {
+      imagemin: {
+        plugins: [
+          zopfli({
+            '8bit': true
+          })
+        ],
+      },
+    }]
+  ]
+};
+```
 
 ### Plugins
 
@@ -112,7 +141,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `imagemin` | Optimize any images added by other webpack plugins (e.g. `copy-webpack-plugin`). | all |
+| `imagemin` | Optimize any images used by your project. | all |
 
 ## Contributing
 

--- a/packages/image-minify/README.md
+++ b/packages/image-minify/README.md
@@ -35,31 +35,29 @@ and plug it into Neutrino:
 
 ```js
 // Using function middleware format
-const images = require('@neutrinojs/image-loader');
 const imagemin = require('@neutrinojs/image-minify');
 
 // Use with default options
-neutrino.use(images);
 neutrino.use(imagemin);
 
 // Usage showing default options
 neutrino.use(imagemin, {
   imagemin: {
     plugins: [
+      optipng(),
       gifsicle(),
+      jpegtran(),
       svgo(),
-      pngquant(),
-      mozjpeg(),
       webp()
-    ]
+    ],
+    optipng: {},
+    gifsicle: {},
+    jpegtran: {},
+    svgo: {},
+    pngquant: null,
+    webp: {}
   },
-  plugin: {
-    name: '[path][name].[ext]',
-    test: /\.(png|jpg|jpeg|gif|webp)$/
-  },
-  useId: 'imagemin',
-  rules: ['svg', 'img'],
-  pluginId: 'imagemin',
+  pluginId: 'imagemin'
 });
 ```
 
@@ -75,36 +73,67 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/image-minify', {
-      imagemin: {},
-      plugin: {
-        name: '[path][name].[ext]',
-        test: /\.(png|jpg|jpeg|gif|webp)$/
+      imagemin: {
+        plugins: [
+          optipng(),
+          gifsicle(),
+          jpegtran(),
+          svgo(),
+          webp()
+        ],
+        optipng: {},
+        gifsicle: {},
+        jpegtran: {},
+        svgo: {},
+        pngquant: null,
+        webp: {}
       },
-      rules: ['svg', 'img'],
       pluginId: 'imagemin'
     }]
   ]
 };
 ```
 
-- `imagemin`: Set options for [imagemin](https://github.com/imagemin/imagemin#options).
-- `plugin`: Set options for [imagemin-webpack](https://github.com/itgalaxy/imagemin-webpack#standalone-plugin)'s ImageminWebpackPlugin.
-- `rules`: Specify rules for the application of imagemin.
-- `pluginId`: The imagemin plugin identifier. Override this to add an additional imagemin plugin instance.
+- `imagemin`: Set options for [imagemin](https://github.com/Klathmon/imagemin-webpack-plugin). See below for specific options.
+- `pluginId`: The `imagemin` plugin identifier. Override this to add an additional imagemin plugin instance.
 
 ## Customization
 
 `@neutrinojs/image-minify` creates some conventions to make overriding the configuration easier once you are
 ready to make changes.
 
-### Rules
+### Imagemin Options
 
-The following is a list of rules and their identifiers which can be overridden:
+The `imagemin` option can accept options related to the
+[`ImageminWebpackPlugin`](https://github.com/Klathmon/imagemin-webpack-plugin). Typically this includes an array of
+additional plugins you wish to add beyond the defaults, or setting options for the default plugins this middleware
+uses. This middleware uses all the default settings for `imagemin-webpack-plugin`, and adds the following
+_additional option_:
 
-| Name | Description | Environments and Commands |
-| --- | --- | --- |
-| `img` | Optimize JPEG, PNG, GIF, and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
-| `svg` | Optimize SVG files imported from modules. Contains a single loader named `imagemin`. | all |
+- `imagemin.webp`: Passes the given object to [`imagemin-webp`](https://github.com/imagemin/imagemin-webp). Set to null
+to disable `webp` optimization.
+
+If you wish to add additional plugins, you can pass an instance of the plugin to the `imagemin.plugins` array.
+
+_Example: Use `imagemin-zopfli` with `8bit` option_:
+
+```js
+const zopfli = require('imagemin-zopfli');
+
+module.exports = {
+  use: [
+    ['@neutrinojs/image-minify', {
+      imagemin: {
+        plugins: [
+          zopfli({
+            '8bit': true
+          })
+        ],
+      },
+    }]
+  ]
+};
+```
 
 ### Plugins
 
@@ -112,7 +141,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `imagemin` | Optimize any images added by other webpack plugins (e.g. `copy-webpack-plugin`). | all |
+| `imagemin` | Optimize any images used by your project. | all |
 
 ## Contributing
 

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -7,9 +7,9 @@ module.exports = (neutrino, opts = {}) => {
   const options = merge({
     imagemin: {
       plugins: [],
-      optipng: {},
-      gifsicle: {},
-      jpegtran: {},
+      optipng: null,
+      gifsicle: null,
+      jpegtran: null,
       svgo: {},
       pngquant: {},
       webp: {}

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -8,7 +8,7 @@ module.exports = (neutrino, opts = {}) => {
     imagemin: {
       plugins: [],
       optipng: null,
-      gifsicle: null,
+      gifsicle: {},
       jpegtran: null,
       svgo: {},
       pngquant: {},

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -1,6 +1,7 @@
 const merge = require('deepmerge');
 const ImageminWebpackPlugin = require('imagemin-webpack-plugin').default;
 const webp = require('imagemin-webp');
+const mozjpeg = require('imagemin-mozjpeg');
 
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
@@ -10,7 +11,7 @@ module.exports = (neutrino, opts = {}) => {
       gifsicle: {},
       jpegtran: {},
       svgo: {},
-      pngquant: null,
+      pngquant: {},
       webp: {}
     },
     pluginId: 'imagemin'
@@ -18,6 +19,10 @@ module.exports = (neutrino, opts = {}) => {
 
   if (options.webp) {
     options.imagemin.plugins.push(webp(options.webp));
+  }
+
+  if (options.mozjpeg) {
+    options.imagemin.plugins.push(mozjpeg(options.mozjpeg));
   }
 
   neutrino.config

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -1,49 +1,26 @@
 const merge = require('deepmerge');
-const ImageminWebpackPlugin = require('imagemin-webpack/ImageminWebpackPlugin');
-const gifsicle = require('imagemin-gifsicle');
-const svgo = require('imagemin-svgo');
-const pngquant = require('imagemin-pngquant');
-const mozjpeg = require('imagemin-mozjpeg');
+const ImageminWebpackPlugin = require('imagemin-webpack-plugin').default;
 const webp = require('imagemin-webp');
-
-const imageminLoader = require.resolve('imagemin-webpack/imagemin-loader');
 
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
     imagemin: {
-      plugins: [
-        gifsicle(),
-        svgo(),
-        pngquant(),
-        mozjpeg(),
-        webp()
-      ]
+      plugins: [],
+      optipng: {},
+      gifsicle: {},
+      jpegtran: {},
+      svgo: {},
+      pngquant: null,
+      webp: {}
     },
-    plugin: {
-      name: '[path][name].[ext]'
-    },
-    pluginId: 'imagemin',
-    useId: 'imagemin',
-    rules: ['svg', 'img']
+    pluginId: 'imagemin'
   }, opts);
 
-  const test = options.rules.map((ruleId) => {
-    neutrino.config.module
-      .rule(ruleId)
-      .use(options.useId)
-        .loader(imageminLoader)
-        .options(options.imagemin);
-
-    return neutrino.config.module.rule(ruleId).get('test');
-  })
-  .filter(Boolean);
-
-  options.plugin = merge({
-    imageminOptions: options.imagemin,
-    test
-  }, options.plugin);
+  if (options.webp) {
+    options.imagemin.plugins.push(webp(options.webp));
+  }
 
   neutrino.config
     .plugin(options.pluginId)
-    .use(ImageminWebpackPlugin, [options.plugin]);
+    .use(ImageminWebpackPlugin, [options.imagemin]);
 };

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
+    "imagemin-mozjpeg": "^7.0.0",
     "imagemin-webp": "^4.1.0",
     "imagemin-webpack-plugin": "^1.6.0"
   },

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -24,12 +24,8 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
-    "imagemin-gifsicle": "5.2.0",
-    "imagemin-mozjpeg": "^6.0.0",
-    "imagemin-pngquant": "^5.0.0",
-    "imagemin-svgo": "^6.0.0",
-    "imagemin-webp": "^4.0.0",
-    "imagemin-webpack": "^1.1.2"
+    "imagemin-webp": "^4.1.0",
+    "imagemin-webpack-plugin": "^1.6.0"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,6 +255,12 @@ ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
+ansi-gray@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -280,6 +286,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
 ansi@^0.3.0, ansi@~0.3.1:
   version "0.3.1"
@@ -1553,7 +1563,7 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bin-build@^2.0.0:
+bin-build@^2.0.0, bin-build@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/bin-build/-/bin-build-2.2.0.tgz#11f8dd61f70ffcfa2bdcaa5b46f5e8fedd4221cc"
   dependencies:
@@ -2303,8 +2313,8 @@ coa@~1.0.1:
     q "^1.1.2"
 
 coa@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.0.tgz#af881ebe214fc29bee4e9e76b4956b6132295546"
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.1.tgz#f3f8b0b15073e35d70263fb1042cb2c023db38af"
   dependencies:
     q "^1.1.2"
 
@@ -2341,6 +2351,10 @@ color-string@^0.3.0:
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
   dependencies:
     color-name "^1.0.0"
+
+color-support@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
 color@^0.11.0:
   version "0.11.4"
@@ -2931,6 +2945,13 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
+css-tree@1.0.0-alpha.27:
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.27.tgz#f211526909c7dc940843d83b9376ed98ddb8de47"
+  dependencies:
+    mdn-data "^1.0.0"
+    source-map "^0.5.3"
+
 css-tree@1.0.0-alpha25:
   version "1.0.0-alpha25"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha25.tgz#1bbfabfbf6eeef4f01d9108ff2edd0be2fe35597"
@@ -2988,10 +3009,10 @@ cssesc@^0.1.0:
     postcss-zindex "^2.0.1"
 
 csso@^3.3.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-3.4.0.tgz#57b27ef553cccbf5aa964c641748641e9af113f3"
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-3.5.0.tgz#acdbba5719e2c87bc801eadc032764b2e4b9d4e7"
   dependencies:
-    css-tree "1.0.0-alpha25"
+    css-tree "1.0.0-alpha.27"
 
 csso@~2.3.1:
   version "2.3.2"
@@ -3020,11 +3041,11 @@ custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
 
-cwebp-bin@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cwebp-bin/-/cwebp-bin-3.2.0.tgz#ae02df453d8c15341b1d8d499a5226bcf3bf4a6f"
+cwebp-bin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cwebp-bin/-/cwebp-bin-4.0.0.tgz#ee2b7f6333d3426fb52bb405fa6f2ec8b62894f4"
   dependencies:
-    bin-build "^2.0.0"
+    bin-build "^2.2.0"
     bin-wrapper "^3.0.1"
     logalot "^2.0.0"
 
@@ -3514,9 +3535,18 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-duplexify@^3.1.2, duplexify@^3.2.0, duplexify@^3.4.2:
+duplexify@^3.1.2, duplexify@^3.4.2:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.1.tgz#4e1516be68838bc90a49994f0b39a6e5960befcd"
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+duplexify@^3.2.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.3.tgz#8b5818800df92fd0125b27ab896491912858243e"
   dependencies:
     end-of-stream "^1.0.0"
     inherits "^2.0.1"
@@ -4277,10 +4307,11 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
 fancy-log@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.0.tgz#45be17d02bb9917d60ccffd4995c999e6c8c9948"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
-    chalk "^1.1.1"
+    ansi-gray "^0.1.1"
+    color-support "^1.1.3"
     time-stamp "^1.0.0"
 
 fast-async@^6.3.0:
@@ -4377,7 +4408,7 @@ file-type@^3.1.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
 
-file-type@^4.1.0:
+file-type@^4.1.0, file-type@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-4.4.0.tgz#1b600e5fca1fbdc6e80c0a70c71c8dba5f7906c5"
 
@@ -5628,7 +5659,7 @@ ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-imagemin-gifsicle@5.2.0:
+imagemin-gifsicle@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz#3781524c457612ef04916af34241a2b42bfcb40a"
   dependencies:
@@ -5636,15 +5667,23 @@ imagemin-gifsicle@5.2.0:
     gifsicle "^3.0.0"
     is-gif "^1.0.0"
 
-imagemin-mozjpeg@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/imagemin-mozjpeg/-/imagemin-mozjpeg-6.0.0.tgz#71a32a457aa1b26117a68eeef2d9b190c2e5091e"
+imagemin-jpegtran@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/imagemin-jpegtran/-/imagemin-jpegtran-5.0.2.tgz#e6882263b8f7916fddb800640cf75d2e970d2ad6"
   dependencies:
     exec-buffer "^3.0.0"
     is-jpg "^1.0.0"
-    mozjpeg "^4.0.0"
+    jpegtran-bin "^3.0.0"
 
-imagemin-pngquant@^5.0.0:
+imagemin-optipng@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz#d22da412c09f5ff00a4339960b98a88b1dbe8695"
+  dependencies:
+    exec-buffer "^3.0.0"
+    is-png "^1.0.0"
+    optipng-bin "^3.0.0"
+
+imagemin-pngquant@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/imagemin-pngquant/-/imagemin-pngquant-5.0.1.tgz#d8a329da553afa226b11ce62debe0b7e37b439e6"
   dependencies:
@@ -5660,24 +5699,31 @@ imagemin-svgo@^6.0.0:
     is-svg "^2.0.0"
     svgo "^1.0.0"
 
-imagemin-webp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/imagemin-webp/-/imagemin-webp-4.0.0.tgz#a2caf32b5f52ad21b949a6fed8efc901daf7249d"
+imagemin-webp@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/imagemin-webp/-/imagemin-webp-4.1.0.tgz#effd00160d8456b95cbde5fd26c32d64b0318062"
   dependencies:
-    cwebp-bin "^3.1.0"
+    cwebp-bin "^4.0.0"
     exec-buffer "^3.0.0"
-    is-cwebp-readable "^1.0.0"
+    is-cwebp-readable "^2.0.1"
 
-imagemin-webpack@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/imagemin-webpack/-/imagemin-webpack-1.1.2.tgz#8fb173fa972516e8f43ea21758f74500e238ab99"
+imagemin-webpack-plugin@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/imagemin-webpack-plugin/-/imagemin-webpack-plugin-1.6.0.tgz#ec24c61fe38f4f121d3939d6d4c03e9eb876ca8b"
   dependencies:
     async-throttle "^1.1.0"
+    babel-runtime "^6.18.0"
     imagemin "^5.3.1"
-    loader-utils "^1.0.0"
-    minimatch "^3.0.3"
-    nodeify "^1.0.0"
-    webpack-sources "^1.0.0"
+    imagemin-gifsicle "^5.1.0"
+    imagemin-jpegtran "^5.0.2"
+    imagemin-optipng "^5.1.0"
+    imagemin-pngquant "^5.0.1"
+    imagemin-svgo "^6.0.0"
+    lodash.map "^4.6.0"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    util.promisify "^1.0.0"
+    webpack-sources "^1.1.0"
 
 imagemin@^5.3.1:
   version "5.3.1"
@@ -5912,11 +5958,11 @@ is-ci@^1.0.10, is-ci@^1.0.7:
   dependencies:
     ci-info "^1.0.0"
 
-is-cwebp-readable@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-cwebp-readable/-/is-cwebp-readable-1.0.3.tgz#9a8fde2bed77f3417ae9371258c58e2ec3285118"
+is-cwebp-readable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-cwebp-readable/-/is-cwebp-readable-2.0.1.tgz#afb93b0c0abd0a25101016ae33aea8aedf926d26"
   dependencies:
-    file-type "^3.1.0"
+    file-type "^4.3.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
@@ -6169,10 +6215,6 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
-is-promise@~1, is-promise@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
 
 is-property@^1.0.0:
   version "1.0.2"
@@ -6630,6 +6672,14 @@ jest-validate@^21.1.0, jest-validate@^21.2.1:
     jest-get-type "^21.2.0"
     leven "^2.1.0"
     pretty-format "^21.2.1"
+
+jpegtran-bin@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz#f60ecf4ae999c0bdad2e9fbcdf2b6f0981e7a29b"
+  dependencies:
+    bin-build "^2.0.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 js-base64@^2.1.9:
   version "2.3.2"
@@ -7249,7 +7299,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.map@^4.4.0:
+lodash.map@^4.4.0, lodash.map@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
@@ -7761,14 +7811,6 @@ move-concurrently@^1.0.1, move-concurrently@~1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-mozjpeg@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/mozjpeg/-/mozjpeg-4.1.1.tgz#859030b24f689a53db9b40f0160d89195b88fd50"
-  dependencies:
-    bin-build "^2.0.0"
-    bin-wrapper "^3.0.0"
-    logalot "^2.0.0"
-
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -7951,13 +7993,6 @@ node-status-codes@^1.0.0:
 node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-
-nodeify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nodeify/-/nodeify-1.0.1.tgz#64ab69a7bdbaf03ce107b4f0335c87c0b9e91b1d"
-  dependencies:
-    is-promise "~1.0.0"
-    promise "~1.3.0"
 
 nodent-compiler@>=3.1.0:
   version "3.1.3"
@@ -8562,6 +8597,14 @@ optionator@^0.8.1, optionator@^0.8.2:
 options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+
+optipng-bin@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/optipng-bin/-/optipng-bin-3.1.4.tgz#95d34f2c488704f6fd70606bfea0c659f1d95d84"
+  dependencies:
+    bin-build "^2.0.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 ora@^0.2.3:
   version "0.2.3"
@@ -9354,12 +9397,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promise@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-1.3.0.tgz#e5cc9a4c8278e4664ffedc01c7da84842b040175"
-  dependencies:
-    is-promise "~1"
-
 promzard@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
@@ -9516,9 +9553,18 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
+  dependencies:
+    deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.1.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.3.tgz#51575a900f8dd68381c710b4712c2154c3e2035b"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -11475,8 +11521,8 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
 unquote@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.0.tgz#98e1fc608b6b854c75afb1b95afc099ba69d942f"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
 
 untildify@^2.0.0:
   version "2.1.0"
@@ -11603,7 +11649,7 @@ util-extend@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
 
-util.promisify@~1.0.0:
+util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
   dependencies:
@@ -11926,7 +11972,7 @@ webpack-sources@1.0.1, webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack-sources@^1.0.0:
+webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,6 +5675,14 @@ imagemin-jpegtran@^5.0.2:
     is-jpg "^1.0.0"
     jpegtran-bin "^3.0.0"
 
+imagemin-mozjpeg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/imagemin-mozjpeg/-/imagemin-mozjpeg-7.0.0.tgz#d926477fc6ef5f3a768a4222f7b2d808d3eba568"
+  dependencies:
+    execa "^0.8.0"
+    is-jpg "^1.0.0"
+    mozjpeg "^5.0.0"
+
 imagemin-optipng@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz#d22da412c09f5ff00a4339960b98a88b1dbe8695"
@@ -7810,6 +7818,14 @@ move-concurrently@^1.0.1, move-concurrently@~1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mozjpeg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mozjpeg/-/mozjpeg-5.0.0.tgz#b8671c4924568a363de003ff2fd397ab83f752c5"
+  dependencies:
+    bin-build "^2.2.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
This fixes #670. Turns out the problem is not babel-minify, but rather some kind of interference between the imagemin plugin we were using and creating libraries.

I switched to a different imagemin plugin with a nice API, which let us cut out some code and direct dependencies. @timkelty what do you think?