### PR TITLE
Fix broken links in the docs

### DIFF
--- a/docs/installation/create-new-project.md
+++ b/docs/installation/create-new-project.md
@@ -50,7 +50,7 @@ the scaffolding phase.
 | Test Runner | Middleware |
 | --- | --- |
 | Jest | [`@neutrinojs/jest`](../packages/jest) |
-| Karma | [`@neutrinojs/karma`](../pakages/karma) |
+| Karma | [`@neutrinojs/karma`](../packages/karma) |
 | Mocha | [`@neutrinojs/mocha`](../packages/mocha) |
 
 Be sure to check out the test runner preset to get more information on its features and how files should be named.
@@ -62,7 +62,7 @@ process. `@neutrinojs/create-project` currently offers two linting middleware ch
 
 | Linting style | Middleware |
 | --- | --- |
-| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](../airbnb) <br /> Other projects: [`@neutrinojs/airbnb-base`](../packages/airbnb-base) |
+| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](../packages/airbnb) <br /> Other projects: [`@neutrinojs/airbnb-base`](../packages/airbnb-base) |
 | StandardJS | [`@neutrinojs/standardjs`](../packages/standardjs) |
 
 ## Project Layout
@@ -83,7 +83,7 @@ No two JavaScript projects are ever the same, and as such there may be times whe
 to the way your Neutrino presets are building your project. Neutrino provides a mechanism to augment presets and
 middleware in the context of a project without resorting to creating and publishing an entirely independent preset.
 To override the build configuration, start with the documentation
-on [customization](../../customization).
+on [customization](../customization/README.md).
 
 ## Contributing
 

--- a/docs/packages/compile-loader/README.md
+++ b/docs/packages/compile-loader/README.md
@@ -162,7 +162,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js/contributing) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/compile-loader.svg

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -11,7 +11,7 @@
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
-- Extends from [@neutrinojs/web](../@neutrinojs/web/README.md)
+- Extends from [@neutrinojs/web](../web/README.md)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -187,7 +187,7 @@ preset builds. You can modify React preset settings from `.neutrinorc.js` by ove
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the React preset and override its options. See the
-[Web documentation](../@neutrinojs/web#preset-options) for specific options you can override with this object.
+[Web documentation](../web/README.md#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -230,7 +230,7 @@ module.exports = {
 
 To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/react` does not use any additional named rules, loaders, or plugins that aren't already in use by the
-Web preset. See the [Web documentation customization](../@neutrinojs/web#customizing)
+Web preset. See the [Web documentation customization](../web/README.md#customizing)
 for preset-specific configuration to override.
 
 For details on merging and overriding Babel configuration, such as supporting decorator syntax, read more
@@ -239,7 +239,7 @@ are comfortable customizing your build.
 
 ### Advanced configuration
 
-By following the [customization guide](../../customization/advanced.md) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web`, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ scripts defined in your project's `package.json`.
 
 ## Setup
 
-After completing the [installation](./installation.md) of Neutrino and your Neutrino preset, you will
+After completing the [installation](./installation/README.md) of Neutrino and your Neutrino preset, you will
 want to define some scripts in your project's `package.json` in order to more simply build your project.
 In a typical project:
 

--- a/packages/compile-loader/README.md
+++ b/packages/compile-loader/README.md
@@ -162,7 +162,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js/contributing) for details.
+[contributing guide](https://neutrino.js.org/contributing) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/compile-loader.svg

--- a/packages/create-project/README.md
+++ b/packages/create-project/README.md
@@ -83,7 +83,7 @@ No two JavaScript projects are ever the same, and as such there may be times whe
 to the way your Neutrino presets are building your project. Neutrino provides a mechanism to augment presets and
 middleware in the context of a project without resorting to creating and publishing an entirely independent preset.
 To override the build configuration, start with the documentation
-on [customization](https://neutrino.js.org/customization).
+on [customization](https://neutrino.js.org/customization/).
 
 ## Contributing
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -85,7 +85,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](https://neutrinojs.org/installation/create-new-project/) section
 for details on all available options.
 
 ### Manual Installation


### PR DESCRIPTION
Fixes #706 and several others found using a link checker site.

Some of these are about to be removed in the new-docs PR, however I plan on backporting this to the `release/v8` branch.