### PR TITLE
Remove default CopyPlugin from src/static/ to build/static/

### DIFF
--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -332,7 +332,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `banner` | Injects source-map-support into the mains (entry points) of your application if detected in `dependencies` or `devDependencies` of your package.json. | Only when `source-map-support` is installed |
-| `copy` | Copies all files from `src/static` to `build` when using `neutrino build`. | `build` command |
 | `clean` | Clears the contents of `build` prior to creating a production bundle. | `build` command |
 | `start-server` | Start a Node.js for the first configured main entry point. | `start` command |
 | `hot` | Enables Hot Module Replacement. | `start` command |

--- a/docs/packages/preact/README.md
+++ b/docs/packages/preact/README.md
@@ -183,10 +183,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../copy).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](../copy) preset alongside this one.
 
 ## Paths
 

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -168,10 +168,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../../packages/copy/README.md).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](../copy) preset alongside this one.
 
 ## Paths
 

--- a/docs/packages/vue/README.md
+++ b/docs/packages/vue/README.md
@@ -186,10 +186,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../copy).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](../copy) preset alongside this one.
 
 ## Paths
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -161,10 +161,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../../packages/copy/README.md).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](../copy) preset alongside this one.
 
 ## Paths
 
@@ -439,7 +437,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | `runtime-chunk` | Creates a separate file/chunk consisting of the webpack manifest-specific code. From `@neutrinojs/chunk`. | `NODE_ENV production` |
 | `name-all` | Names all remaining modules that do not get named via `named-modules`. From `@neutrinojs/chunk`. | `NODE_ENV production` |
 | `hot` | Enables Hot Module Replacement. From `@neutrinojs/hot`. | `start` command |
-| `copy` | Copies files during build, defaults from `src/static` to `build/static`. From `@neutrinojs/copy` | `build` command |
 | `clean` | Removes the `build` directory prior to building. From `@neutrinojs/clean`. | `build` command |
 | `babel-minify` | Minifies source code using `BabelMinifyWebpackPlugin`. From `@neutrinojs/minify`. | `NODE_ENV production` |
 | `imagemin` | Optimize any images added by other webpack plugins (e.g. `copy-webpack-plugin`). From `@neutrinojs/minify`. | Enable with `options.minify.style`. |

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -25,9 +25,7 @@ necessary for creating your builds.
 ## Build Assets
 
 When creating a build bundle, a preset will put the compiled assets, including any generated
-JavaScript files, into a directory named `build` by default. Typically your Neutrino preset will copy
-any files from the `static` directory over to the build directory, allowing you to maintain
-the same relative path structure for static assets as is used for the source files.
+JavaScript files, into a directory named `build` by default.
 
 Normally most projects will exclude checking in this build directory to source control.
 Be sure to add this directory to your project's `.gitignore`, `.hgignore`, or similar file.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -332,7 +332,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `banner` | Injects source-map-support into the mains (entry points) of your application if detected in `dependencies` or `devDependencies` of your package.json. | Only when `source-map-support` is installed |
-| `copy` | Copies all files from `src/static` to `build` when using `neutrino build`. | `build` command |
 | `clean` | Clears the contents of `build` prior to creating a production bundle. | `build` command |
 | `start-server` | Start a Node.js for the first configured main entry point. | `start` command |
 | `hot` | Enables Hot Module Replacement. | `start` command |

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,6 +1,5 @@
 const banner = require('@neutrinojs/banner');
 const compile = require('@neutrinojs/compile-loader');
-const copy = require('@neutrinojs/copy');
 const clean = require('@neutrinojs/clean');
 const startServer = require('@neutrinojs/start-server');
 const hot = require('@neutrinojs/hot');
@@ -25,7 +24,6 @@ const getOutputForEntry = pipe(
 
 module.exports = (neutrino, opts = {}) => {
   const pkg = neutrino.options.packageJson;
-  const staticDir = join(neutrino.options.source, 'static');
   const sourceMap = pathOr(
     pathOr(false, ['dependencies', 'source-map-support'], pkg),
     ['devDependencies', 'source-map-support'],
@@ -43,7 +41,6 @@ module.exports = (neutrino, opts = {}) => {
 
   neutrino.use(compile, {
     include: [neutrino.options.source, neutrino.options.tests],
-    exclude: [staticDir],
     babel: compile.merge({
       plugins: [
         require.resolve('babel-plugin-dynamic-import-node')
@@ -136,12 +133,5 @@ module.exports = (neutrino, opts = {}) => {
     })
     .when(neutrino.options.command === 'build', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
-      neutrino.use(copy, {
-        patterns: [{
-          context: staticDir,
-          from: '**/*',
-          to: basename(staticDir)
-        }]
-      });
     });
 };

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,7 +29,6 @@
     "@neutrinojs/banner": "^8.2.0",
     "@neutrinojs/clean": "^8.2.0",
     "@neutrinojs/compile-loader": "^8.2.0",
-    "@neutrinojs/copy": "^8.2.0",
     "@neutrinojs/hot": "^8.2.0",
     "@neutrinojs/start-server": "^8.2.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -183,10 +183,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](https://neutrino.js.org/packages/copy) preset alongside this one.
 
 ## Paths
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -168,10 +168,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](https://neutrino.js.org/packages/copy) preset alongside this one.
 
 ## Paths
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -186,10 +186,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](https://neutrino.js.org/packages/copy) preset alongside this one.
 
 ## Paths
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -161,10 +161,8 @@ You can either serve or deploy the contents of this `build` directory as a stati
 
 ## Static assets
 
-If you wish to copy files to the build directory that are not imported from application code, you can place
-them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
-to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy/README.md).
+If you wish to copy files to the build directory that are not imported from application code,
+use the [@neutrinojs/copy](https://neutrino.js.org/packages/copy) preset alongside this one.
 
 ## Paths
 
@@ -439,7 +437,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | `runtime-chunk` | Creates a separate file/chunk consisting of the webpack manifest-specific code. From `@neutrinojs/chunk`. | `NODE_ENV production` |
 | `name-all` | Names all remaining modules that do not get named via `named-modules`. From `@neutrinojs/chunk`. | `NODE_ENV production` |
 | `hot` | Enables Hot Module Replacement. From `@neutrinojs/hot`. | `start` command |
-| `copy` | Copies files during build, defaults from `src/static` to `build/static`. From `@neutrinojs/copy` | `build` command |
 | `clean` | Removes the `build` directory prior to building. From `@neutrinojs/clean`. | `build` command |
 | `babel-minify` | Minifies source code using `BabelMinifyWebpackPlugin`. From `@neutrinojs/minify`. | `NODE_ENV production` |
 | `imagemin` | Optimize any images added by other webpack plugins (e.g. `copy-webpack-plugin`). From `@neutrinojs/minify`. | Enable with `options.minify.style`. |

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -7,12 +7,11 @@ const env = require('@neutrinojs/env');
 const hot = require('@neutrinojs/hot');
 const htmlTemplate = require('@neutrinojs/html-template');
 const chunk = require('@neutrinojs/chunk');
-const copy = require('@neutrinojs/copy');
 const clean = require('@neutrinojs/clean');
 const minify = require('@neutrinojs/minify');
 const loaderMerge = require('@neutrinojs/loader-merge');
 const devServer = require('@neutrinojs/dev-server');
-const { join, basename } = require('path');
+const { join } = require('path');
 const { resolve } = require('url');
 const merge = require('deepmerge');
 const ManifestPlugin = require('webpack-manifest-plugin');
@@ -98,8 +97,6 @@ module.exports = (neutrino, opts = {}) => {
     }, options.babel)
   });
 
-  const staticDir = join(neutrino.options.source, 'static');
-
   neutrino.use(env, options.env);
   neutrino.use(htmlLoader);
   neutrino.use(compileLoader, {
@@ -107,7 +104,6 @@ module.exports = (neutrino, opts = {}) => {
       neutrino.options.source,
       neutrino.options.tests
     ],
-    exclude: [staticDir],
     babel: options.babel
   });
 
@@ -216,13 +212,6 @@ module.exports = (neutrino, opts = {}) => {
     })
     .when(neutrino.options.command === 'build', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
-      neutrino.use(copy, {
-        patterns: [{
-          context: staticDir,
-          from: '**/*',
-          to: basename(staticDir)
-        }]
-      });
 
       if (options.manifest) {
         neutrino.config.plugin('manifest')

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,7 +29,6 @@
     "@neutrinojs/chunk": "^8.2.0",
     "@neutrinojs/clean": "^8.2.0",
     "@neutrinojs/compile-loader": "^8.2.0",
-    "@neutrinojs/copy": "^8.2.0",
     "@neutrinojs/dev-server": "^8.2.0",
     "@neutrinojs/env": "^8.2.0",
     "@neutrinojs/font-loader": "^8.2.0",


### PR DESCRIPTION
Since for most assets users should be importing in the build, and for the valid use-cases of not doing that (eg `robots.txt`), this default plugin didn't help anyway.

Another step forwards in making Neutrino default to fulfilling the 80% case, and then leaving the 20% to opt-in middleware, rather than having too much enabled by default.