### PR TITLE
pwa: Update offline-plugin to v5

### DIFF
--- a/packages/pwa/index.js
+++ b/packages/pwa/index.js
@@ -13,7 +13,6 @@ module.exports = (neutrino, options = {}) => {
         ServiceWorker: {
           events: true
         },
-        AppCache: false,
         relativePaths: false,
         excludes: ['_redirects'],
         cacheMaps: [{ match: /.*/, to: '/', requestTypes: ['navigate'] }],

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
-    "offline-plugin": "^4.8.5"
+    "offline-plugin": "^5.0.2"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0"

--- a/packages/pwa/pwa.js
+++ b/packages/pwa/pwa.js
@@ -1,6 +1,6 @@
-import runtime from 'offline-plugin/runtime';
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 
-runtime.install({
-  onUpdateReady: () => runtime.applyUpdate(),
+OfflinePluginRuntime.install({
+  onUpdateReady: () => OfflinePluginRuntime.applyUpdate(),
   onUpdated: () => window.location.reload()
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8650,9 +8650,9 @@ obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
 
-offline-plugin@^4.8.5:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-4.9.1.tgz#e97a6be3118b4dc360e06ed4bc473f10f2de73b6"
+offline-plugin@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-5.0.2.tgz#67b429c31158ecd2161a1ef4145759d463f887ba"
   dependencies:
     deep-extend "^0.4.0"
     ejs "^2.3.4"


### PR DESCRIPTION
* Adds support for webpack 4
* Removes redundant `AppCache` option, since the default is now `false`
* Updates the runtime entrypoint to match the docs:
  https://github.com/NekR/offline-plugin/blob/v5.0.2/docs/runtime.md

Full changelog:
https://github.com/NekR/offline-plugin/releases/tag/v5.0.0

I tested that a build with this + the React preset succeeded (when it didn't previously), though it's non-trivial to test this locally beyond that.

Closes #824.