### PR TITLE
Raise minimum node.js from 8.0 to 8.3

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -11,7 +11,7 @@ with this symbol show sample console output from running the previous command._
 
 Developing for neutrino-dev requires:
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, installation instructions at https://yarnpkg.com/en/docs/install
 - git, GitHub account
 

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Installing Neutrino requires Node.js v8+, and either [Yarn](https://yarnpkg.com/lang/en/docs/install/) or
+Installing Neutrino requires Node.js v8.3+, and either [Yarn](https://yarnpkg.com/lang/en/docs/install/) or
 npm. At a minimum, you will be installing Neutrino and Neutrino middleware, such as `@neutrinojs/react`.
 
 ## Create New Project

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -19,7 +19,7 @@ _Note: If you are building a React project, you should probably use
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -16,7 +16,7 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/banner/README.md
+++ b/docs/packages/banner/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/clean/README.md
+++ b/docs/packages/clean/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/compile-loader/README.md
+++ b/docs/packages/compile-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/copy/README.md
+++ b/docs/packages/copy/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/dev-server/README.md
+++ b/docs/packages/dev-server/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/env/README.md
+++ b/docs/packages/env/README.md
@@ -10,7 +10,7 @@ use) available inside your project. Always injects `process.env.NODE_ENV`, unles
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/eslint/README.md
+++ b/docs/packages/eslint/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/font-loader/README.md
+++ b/docs/packages/font-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/fork/README.md
+++ b/docs/packages/fork/README.md
@@ -9,7 +9,7 @@ You can combine this with other middleware to configure and build multiple proje
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/hot/README.md
+++ b/docs/packages/hot/README.md
@@ -9,7 +9,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/html-loader/README.md
+++ b/docs/packages/html-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/html-template/README.md
+++ b/docs/packages/html-template/README.md
@@ -9,7 +9,7 @@ entry points.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/image-loader/README.md
+++ b/docs/packages/image-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/image-minify/README.md
+++ b/docs/packages/image-minify/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/jest/README.md
+++ b/docs/packages/jest/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/karma/README.md
+++ b/docs/packages/karma/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -18,7 +18,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/loader-merge/README.md
+++ b/docs/packages/loader-merge/README.md
@@ -9,7 +9,7 @@ a named rule and named loader in a Neutrino configuration.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/mocha/README.md
+++ b/docs/packages/mocha/README.md
@@ -14,7 +14,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a Node.js project
-- Modern Babel compilation supporting ES modules, Node.js 8+, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, Node.js 8.3+, async functions, and dynamic imports
 - Supports automatically-wired sourcemaps
 - Tree-shaking to create smaller bundles
 - Hot Module Replacement with source-watching during development
@@ -18,7 +18,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 
@@ -258,7 +258,7 @@ module.exports = {
 
       // Target specific versions via babel-preset-env
       targets: {
-        node: '8.0'
+        node: '8.3'
       },
 
       // Remove the contents of the output directory prior to building.
@@ -272,7 +272,7 @@ module.exports = {
         // Override options for babel-preset-env, showing defaults:
         presets: [
           ['babel-preset-env', {
-            targets: { node: '8.0' },
+            targets: { node: '8.3' },
             modules: false,
             useBuiltIns: true,
           }]

--- a/docs/packages/preact/README.md
+++ b/docs/packages/preact/README.md
@@ -26,7 +26,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/pwa/README.md
+++ b/docs/packages/pwa/README.md
@@ -9,7 +9,7 @@ Application capabilities. This middleware is usually only added during productio
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/react-components/README.md
+++ b/docs/packages/react-components/README.md
@@ -31,7 +31,7 @@ polyfills in your library code, consider importing babel-polyfill, core-js, or o
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 - React, React DOM

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -26,7 +26,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/standardjs/README.md
+++ b/docs/packages/standardjs/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/docs/packages/start-server/README.md
+++ b/docs/packages/start-server/README.md
@@ -9,7 +9,7 @@ completion of a build.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/style-loader/README.md
+++ b/docs/packages/style-loader/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/style-minify/README.md
+++ b/docs/packages/style-minify/README.md
@@ -10,7 +10,7 @@ added during production builds.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/vue/README.md
+++ b/docs/packages/vue/README.md
@@ -22,7 +22,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -22,7 +22,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "repository": "mozilla-neutrino/neutrino-dev",
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -19,7 +19,7 @@ _Note: If you are building a React project, you should probably use
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/airbnb-base/package.json
+++ b/packages/airbnb-base/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -16,7 +16,7 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/clean/README.md
+++ b/packages/clean/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/clean/package.json
+++ b/packages/clean/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/compile-loader/README.md
+++ b/packages/compile-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/copy/README.md
+++ b/packages/copy/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -10,7 +10,7 @@ use) available inside your project. Always injects `process.env.NODE_ENV`, unles
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/font-loader/README.md
+++ b/packages/font-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/fork/README.md
+++ b/packages/fork/README.md
@@ -9,7 +9,7 @@ You can combine this with other middleware to configure and build multiple proje
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/fork/package.json
+++ b/packages/fork/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/hot/README.md
+++ b/packages/hot/README.md
@@ -9,7 +9,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/hot/package.json
+++ b/packages/hot/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/html-loader/README.md
+++ b/packages/html-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/html-loader/package.json
+++ b/packages/html-loader/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -9,7 +9,7 @@ entry points.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/image-loader/README.md
+++ b/packages/image-loader/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/image-minify/README.md
+++ b/packages/image-minify/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/karma/README.md
+++ b/packages/karma/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/karma/package.json
+++ b/packages/karma/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -18,7 +18,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -35,7 +35,7 @@ module.exports = (neutrino, opts = {}) => {
           modules: false,
           useBuiltIns: true,
           targets: options.target === 'node' ?
-            { node: '8.0' } :
+            { node: '8.3' } :
             { browsers: [] }
         }]
       ]

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/loader-merge/README.md
+++ b/packages/loader-merge/README.md
@@ -9,7 +9,7 @@ a named rule and named loader in a Neutrino configuration.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/loader-merge/package.json
+++ b/packages/loader-merge/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -14,7 +14,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -22,7 +22,7 @@
     "test": "ava test"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a Node.js project
-- Modern Babel compilation supporting ES modules, Node.js 8+, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, Node.js 8.3+, async functions, and dynamic imports
 - Supports automatically-wired sourcemaps
 - Tree-shaking to create smaller bundles
 - Hot Module Replacement with source-watching during development
@@ -18,7 +18,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 
@@ -258,7 +258,7 @@ module.exports = {
 
       // Target specific versions via babel-preset-env
       targets: {
-        node: '8.0'
+        node: '8.3'
       },
 
       // Remove the contents of the output directory prior to building.
@@ -272,7 +272,7 @@ module.exports = {
         // Override options for babel-preset-env, showing defaults:
         presets: [
           ['babel-preset-env', {
-            targets: { node: '8.0' },
+            targets: { node: '8.3' },
             modules: false,
             useBuiltIns: true,
           }]

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -31,7 +31,7 @@ module.exports = (neutrino, opts = {}) => {
   const options = merge({
     hot: true,
     targets: {
-      node: '8.0'
+      node: '8.3'
     },
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -26,7 +26,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -9,7 +9,7 @@ Application capabilities. This middleware is usually only added during productio
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -31,7 +31,7 @@ polyfills in your library code, consider importing babel-polyfill, core-js, or o
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 - React, React DOM

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,7 +26,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8, Neutrino build preset
 

--- a/packages/standardjs/package.json
+++ b/packages/standardjs/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/start-server/README.md
+++ b/packages/start-server/README.md
@@ -9,7 +9,7 @@ completion of a build.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -16,7 +16,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/style-minify/README.md
+++ b/packages/style-minify/README.md
@@ -10,7 +10,7 @@ added during production builds.
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/style-minify/package.json
+++ b/packages/style-minify/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -22,7 +22,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -22,7 +22,7 @@
 
 ## Requirements
 
-- Node.js v8+
+- Node.js v8.3+
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino v8
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=8.3",
     "npm": ">=5.4.0",
     "yarn": ">=1.2.1"
   },


### PR DESCRIPTION
Since it guarantees object rest/spread properties support:
http://node.green/#ES2018-features-object-rest-spread-properties

...and so will mean the Babel plugin for it can be dropped from node environments (eg the Jest test runner) in future PRs.