### PR TITLE
Extract css without contenthash by default (react-components preset)

### DIFF
--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -13,7 +13,8 @@ module.exports = (neutrino, opts = {}) => {
       title: 'React Preview'
     },
     manifest: process.env.NODE_ENV === 'development',
-    externals: opts.externals !== false && {}
+    externals: opts.externals !== false && {},
+    style: { extract: { plugin: { filename: '[name].css' } } },
   }, opts);
 
   neutrino.config.resolve.modules

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -14,7 +14,7 @@ module.exports = (neutrino, opts = {}) => {
     },
     manifest: process.env.NODE_ENV === 'development',
     externals: opts.externals !== false && {},
-    style: { extract: { plugin: { filename: '[name].css' } } },
+    style: { extract: { plugin: { filename: '[name].css' } } }
   }, opts);
 
   neutrino.config.resolve.modules


### PR DESCRIPTION
Changes the default options for styles so that the content hash isn't included in filenames when css is extracted. This makes stylesheets easier to import.

EX:

```js
// BEFORE
import 'my-component/build/MyComponent.qwerihqwenoasidf.css'
// AFTER
import 'my-component/build/MyComponent.css'
```