### PR TITLE
Fix Jest entry files search on Windows

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -51,10 +51,7 @@ function normalizeJestOptions(opts, neutrino, usingBabel) {
   const { extensions, source, tests, root } = neutrino.options
   const collectCoverageFrom = [join(relative(root, source), `**/*.{${extensions.join(',')}}`)]
 
-  const testRegex = join(
-    basename(tests),
-    `.*(_test|_spec|\\.test|\\.spec)\\.(${extensions.join('|')})$`
-  );
+  const testRegex = `${basename(tests)}/.*(_test|_spec|\\.test|\\.spec)\\.(${extensions.join('|')})$`;
 
   return merge.all([
     {


### PR DESCRIPTION
Jest can't find test (spec) files on Windows. The reason is backslashes in a test path. This PR changes slashes to Unix style in a file 'test' RegExp only. I hope there is no issue with other paths in Jest.