### PR TITLE
Adjust Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":maintainLockFilesWeekly",
+    ":prNotPending",
+    ":unpublishSafe"
   ],
   "reviewers": [
     "mozilla-neutrino/core-contributors"


### PR DESCRIPTION
Makes Renovate:
* refresh the lockfile every Monday ([docs](https://renovateapp.com/docs/config-presets/config-default#maintainlockfilesweekly))
* wait until the Travis run on the branch has completed before opening the PR (avoids the issue of opening a GitHub notification email only to find there isn't yet a Travis result to inform review; [docs](https://renovateapp.com/docs/config-presets/config-default#prnotpending)).
* add a status check to its PRs, that warns if the package is still within the 24 hour period in which it could be unpublished ([docs](https://renovateapp.com/docs/config-presets/config-default#unpublishsafe)). This combined with `:prNotPending` has an added bonus of reducing noise if a release was broken and then fixed within the 24 hour period.

(The newly added options are what we've been using on mozilla/treeherder for the last few months.)