### PR TITLE
Disable Renovate's automatic semantic commits detection

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     ":maintainLockFilesWeekly",
     ":prNotPending",
+    ":semanticCommitsDisabled",
     ":unpublishSafe"
   ],
   "reviewers": [


### PR DESCRIPTION
Since it interprets the commits of form "foo: ..." as meaning that we use the semantic commits workflow (eg "chore(deps): ..."), when we don't.

See:
https://renovatebot.com/docs/deep-dives/semantic-commits