### PR TITLE
Stop using the fast-async babel plugin

### DIFF
--- a/docs/customization/README.md
+++ b/docs/customization/README.md
@@ -242,7 +242,6 @@ module.exports = {
     }],
 
     ['@neutrinojs/react', {
-      polyfills: { async: false },
       html: { title: 'Epic React App' }
     }],
 

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -172,7 +172,7 @@ module.exports = {
     '@neutrinojs/airbnb-base',
     
     // array format
-    ['@neutrinojs/react', { polyfills: { async: false } }],
+    ['@neutrinojs/react', html: { title: 'Epic React App' } }],
     
     // function format
     (neutrino) => {

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -245,11 +245,6 @@ module.exports = {
       // such as whitelisting dependencies for bundling.
       externals: {},
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Remove the contents of the output directory prior to building.
       // Set to false to disable cleaning this directory
       clean: {

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -256,11 +256,6 @@ module.exports = {
       // Enables Hot Module Replacement. Set to false to disable
       hot: true,
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Target specific versions via babel-preset-env
       targets: {
         node: '6.10'
@@ -280,9 +275,6 @@ module.exports = {
             targets: { node: '6.10' },
             modules: false,
             useBuiltIns: true,
-            // These are excluded when using polyfills.async. Disabling the async polyfill
-            // will remove these from the exclusion list
-            exclude: ['transform-regenerator', 'transform-async-to-generator']
           }]
         ]
       }

--- a/docs/packages/preact/README.md
+++ b/docs/packages/preact/README.md
@@ -233,7 +233,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -222,7 +222,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/docs/packages/vue/README.md
+++ b/docs/packages/vue/README.md
@@ -237,7 +237,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -191,11 +191,6 @@ module.exports = {
       // Enables Hot Module Replacement. Set to false to disable
       hot: true,
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Sets webpack's `output.publicPath` and
       // `devServer.publicPath` settings. Useful if you want to
       // serve assets from a non-root location (e.g. `/assets/`)
@@ -253,7 +248,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -245,11 +245,6 @@ module.exports = {
       // such as whitelisting dependencies for bundling.
       externals: {},
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Remove the contents of the output directory prior to building.
       // Set to false to disable cleaning this directory
       clean: {

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -18,9 +18,6 @@ module.exports = (neutrino, opts = {}) => {
   const options = merge({
     target: 'web',
     libraryTarget: 'umd',
-    polyfills: {
-      async: true
-    },
     babel: {},
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
@@ -30,7 +27,6 @@ module.exports = (neutrino, opts = {}) => {
   Object.assign(options, {
     babel: compileLoader.merge({
       plugins: [
-        ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
         options.target === 'node' ?
           require.resolve('babel-plugin-dynamic-import-node') :
           require.resolve('babel-plugin-syntax-dynamic-import')
@@ -40,7 +36,6 @@ module.exports = (neutrino, opts = {}) => {
           debug: neutrino.options.debug,
           modules: false,
           useBuiltIns: true,
-          exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : [],
           targets: options.target === 'node' ?
             { node: '6.10' } :
             { browsers: [] }

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -41,7 +41,6 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.0",
     "deepmerge": "^1.5.2",
-    "fast-async": "^6.3.0",
     "webpack": "^3.10.0",
     "webpack-node-externals": "^1.6.0",
     "webpack-sources": "1.0.1",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -256,11 +256,6 @@ module.exports = {
       // Enables Hot Module Replacement. Set to false to disable
       hot: true,
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Target specific versions via babel-preset-env
       targets: {
         node: '6.10'
@@ -280,9 +275,6 @@ module.exports = {
             targets: { node: '6.10' },
             modules: false,
             useBuiltIns: true,
-            // These are excluded when using polyfills.async. Disabling the async polyfill
-            // will remove these from the exclusion list
-            exclude: ['transform-regenerator', 'transform-async-to-generator']
           }]
         ]
       }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -33,9 +33,6 @@ module.exports = (neutrino, opts = {}) => {
   );
   const options = merge({
     hot: true,
-    polyfills: {
-      async: true
-    },
     targets: {
       node: '6.10'
     },
@@ -49,7 +46,6 @@ module.exports = (neutrino, opts = {}) => {
     exclude: [staticDir],
     babel: compile.merge({
       plugins: [
-        ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
         require.resolve('babel-plugin-dynamic-import-node')
       ],
       presets: [
@@ -57,8 +53,7 @@ module.exports = (neutrino, opts = {}) => {
           debug: neutrino.options.debug,
           targets: options.targets,
           modules: false,
-          useBuiltIns: true,
-          exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : []
+          useBuiltIns: true
         }]
       ]
     }, options.babel)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,6 @@
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-preset-env": "^1.6.0",
     "deepmerge": "^1.5.2",
-    "fast-async": "^6.3.0",
     "ramda": "^0.25.0",
     "webpack": "^3.10.0",
     "webpack-node-externals": "^1.6.0",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -233,7 +233,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -222,7 +222,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -237,7 +237,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -191,11 +191,6 @@ module.exports = {
       // Enables Hot Module Replacement. Set to false to disable
       hot: true,
 
-      polyfills: {
-        // Enables fast-async polyfill. Set to false to disable
-        async: true
-      },
-
       // Sets webpack's `output.publicPath` and
       // `devServer.publicPath` settings. Useful if you want to
       // serve assets from a non-root location (e.g. `/assets/`)
@@ -253,7 +248,6 @@ module.exports = {
           ['babel-preset-env', {
             modules: false,
             useBuiltIns: true,
-            exclude: ['transform-regenerator', 'transform-async-to-generator'],
           }]
         ]
       }

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -28,9 +28,6 @@ module.exports = (neutrino, opts = {}) => {
     hot: true,
     hotEntries: [],
     html: {},
-    polyfills: {
-      async: true
-    },
     devServer: {
       hot: opts.hot !== false,
       publicPath: resolve('/', publicPath)
@@ -88,7 +85,6 @@ module.exports = (neutrino, opts = {}) => {
     }),
     babel: compileLoader.merge({
       plugins: [
-        ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
         require.resolve('babel-plugin-syntax-dynamic-import')
       ],
       presets: [
@@ -96,7 +92,6 @@ module.exports = (neutrino, opts = {}) => {
           debug: neutrino.options.debug,
           modules: false,
           useBuiltIns: true,
-          exclude: options.polyfills.async ? ['transform-regenerator', 'transform-async-to-generator'] : [],
           targets: options.targets
         }]
       ]

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,6 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-env": "^1.6.0",
     "deepmerge": "^1.5.2",
-    "fast-async": "^6.3.0",
     "webpack": "^3.10.0",
     "webpack-manifest-plugin": "^2.0.0",
     "webpack-sources": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,10 +204,6 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-es7-plugin@>=1.1.6:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz#f2ee1f3228a90eead1245f9ab1922eb2e71d336b"
-
 acorn-globals@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -241,7 +237,7 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.1, acorn@^5.5.0, acorn@^5.5.3:
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.1, acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
@@ -359,13 +355,13 @@ ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
 
-ansi-regex@*, ansi-regex@^3.0.0, ansi-regex@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0, ansi-regex@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -3665,7 +3661,7 @@ debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -5051,13 +5047,6 @@ fancy-log@^1.1.0:
     ansi-gray "^0.1.1"
     color-support "^1.1.3"
     time-stamp "^1.0.0"
-
-fast-async@^6.3.0:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/fast-async/-/fast-async-6.3.4.tgz#eedac29557146fa2643255756c807bb154fb1604"
-  dependencies:
-    nodent-compiler ">=3.1.8"
-    nodent-runtime ">=3.2.1"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -6701,7 +6690,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -8419,10 +8408,6 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -8438,25 +8423,11 @@ lodash._basevalues@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -8598,7 +8569,7 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -9515,18 +9486,6 @@ nodemailer@^2.5.0:
     nodemailer-smtp-pool "2.8.2"
     nodemailer-smtp-transport "2.7.2"
     socks "1.1.9"
-
-nodent-compiler@>=3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/nodent-compiler/-/nodent-compiler-3.1.8.tgz#2171b805c394c1ddeaf87f8347bba7edd29b3090"
-  dependencies:
-    acorn "^5.5.3"
-    acorn-es7-plugin ">=1.1.6"
-    source-map "^0.5.6"
-
-nodent-runtime@>=3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
 
 "nopt@2 || 3", nopt@3.x, nopt@~3.0.6:
   version "3.0.6"
@@ -11473,7 +11432,7 @@ readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -13934,7 +13893,7 @@ vali-date@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@~3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:


### PR DESCRIPTION
Since:
* The default Neutrino supported browsers (last two versions of Chrome, Firefox, Edge, Opera, Safari & iOS) all support async natively:
  https://caniuse.com/#feat=async-functions
* The same applies to Node 8+ (and Neutrino 9 is dropping support for Node 6):
  http://node.green/#ES2017-features-async-functions
* Neutrino 9 final will be released with Babel 7, which will likely include built-in support for the fast-async plugin anyway:
  https://github.com/babel/babel/pull/7076
* It's another dependency to cause possible regressions, eg:
  https://github.com/MatAtBread/fast-async/issues/53

Fixes #741.