### PR TITLE
Neutrino start should pay attention to NODE_ENV env variable

### DIFF
--- a/packages/neutrino/bin/start.js
+++ b/packages/neutrino/bin/start.js
@@ -9,7 +9,7 @@ module.exports = (middleware, args, cli) => {
     cli,
     middleware,
     args,
-    NODE_ENV: 'development',
+    NODE_ENV: process.env.NODE_ENV || 'development',
     commandHandler(config, neutrino) {
       if (!args.start) {
         spinner.enabled = global.interactive;


### PR DESCRIPTION
neutrino start always sets NODE_ENV to development regardless of process.env.NODE_ENV.
This fixes running neutrino as development in production environments like Heroku.