### PR TITLE
Use spread properties instead of Object.assign()/deepmerge

### DIFF
--- a/docs/creating-presets.md
+++ b/docs/creating-presets.md
@@ -137,10 +137,11 @@ _Example:_
 
 ```js
 module.exports = (neutrino, opts = {}) => {
-  const options = Object.assign({
+  const options = {
     quiet: false,
-    logLevel: 'warn'
-  }, opts);
+    logLevel: 'warn',
+    ...opts
+  };
   
   // ...
 };

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -208,11 +208,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'off'
         }
-      }))
+      })
   ]
 };
 ```

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -208,12 +208,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'off'
         }
-      })
+      }))
   ]
 };
 ```

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -205,12 +205,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'off'
         }
-      })
+      }))
   ]
 };
 ```

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -205,11 +205,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'off'
         }
-      }))
+      })
   ]
 };
 ```

--- a/docs/packages/standardjs/README.md
+++ b/docs/packages/standardjs/README.md
@@ -206,12 +206,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'error'
         }
-      })
+      }))
   ]
 };
 ```

--- a/docs/packages/standardjs/README.md
+++ b/docs/packages/standardjs/README.md
@@ -206,11 +206,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'error'
         }
-      }))
+      })
   ]
 };
 ```

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -208,11 +208,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'off'
         }
-      }))
+      })
   ]
 };
 ```

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -208,12 +208,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'off'
         }
-      })
+      }))
   ]
 };
 ```

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -205,12 +205,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'off'
         }
-      })
+      }))
   ]
 };
 ```

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -205,11 +205,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'off'
         }
-      }))
+      })
   ]
 };
 ```

--- a/packages/banner/index.js
+++ b/packages/banner/index.js
@@ -1,15 +1,13 @@
 const { BannerPlugin } = require('webpack');
-const merge = require('deepmerge');
 
 module.exports = (neutrino, options = {}) => {
   neutrino.config
     .plugin(options.pluginId || 'banner')
-    .use(BannerPlugin, [
-      merge({
-        banner: 'require(\'source-map-support\').install();',
-        test: neutrino.regexFromExtensions(),
-        raw: true,
-        entryOnly: true
-      }, options)
-    ]);
+    .use(BannerPlugin, [{
+      banner: 'require(\'source-map-support\').install();',
+      test: neutrino.regexFromExtensions(),
+      raw: true,
+      entryOnly: true,
+      ...options
+    }]);
 };

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -22,7 +22,6 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "webpack": "^4.7.0"
   },
   "peerDependencies": {

--- a/packages/clean/index.js
+++ b/packages/clean/index.js
@@ -1,13 +1,13 @@
 const CleanPlugin = require('clean-webpack-plugin');
-const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
-  const options = merge({
+  const options = {
     pluginId: 'clean',
     paths: [],
     root: neutrino.options.root,
-    verbose: neutrino.options.debug
-  }, opts);
+    verbose: neutrino.options.debug,
+    ...opts
+  };
   const { paths, pluginId } = options;
 
   delete options.paths;

--- a/packages/clean/package.json
+++ b/packages/clean/package.json
@@ -22,8 +22,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "clean-webpack-plugin": "^0.1.19",
-    "deepmerge": "^1.5.2"
+    "clean-webpack-plugin": "^0.1.19"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0"

--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -1,4 +1,3 @@
-const merge = require('deepmerge');
 const babelMerge = require('babel-merge');
 
 module.exports = (neutrino, options = {}) => neutrino.config.module
@@ -8,9 +7,10 @@ module.exports = (neutrino, options = {}) => neutrino.config.module
     .when(options.exclude, rule => rule.exclude.merge(options.exclude))
     .use(options.useId || 'babel')
       .loader(require.resolve('babel-loader'))
-      .options(merge({
+      .options({
         cacheDirectory: true,
-        babelrc: false
-      }, options.babel || {}));
+        babelrc: false,
+        ...(options.babel || {})
+      });
 
 module.exports.merge = babelMerge;

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -26,7 +26,6 @@
     "@babel/core": "^7.0.0-beta.46",
     "babel-loader": "^8.0.0-beta.2",
     "babel-merge": "^1.1.1",
-    "deepmerge": "^1.5.2",
     "webpack": "^4.7.0"
   },
   "peerDependencies": {

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -92,7 +92,7 @@ module.exports = class Project extends Generator {
 
     const jsonPath = join(this.options.directory, 'package.json');
     const json = readJsonSync(jsonPath);
-    const packageJson = Object.assign(json, { scripts });
+    const packageJson = { ...json, scripts };
 
     writeJsonSync(jsonPath, packageJson, { spaces: 2 });
     this.log(`   ${chalk.green('create')} ${join(basename(this.options.directory), 'package.json')}`);

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -115,16 +115,14 @@ module.exports = (neutrino, opts = {}) => {
       .argv;
     const configFile = join(tmpdir(), 'config.json');
     const options = normalizeJestOptions(opts, neutrino, usingBabel);
-    const cliOptions = Object.assign(
-      jestArgs,
-      {
-        // Jest is looking for Array of files in `argv._`. Providing them
-        _: jestArgs.files,
-        config: configFile,
-        coverage: args.coverage,
-        watch: args.watch
-      }
-    );
+    const cliOptions = {
+      ...jestArgs,
+      // Jest is looking for Array of files in `argv._`. Providing them
+      _: jestArgs.files,
+      config: configFile,
+      coverage: args.coverage,
+      watch: args.watch
+    };
 
     writeFileSync(configFile, `${JSON.stringify(options, null, 2)}\n`);
 

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -25,7 +25,6 @@
     "@babel/register": "^7.0.0-beta.46",
     "@neutrinojs/loader-merge": "^8.2.0",
     "change-case": "^3.0.2",
-    "deepmerge": "^1.5.2",
     "mocha": "^5.1.1",
     "ramda": "^0.25.0"
   },

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,16 +1,17 @@
 const mocha = require('./mocha');
-const merge = require('deepmerge');
 const { omit } = require('ramda');
 const loaderMerge = require('@neutrinojs/loader-merge');
 
 module.exports = (neutrino, opts = {}) => {
   neutrino.on('test', ({ files }) => {
     const usingBabel = neutrino.config.module.rules.has('compile');
-    const options = merge.all([
-      { reporter: 'spec', ui: 'tdd', bail: true },
-      opts,
-      files && files.length ? { recursive: true } : {}
-    ]);
+    const options = {
+      reporter: 'spec',
+      ui: 'tdd',
+      bail: true,
+      ...opts,
+      ...(files && files.length ? { recursive: true } : {})
+    };
 
     neutrino.config.when(usingBabel, () => {
       neutrino.use(loaderMerge('compile', 'babel'), {

--- a/packages/neutrino/bin/build.js
+++ b/packages/neutrino/bin/build.js
@@ -1,4 +1,3 @@
-const merge = require('deepmerge');
 const ora = require('ora');
 const { build } = require('../src');
 const base = require('./base');
@@ -32,12 +31,13 @@ module.exports = (middleware, args, cli) => {
       spinner.succeed('Building project completed');
 
       if (stats) {
-        console.log(stats.toString(merge({
+        console.log(stats.toString({
           modules: false,
           colors: true,
           chunks: false,
-          children: false
-        }, stats.compilation.compiler.options.stats || {})));
+          children: false,
+          ...(stats.compilation.compiler.options.stats || {})
+        }));
       }
     }
   });

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -8,11 +8,7 @@ const MODULES = join(__dirname, 'node_modules');
 module.exports = (neutrino, opts = {}) => {
   const options = {
     hot: true,
-    babel: {},
-    ...opts
-  };
-
-  Object.assign(options, {
+    ...opts,
     babel: compileLoader.merge({
       plugins: [
         [require.resolve('@babel/plugin-transform-react-jsx'), { pragma: 'h' }],
@@ -20,8 +16,8 @@ module.exports = (neutrino, opts = {}) => {
         // https://github.com/facebook/create-react-app/issues/4263
         [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }]
       ]
-    }, options.babel)
-  });
+    }, opts.babel || {})
+  };
 
   neutrino.use(web, options);
 

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -2,15 +2,15 @@ const compileLoader = require('@neutrinojs/compile-loader');
 const loaderMerge = require('@neutrinojs/loader-merge');
 const web = require('@neutrinojs/web');
 const { join } = require('path');
-const merge = require('deepmerge');
 
 const MODULES = join(__dirname, 'node_modules');
 
 module.exports = (neutrino, opts = {}) => {
-  const options = merge({
+  const options = {
     hot: true,
-    babel: {}
-  }, opts);
+    babel: {},
+    ...opts
+  };
 
   Object.assign(options, {
     babel: compileLoader.merge({

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -30,7 +30,6 @@
     "@neutrinojs/compile-loader": "^8.2.0",
     "@neutrinojs/loader-merge": "^8.2.0",
     "@neutrinojs/web": "^8.2.0",
-    "deepmerge": "^1.5.2",
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.7.0"
   },

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -206,12 +206,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => {
+      .tap(options => ({
         ...options,
         rules: {
           semi: 'error'
         }
-      })
+      }))
   ]
 };
 ```

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -206,11 +206,12 @@ module.exports = {
     (neutrino) => neutrino.config.module
       .rule('lint')
       .use('eslint')
-      .tap(options => Object.assign({}, options, {
+      .tap(options => {
+        ...options,
         rules: {
           semi: 'error'
         }
-      }))
+      })
   ]
 };
 ```

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -60,14 +60,10 @@ module.exports = (neutrino, opts = {}) => {
       },
       ...options.loaders
     ]
-    .map((loader, index) => {
-      const obj = typeof loader === 'object' ? loader : { loader };
-
-      return {
-        ...obj,
-        useId: obj.useId || `${options.cssUseId}-${index}`
-      };
-    });
+    .map((loader, index) => ({
+      useId: `${options.cssUseId}-${index}`,
+      ...(typeof loader === 'object' ? loader : { loader })
+    }));
 
     loaders.forEach(loader => {
       styleRule

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -63,9 +63,10 @@ module.exports = (neutrino, opts = {}) => {
     .map((loader, index) => {
       const obj = typeof loader === 'object' ? loader : { loader };
 
-      return Object.assign(obj, {
+      return {
+        ...obj,
         useId: obj.useId || `${options.cssUseId}-${index}`
-      });
+      };
     });
 
     loaders.forEach(loader => {

--- a/packages/style-minify/index.js
+++ b/packages/style-minify/index.js
@@ -1,11 +1,11 @@
-const merge = require('deepmerge');
 const OptimizeCssPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = ({ config }, opts = {}) => {
-  const options = merge({
+  const options = {
     pluginId: 'optimize-css',
-    plugin: {}
-  }, opts);
+    plugin: {},
+    ...opts
+  };
 
   config
     .plugin(options.pluginId)

--- a/packages/style-minify/package.json
+++ b/packages/style-minify/package.json
@@ -25,7 +25,6 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "optimize-css-assets-webpack-plugin": "^4.0.1",
     "webpack": "^4.7.0"
   },

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -4,13 +4,14 @@ const StylelintPlugin = require('stylelint-webpack-plugin');
 const { lint, formatters } = require('stylelint');
 
 module.exports = (neutrino, opts = {}) => {
-  const options = merge({
+  const options = {
     pluginId: 'stylelint',
     configBasedir: neutrino.options.root,
     files: '**/*.+(css|scss|sass|less)',
     context: neutrino.options.source,
-    formatter: formatters.string
-  }, opts);
+    formatter: formatters.string,
+    ...opts
+  };
 
   const getStylelintRcConfig = config => config
     .plugin(options.pluginId)


### PR DESCRIPTION
Now that we require Node 8.3+, we can use spread properties instead of:
* Object.assign()
* deepmerge in cases where we just need a shallow merge.

http://node.green/#ES2018-features-object-rest-spread-properties