### PR TITLE
Update the suggested .eslintrc.js shim so it can find .neutrinorc.js from any location

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -412,7 +412,7 @@ command. The results of this command can be returned with `call`, which is loade
 ```js
 const { Neutrino } = require('neutrino');
 
-const eslintConfig = Neutrino()
+const eslintConfig = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -40,7 +40,7 @@ For a concrete example, `.eslintrc.js`, which utilizes these changes, would migr
 ```js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -261,7 +261,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -275,7 +275,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // You can choose to not use .neutrinorc.js as the middleware to
 // use if you prefer, specifying any middleware you wish.
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/airbnb-base', {
     eslint: {
       rules: { semi: 'off' }

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -5,7 +5,7 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][npm-downloads]][npm-url]
-[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url] 
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 
@@ -258,8 +258,8 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
-  .use(__dirname + '/.neutrinorc.js')
+module.exports = Neutrino({ root: __dirname })
+  .use('.neutrinorc.js')
   .call('eslintrc');
 ```
 

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -272,7 +272,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // You can choose to not use .neutrinorc.js as the middleware to
 // use if you prefer, specifying any middleware you wish.
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/airbnb', {
     eslint: {
       rules: { semi: 'off' }

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -259,7 +259,7 @@ const { Neutrino } = require('neutrino');
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
 module.exports = Neutrino()
-  .use('.neutrinorc.js')
+  .use(__dirname + '/.neutrinorc.js')
   .call('eslintrc');
 ```
 

--- a/docs/packages/eslint/README.md
+++ b/docs/packages/eslint/README.md
@@ -145,7 +145,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -156,7 +156,7 @@ _Example: Create a .eslintrc.js file in the root of the project, using specified
 // .eslintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/eslint', {
     eslint: {
       rules: { semi: 'off' }

--- a/docs/packages/standardjs/README.md
+++ b/docs/packages/standardjs/README.md
@@ -259,7 +259,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -270,7 +270,7 @@ _Example: Create a .eslintrc.js file in the root of the project, using specified
 // .eslintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/standardjs', {
     eslint: {
       rules: { semi: 'error' }

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -95,7 +95,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling stylelintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('stylelintrc');
 ```
@@ -106,7 +106,7 @@ _Example: Create a .stylelintrc.js file in the root of the project, using specif
 // .stylelintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/stylelint', {
     config: {
       rules: { 'max-empty-lines': 2 }

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -261,7 +261,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -275,7 +275,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // You can choose to not use .neutrinorc.js as the middleware to
 // use if you prefer, specifying any middleware you wish.
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/airbnb-base', {
     eslint: {
       rules: { semi: 'off' }

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -258,7 +258,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -272,7 +272,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // You can choose to not use .neutrinorc.js as the middleware to
 // use if you prefer, specifying any middleware you wish.
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/airbnb', {
     eslint: {
       rules: { semi: 'off' }

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -5,7 +5,7 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][npm-downloads]][npm-url]
-[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url] 
+[![Join the Neutrino community on Spectrum][spectrum-image]][spectrum-url]
 
 ## Features
 

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -145,7 +145,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -156,7 +156,7 @@ _Example: Create a .eslintrc.js file in the root of the project, using specified
 // .eslintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/eslint', {
     eslint: {
       rules: { semi: 'off' }

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -259,7 +259,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling eslintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('eslintrc');
 ```
@@ -270,7 +270,7 @@ _Example: Create a .eslintrc.js file in the root of the project, using specified
 // .eslintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/standardjs', {
     eslint: {
       rules: { semi: 'error' }

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -95,7 +95,7 @@ const { Neutrino } = require('neutrino');
 // Specify middleware to Neutrino prior to calling stylelintrc.
 // Even if using .neutrinorc.js, you must specify it when using
 // the API
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('.neutrinorc.js')
   .call('stylelintrc');
 ```
@@ -106,7 +106,7 @@ _Example: Create a .stylelintrc.js file in the root of the project, using specif
 // .stylelintrc.js
 const { Neutrino } = require('neutrino');
 
-module.exports = Neutrino()
+module.exports = Neutrino({ root: __dirname })
   .use('@neutrinojs/stylelint', {
     config: {
       rules: { 'max-empty-lines': 2 }


### PR DESCRIPTION
When emacs flycheck package runs `eslint`, it runs it from the same directory as the source file.  If that's the case, the suggested `.eslintrc.js` shim in this file will fail to find the `.neutrinorc.js` file.  This simple fix just looks for it in the same directory as the `.eslintrc.js` file.  This shouldn't (hopefully) have any negative consequences for any IDEs that run `eslint` from the project root that are currently working.