### PR TITLE
Misc monorepo testing improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,6 @@
 packages/**/node_modules/
+# Remove ignore of neutrinorc since ESLint ignores dotfiles by default
+!.neutrinorc.js
 # TODO: Fix lint errors in our tests and remove this line
 packages/**/test/
 # The templates have any lint errors fixed during project creation,

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,3 @@ node_modules
 # Project metadata
 .idea
 /.vscode
-
-# Verdaccio
-storage
-htpasswd

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "link:all": "lerna exec yarn link",
     "lint": "node packages/neutrino/bin/neutrino lint",
     "precommit": "lint-staged",
-    "random": "node -e \"process.stdout.write(require('crypto').randomBytes(8).toString('hex'))\"",
     "release": "lerna publish --force-publish=*",
     "release:preview": "lerna publish --force-publish=* --skip-git --skip-npm",
     "test": "ava --fail-fast packages/*/test \"!packages/create-project/test\"",

--- a/packages/create-project/bin/create-project.js
+++ b/packages/create-project/bin/create-project.js
@@ -12,6 +12,7 @@ env.register(require.resolve(dir), 'create-project');
 
 const cli = yargs.command('<project-directory>')
   .option('debug', { description: 'Run in debug mode' })
+  .option('registry', { description: 'Specify an alternate npm registry' })
   .demandCommand(1, 'Only <project-directory> is required')
   .help()
   .wrap(null)
@@ -22,5 +23,6 @@ const name = basename(directory);
 env.run('create-project', {
   directory,
   name,
+  registry: cli.registry,
   stdio: cli.debug ? 'inherit' : 'ignore'
 }, done);

--- a/scripts/test-create-project-ci.sh
+++ b/scripts/test-create-project-ci.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/test-create-project-ci.sh
+++ b/scripts/test-create-project-ci.sh
@@ -7,7 +7,6 @@ export YARN_AUTH_TOKEN="//localhost:4873/:_authToken=token"
 
 # Start verdaccio registry proxy in the background
 yarn verdaccio --config verdaccio.yml &
-yarn config set registry "http://localhost:4873"
 
 # Verdaccio isn't ready to immediately accept connections, so we need to wait
 while ! nc -zw 1 localhost 4873; do sleep 1; done

--- a/scripts/test-create-project-ci.sh
+++ b/scripts/test-create-project-ci.sh
@@ -11,13 +11,16 @@ yarn verdaccio --config verdaccio.yml &
 # Verdaccio isn't ready to immediately accept connections, so we need to wait
 while ! nc -zw 1 localhost 4873; do sleep 1; done
 
-# Publish all monorepo packages to the verdaccio registry
-yarn lerna publish \
-  --force-publish=* \
-  --skip-git \
+# Publish all monorepo packages to the verdaccio registry.
+# Canary mode ensures no git or working directory changes are made, but we
+# have to override the tag from `canary` to `latest` so create-project works.
+# The minor version will be bumped and a `-alpha.GIT_SHA` suffix added, which
+# should help avoid errors from clashing with an already-published version.
+yarn release \
   --registry http://localhost:4873/ \
   --yes \
-  --cd-version major
+  --canary \
+  --npm-tag latest
 
 # Run the integration tests, which will install packages
 # from the verdaccio registry

--- a/scripts/test-create-project-ci.sh
+++ b/scripts/test-create-project-ci.sh
@@ -25,3 +25,9 @@ yarn release \
 # Run the integration tests, which will install packages
 # from the verdaccio registry
 yarn test:create-project
+
+# Remove cached Neutrino packages to avoid Travis cache churn.
+# Not using `yarn cache clean` since it doesn't support globs,
+# and does nothing more than call `fs.unlink(dir)` anyway.
+YARN_CACHE_DIR="$(yarn cache dir)"
+rm -rf "${YARN_CACHE_DIR}"/*-neutrino-*/ "${YARN_CACHE_DIR}"/*-@neutrinojs/

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -1,22 +1,21 @@
 store:
   memory:
     limit: 10000
-auth:
-  htpasswd:
-    file: ./htpasswd
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    # Make request fail sooner if NPM being flaky (default is 30s).
+    timeout: 10s
+    # Increase number of failed requests before disabling uplink (default 2).
+    max_fails: 20
 packages:
-  '**':
-    access: $all
-    publish: $all
-    proxy: npmjs
   'neutrino':
     access: $anonymous
     publish: $anonymous
-    proxy: npmjs
-  '@neutrinojs':
+  '@neutrinojs/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
     access: $anonymous
     publish: $anonymous
     proxy: npmjs


### PR DESCRIPTION
* Ensure the monorepo .neutrinorc.js is included in linting
* Remove unused `random` package.json lifecycle script
* Add --registry option to create-project 
* Remove unnecessary 'yarn config set registry' from `test-create-project-ci.sh`
* Fix `test-create-project-ci.sh` shebang whitespace
* Adjust settings used for `lerna publish` in CI
* Make verdaccio more resilient to NPM flakiness + prevent NPM published Neutrino packages from accidentally being used instead of the local versions (by disabling proxying for them)
* Remove neutrino packages from Travis yarn cache after testing  to prevent cache churn

These are some of the changes split out from #852, plus some others to ensure the verdaccio testing works even when used later on release branches. See individual commit messages for more details.