### PR TITLE
Add Node 10 to the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ cache: yarn
 node_js:
 - '8'
 - '9'
+- '10'
 before_install:
 # Use newer yarn than that pre-installed in the Travis image.
 - curl -sSfL https://yarnpkg.com/install.sh | bash
 - export PATH="$HOME/.yarn/bin:$PATH"
 install:
-- yarn install --frozen-lockfile
+# Remove --ignore-engines when this fixed:
+# https://github.com/anodynos/upath/issues/14
+- yarn install --frozen-lockfile --ignore-engines
 - yarn link:all
 script:
 - yarn validate:eslintrc


### PR DESCRIPTION
Node 10 has now been released:
https://nodejs.org/en/blog/release/v10.0.0/

We already have `"node": ">=8"` in package.json engines and `Node.js v8+` in the READMEs, so this should be all that needs updating.