### PR TITLE
Stop passing invalid 'name' option to html-loader

### DIFF
--- a/packages/html-loader/index.js
+++ b/packages/html-loader/index.js
@@ -1,8 +1,6 @@
-const merge = require('deepmerge');
-
 module.exports = (neutrino, options = {}) => neutrino.config.module
   .rule('html')
   .test(neutrino.regexFromExtensions(['html']))
   .use('html')
     .loader(require.resolve('html-loader'))
-    .options(merge({ name: '[name].[ext]' }, options));
+    .options(options);

--- a/packages/html-loader/package.json
+++ b/packages/html-loader/package.json
@@ -22,7 +22,6 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "html-loader": "^0.5.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Since it's not an option [html-loader](https://webpack.js.org/loaders/html-loader/) has ever recognised.

Fixes #681.