### PR TITLE
Make 'neutrino lint --debug' configure ESLint debug logging

### DIFF
--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -1,7 +1,6 @@
 const Future = require('fluture');
 const deepmerge = require('deepmerge');
 const clone = require('lodash.clonedeep');
-const { CLIEngine } = require('eslint');
 const {
   assoc, curry, evolve, keys, omit, pathOr, pipe, prop, reduce
 } = require('ramda');
@@ -121,6 +120,16 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.register(
     'lint',
     () => {
+      if (neutrino.options.debug) {
+        // Inspired by the ESLint CLI `--debug` implementation (but with less verbose output):
+        // https://github.com/eslint/eslint/blob/v4.19.0/bin/eslint.js#L21-L23
+        // eslint-disable-next-line global-require
+        require('debug').enable('eslint:cli-engine');
+      }
+      // Must be imported after configuring debug.
+      // eslint-disable-next-line global-require
+      const { CLIEngine } = require('eslint');
+
       const { fix = false } = neutrino.options.args;
       const ignorePattern = (options.exclude || [])
         .map(exclude => join(

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "babel-eslint": "^8.0.3",
+    "debug": "^3.1.0",
     "deepmerge": "^1.5.2",
     "eslint": "^4.12.1",
     "eslint-loader": "^2.0.0",


### PR DESCRIPTION
Inspired by the ESLint CLI implementation:
https://github.com/eslint/eslint/blob/v4.19.0/bin/eslint.js#L21-L23

Results in output like:
```
$ node packages/neutrino/bin/neutrino lint --debug
- Running lint  eslint:cli-engine Processing C:\Users\Ed\src\neutrino-dev\.eslintrc.js +0ms
  eslint:cli-engine Linting C:\Users\Ed\src\neutrino-dev\.eslintrc.js +0ms
  eslint:cli-engine Processing C:\Users\Ed\src\neutrino-dev\.neutrinorc.js +469ms
  eslint:cli-engine Linting C:\Users\Ed\src\neutrino-dev\.neutrinorc.js +0ms
  eslint:cli-engine Processing C:\Users\Ed\src\neutrino-dev\packages\airbnb-base\eslintrc.js +31ms
  eslint:cli-engine Linting C:\Users\Ed\src\neutrino-dev\packages\airbnb-base\eslintrc.js +0ms
```

Debug logging has deliberately been configured only for the `lint` command case, since:
* for the `eslintrc` command, users can just (and will have to anyway) pass `--debug` directly to the eslint CLI
* the `eslint-loader` case ends up being way too spammy (and if people are debugging ESLint issues, they'll presumably be focusing on them specifically using the `lint` command and not `start`/`build`).

Refs #389.