### PR TITLE
Remove NamedModulesPlugin from @neutrinojs/hot

### DIFF
--- a/docs/packages/hot/README.md
+++ b/docs/packages/hot/README.md
@@ -60,7 +60,6 @@ The following is a list of plugins and their identifiers which can be overridden
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `hot` | Enables Hot Module Replacement. | all |
-| `named-modules` | Enables named modules for improved debugging and console output. | all |
 
 ## Contributing
 

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -335,7 +335,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | `clean` | Clears the contents of `build` prior to creating a production bundle. | `build` command |
 | `start-server` | Start a Node.js for the first configured main entry point. | `start` command |
 | `hot` | Enables Hot Module Replacement. | `start` command |
-| `named-modules` | Enables named modules for improved debugging and console output. From `@neutrinojs/hot`. | `start` command |
 
 ### Override configuration
 

--- a/packages/hot/README.md
+++ b/packages/hot/README.md
@@ -60,7 +60,6 @@ The following is a list of plugins and their identifiers which can be overridden
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `hot` | Enables Hot Module Replacement. | all |
-| `named-modules` | Enables named modules for improved debugging and console output. | all |
 
 ## Contributing
 

--- a/packages/hot/index.js
+++ b/packages/hot/index.js
@@ -1,8 +1,5 @@
-const { HotModuleReplacementPlugin, NamedModulesPlugin } = require('webpack');
+const { HotModuleReplacementPlugin } = require('webpack');
 
 module.exports = ({ config }) => config
   .plugin('hot')
-    .use(HotModuleReplacementPlugin)
-    .end()
-  .plugin('named-modules')
-    .use(NamedModulesPlugin);
+    .use(HotModuleReplacementPlugin);

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -335,7 +335,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | `clean` | Clears the contents of `build` prior to creating a production bundle. | `build` command |
 | `start-server` | Start a Node.js for the first configured main entry point. | `start` command |
 | `hot` | Enables Hot Module Replacement. | `start` command |
-| `named-modules` | Enables named modules for improved debugging and console output. From `@neutrinojs/hot`. | `start` command |
 
 ### Override configuration
 


### PR DESCRIPTION
Since webpack 4 now loads the plugin by default in development.

Leftover from #809.