### PR TITLE
Make lint-staged not automatically fix lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "yarn lint --fix",
-      "git add"
+      "yarn lint"
     ]
   }
 }


### PR DESCRIPTION
Since otherwise it breaks partial staging of changes in a file.

Fixes #756.