### PR TITLE
Docs: Correct style-loader's sass-loader example

### DIFF
--- a/docs/packages/style-loader/README.md
+++ b/docs/packages/style-loader/README.md
@@ -142,6 +142,9 @@ will be used as the `loader` property, `options` will be left blank, and the `us
 ```js
 module.exports = {
   use: ['@neutrinojs/style-loader', {
+    // Override the default file extension of `.css` if needed
+    test: /\.(css|sass|scss)$/,
+    moduleTest: /\.module\.(css|sass|scss)$/,
     loaders: [
       // Define loaders as objects
       {

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -142,6 +142,9 @@ will be used as the `loader` property, `options` will be left blank, and the `us
 ```js
 module.exports = {
   use: ['@neutrinojs/style-loader', {
+    // Override the default file extension of `.css` if needed
+    test: /\.(css|sass|scss)$/,
+    moduleTest: /\.module\.(css|sass|scss)$/,
     loaders: [
       // Define loaders as objects
       {


### PR DESCRIPTION
Since unless the default file extension regex is overridden, the `.sass` (old style) or `.scss` (new style) Sass styles will not be seen by `sass-loader`:
https://github.com/webpack-contrib/sass-loader#examples
https://sass-lang.com/documentation/file.SASS_REFERENCE.html

Closes #755.
Closes #803.
Refs #871.