### PR TITLE
web: Simplify the font and image rules/loaders

### DIFF
--- a/docs/packages/font-loader/README.md
+++ b/docs/packages/font-loader/README.md
@@ -41,10 +41,7 @@ neutrino.use(fonts);
 
 // Usage showing default options
 neutrino.use(fonts, {
-  limit: '10000',
-  woff: {},
-  ttf: {},
-  eot: {}
+  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -60,19 +57,13 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/font-loader', {
-      limit: '10000',
-      woff: {},
-      ttf: {},
-      eot: {}
+      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
     }]
   ]
 };
 ```
 
-- `limit`: Return a Data URL if the file is smaller than a byte limit.
-- `woff`: Set options for the url-loader used when loading woff files.
-- `tff`: Set options for the url-loader used when loading ttf files.
-- `eot`: Set options for the file-loader used when loading eot files.
+- `name`: The template used by `file-loader` to determine the output filename.
 
 ## Customization
 
@@ -85,9 +76,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `woff` | Allows importing WOFF font files from modules. Contains a single loader named `url`. | all |
-| `ttf` | Allows importing TTF font files from modules. Contains a single loader named `url`. | all |
-| `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. | all |
+| `font` | Allows importing EOT, TTF, WOFF and WOFF2 font files from modules. Contains a single loader named `file`. | all |
 
 ## Contributing
 

--- a/docs/packages/image-loader/README.md
+++ b/docs/packages/image-loader/README.md
@@ -42,9 +42,7 @@ neutrino.use(images);
 // Usage showing default options
 neutrino.use(images, {
   limit: 8192,
-  svg: {},
-  img: {},
-  ico: {}
+  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -61,18 +59,14 @@ module.exports = {
   use: [
     ['@neutrinojs/image-loader', {
       limit: 8192,
-      svg: {},
-      img: {},
-      ico: {}
+      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
     }]
   ]
 };
 ```
 
-- `limit`: Return a Data URL if the file is smaller than a byte limit.
-- `svg`: Set options for the url-loader used when loading svg files.
-- `img`: Set options for the url-loader used when loading png, jpeg, gif, and webp files.
-- `ico`: Set options for the url-loader used when loading ico files.
+- `limit`: Return a Data URL instead of outputting a file, if the file is smaller than a byte limit.
+- `name`: The template used by `file-loader` to determine the output filename.
 
 ## Customization
 
@@ -85,9 +79,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `img` | Allows importing JPEG, PNG, GIF, and WEBP files from modules. Contains a single loader named `url`. | all |
-| `svg` | Allows importing SVG files from modules. Contains a single loader named `url`. | all |
-| `ico` | Allows importing ICO files from modules. Contains a single loader named `url`. | all |
+| `image` | Allows importing ICO, JPEG, PNG, GIF, SVG and WEBP files from modules. Contains a single loader named `url`. | all |
 
 ## Contributing
 

--- a/docs/packages/image-minify/README.md
+++ b/docs/packages/image-minify/README.md
@@ -55,10 +55,10 @@ neutrino.use(imagemin, {
   },
   plugin: {
     name: '[path][name].[ext]',
-    test: /\.(png|jpg|jpeg|gif|webp)$/
+    test: /\.(ico|png|jpg|jpeg|gif|svg|webp)$/
   },
   useId: 'imagemin',
-  rules: ['svg', 'img'],
+  rules: ['image'],
   pluginId: 'imagemin',
 });
 ```
@@ -79,9 +79,9 @@ module.exports = {
       imagemin: {},
       plugin: {
         name: '[path][name].[ext]',
-        test: /\.(png|jpg|jpeg|gif|webp)$/
+        test: /\.(ico|png|jpg|jpeg|gif|svg|webp)$/
       },
-      rules: ['svg', 'img'],
+      rules: ['image'],
       pluginId: 'imagemin'
     }]
   ]
@@ -104,8 +104,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `img` | Optimize JPEG, PNG, GIF, and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
-| `svg` | Optimize SVG files imported from modules. Contains a single loader named `imagemin`. | all |
+| `image` | Optimize JPEG, PNG, GIF, SVG and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
 
 ### Plugins
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -411,9 +411,8 @@ The following is a list of rules and their identifiers which can be overridden:
 | `html` | Allows importing HTML files from modules. Contains a single loader named `html`. From `@neutrinojs/html-loader`. | all |
 | `style` | Allows importing CSS stylesheets from modules. In production contains two loaders named `extract` and `css` which use `MiniCssExtractPlugin.loader` and `css-loader`, respectively. In development the `extract` loader is replaced by `style`, which uses `style-loader`. From `@neutrinojs/style-loader`. | all |
 | `style-modules` | Allows importing CSS Modules styles from modules. In production contains two loaders named `extract` and `css` which use `MiniCssExtractPlugin.loader` and `css-loader`, respectively. In development the `extract` loader is replaced by `style`, which uses `style-loader`. From `@neutrinojs/style-loader`. | all |
-| `img`, `svg`, `ico` | Allows import image files from modules. Each contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
-| `woff`, `ttf` | Allows importing WOFF and TTF font files from modules. Each contains a single loader named `url`. From `@neutrinojs/font-loader`. | all |
-| `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
+| `image` | Allows importing ICO, JPEG, PNG, GIF, SVG and WEBP files from modules. Contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
+| `font` | Allows importing EOT, TTF, WOFF and WOFF2 font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
 | `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins

--- a/packages/font-loader/README.md
+++ b/packages/font-loader/README.md
@@ -41,10 +41,7 @@ neutrino.use(fonts);
 
 // Usage showing default options
 neutrino.use(fonts, {
-  limit: '10000',
-  woff: {},
-  ttf: {},
-  eot: {}
+  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -60,19 +57,13 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/font-loader', {
-      limit: '10000',
-      woff: {},
-      ttf: {},
-      eot: {}
+      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
     }]
   ]
 };
 ```
 
-- `limit`: Return a Data URL if the file is smaller than a byte limit.
-- `woff`: Set options for the url-loader used when loading woff files.
-- `tff`: Set options for the url-loader used when loading ttf files.
-- `eot`: Set options for the file-loader used when loading eot files.
+- `name`: The template used by `file-loader` to determine the output filename.
 
 ## Customization
 
@@ -85,9 +76,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `woff` | Allows importing WOFF font files from modules. Contains a single loader named `url`. | all |
-| `ttf` | Allows importing TTF font files from modules. Contains a single loader named `url`. | all |
-| `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. | all |
+| `font` | Allows importing EOT, TTF, WOFF and WOFF2 font files from modules. Contains a single loader named `file`. | all |
 
 ## Contributing
 

--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,32 +1,13 @@
-const merge = require('deepmerge');
-
 module.exports = (neutrino, options = {}) => {
   const isBuild = neutrino.options.command === 'build';
-  const urlLoader = require.resolve('url-loader');
-  const fileLoader = require.resolve('file-loader');
-  const { limit, name } = merge({
-    limit: 10000,
+  const defaultOptions = {
     name: isBuild ? '[name].[hash].[ext]' : '[name].[ext]'
-  }, options);
+  };
 
   neutrino.config.module
-    .rule('woff')
-    .test(/\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
-    .use('url')
-      .loader(urlLoader)
-      .options(merge({ limit, name, mimetype: 'application/font-woff' }, options.woff || {}));
-
-  neutrino.config.module
-    .rule('ttf')
-    .test(/\.ttf(\?v=\d+\.\d+\.\d+)?$/)
-    .use('url')
-      .loader(urlLoader)
-      .options(merge({ limit, name, mimetype: 'application/octet-stream' }, options.ttf || {}));
-
-  neutrino.config.module
-    .rule('eot')
-    .test(/\.eot(\?v=\d+\.\d+\.\d+)?$/)
+    .rule('font')
+    .test(/\.(eot|ttf|woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
     .use('file')
-      .loader(fileLoader)
-      .options(merge({ name }, options.eot || {}));
+      .loader(require.resolve('file-loader'))
+      .options({ ...defaultOptions, ...options });
 };

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -22,9 +22,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "file-loader": "^1.1.11",
-    "url-loader": "^1.0.1",
     "webpack": "^4.7.0"
   },
   "peerDependencies": {

--- a/packages/font-loader/test/middleware_test.js
+++ b/packages/font-loader/test/middleware_test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { Neutrino } from 'neutrino';
 
 const mw = () => require('..');
-const options = { limit: 1024, woff: { limit: 2048 }, ttf: { limit: 4096 }, eot: { limit: 8192 } };
+const options = { name: '[name].[ext]' };
 
 test('loads middleware', t => {
   t.notThrows(mw);

--- a/packages/image-loader/README.md
+++ b/packages/image-loader/README.md
@@ -42,9 +42,7 @@ neutrino.use(images);
 // Usage showing default options
 neutrino.use(images, {
   limit: 8192,
-  svg: {},
-  img: {},
-  ico: {}
+  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -61,18 +59,14 @@ module.exports = {
   use: [
     ['@neutrinojs/image-loader', {
       limit: 8192,
-      svg: {},
-      img: {},
-      ico: {}
+      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
     }]
   ]
 };
 ```
 
-- `limit`: Return a Data URL if the file is smaller than a byte limit.
-- `svg`: Set options for the url-loader used when loading svg files.
-- `img`: Set options for the url-loader used when loading png, jpeg, gif, and webp files.
-- `ico`: Set options for the url-loader used when loading ico files.
+- `limit`: Return a Data URL instead of outputting a file, if the file is smaller than a byte limit.
+- `name`: The template used by `file-loader` to determine the output filename.
 
 ## Customization
 
@@ -85,9 +79,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `img` | Allows importing JPEG, PNG, GIF, and WEBP files from modules. Contains a single loader named `url`. | all |
-| `svg` | Allows importing SVG files from modules. Contains a single loader named `url`. | all |
-| `ico` | Allows importing ICO files from modules. Contains a single loader named `url`. | all |
+| `image` | Allows importing ICO, JPEG, PNG, GIF, SVG and WEBP files from modules. Contains a single loader named `url`. | all |
 
 ## Contributing
 

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -1,31 +1,14 @@
-const merge = require('deepmerge');
-
 module.exports = (neutrino, options = {}) => {
   const isBuild = neutrino.options.command === 'build';
-  const urlLoader = require.resolve('url-loader');
-  const { limit, name } = merge({
+  const defaultOptions = {
     limit: 8192,
     name: isBuild ? '[name].[hash].[ext]' : '[name].[ext]'
-  }, options);
+  };
 
   neutrino.config.module
-    .rule('svg')
-    .test(/\.svg(\?v=\d+\.\d+\.\d+)?$/)
+    .rule('image')
+    .test(/\.(ico|png|jpg|jpeg|gif|svg|webp)(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
-      .loader(urlLoader)
-      .options(merge({ limit, name }, options.svg || {}));
-
-  neutrino.config.module
-    .rule('img')
-    .test(/\.(png|jpg|jpeg|gif|webp)(\?v=\d+\.\d+\.\d+)?$/)
-    .use('url')
-      .loader(urlLoader)
-      .options(merge({ limit, name }, options.img || {}));
-
-  neutrino.config.module
-    .rule('ico')
-    .test(/\.ico(\?v=\d+\.\d+\.\d+)?$/)
-    .use('url')
-      .loader(urlLoader)
-      .options(merge({ limit, name }, options.ico || {}));
+      .loader(require.resolve('url-loader'))
+      .options({ ...defaultOptions, ...options });
 };

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -22,7 +22,6 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "file-loader": "^1.1.11",
     "url-loader": "^1.0.1"
   },

--- a/packages/image-loader/test/middleware_test.js
+++ b/packages/image-loader/test/middleware_test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { Neutrino } from 'neutrino';
 
 const mw = () => require('..');
-const options = { limit: 1024, img: { limit: 2048 }, svg: { limit: 4096 }, ico: { limit: 8192 } };
+const options = { limit: 1024, name: '[name].[ext]' };
 
 test('loads middleware', t => {
   t.notThrows(mw);

--- a/packages/image-minify/README.md
+++ b/packages/image-minify/README.md
@@ -55,10 +55,10 @@ neutrino.use(imagemin, {
   },
   plugin: {
     name: '[path][name].[ext]',
-    test: /\.(png|jpg|jpeg|gif|webp)$/
+    test: /\.(ico|png|jpg|jpeg|gif|svg|webp)$/
   },
   useId: 'imagemin',
-  rules: ['svg', 'img'],
+  rules: ['image'],
   pluginId: 'imagemin',
 });
 ```
@@ -79,9 +79,9 @@ module.exports = {
       imagemin: {},
       plugin: {
         name: '[path][name].[ext]',
-        test: /\.(png|jpg|jpeg|gif|webp)$/
+        test: /\.(ico|png|jpg|jpeg|gif|svg|webp)$/
       },
-      rules: ['svg', 'img'],
+      rules: ['image'],
       pluginId: 'imagemin'
     }]
   ]
@@ -104,8 +104,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
-| `img` | Optimize JPEG, PNG, GIF, and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
-| `svg` | Optimize SVG files imported from modules. Contains a single loader named `imagemin`. | all |
+| `image` | Optimize JPEG, PNG, GIF, SVG and WEBP files imported from modules. Contains a single loader named `imagemin`. | all |
 
 ### Plugins
 

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -25,7 +25,7 @@ module.exports = (neutrino, opts = {}) => {
     },
     pluginId: 'imagemin',
     useId: 'imagemin',
-    rules: ['svg', 'img']
+    rules: ['image']
   }, opts);
 
   if (!options.enabled) {

--- a/packages/image-minify/test/middleware_test.js
+++ b/packages/image-minify/test/middleware_test.js
@@ -4,7 +4,7 @@ import { Neutrino } from 'neutrino';
 const mw = () => require('..');
 const prodEnv = { env: { NODE_ENV: 'production' } };
 const devEnv = { env: { NODE_ENV: 'development' } };
-const options = { rules: ['img'] };
+const options = { rules: ['image'] };
 
 test('loads middleware', t => {
   t.notThrows(mw);

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -411,9 +411,8 @@ The following is a list of rules and their identifiers which can be overridden:
 | `html` | Allows importing HTML files from modules. Contains a single loader named `html`. From `@neutrinojs/html-loader`. | all |
 | `style` | Allows importing CSS stylesheets from modules. In production contains two loaders named `extract` and `css` which use `MiniCssExtractPlugin.loader` and `css-loader`, respectively. In development the `extract` loader is replaced by `style`, which uses `style-loader`. From `@neutrinojs/style-loader`. | all |
 | `style-modules` | Allows importing CSS Modules styles from modules. In production contains two loaders named `extract` and `css` which use `MiniCssExtractPlugin.loader` and `css-loader`, respectively. In development the `extract` loader is replaced by `style`, which uses `style-loader`. From `@neutrinojs/style-loader`. | all |
-| `img`, `svg`, `ico` | Allows import image files from modules. Each contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
-| `woff`, `ttf` | Allows importing WOFF and TTF font files from modules. Each contains a single loader named `url`. From `@neutrinojs/font-loader`. | all |
-| `eot` | Allows importing EOT font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
+| `image` | Allows importing ICO, JPEG, PNG, GIF, SVG and WEBP files from modules. Contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
+| `font` | Allows importing EOT, TTF, WOFF and WOFF2 font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
 | `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins


### PR DESCRIPTION
* Switches fonts from `url-loader` to `file-loader` (preventing inlining).
* Consolidates the `eot`, `ttf`, and `woff` rules into a single `font` rule.
* Consolidates the `ico`, `img` and `svg` rules into a single `image` rule.

Fixes #856.