### PR TITLE
[v8.x] Really prevent yarn "unmet peer dependency" warnings

### DIFF
--- a/packages/babel-minify/package.json
+++ b/packages/babel-minify/package.json
@@ -26,9 +26,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "@neutrinojs/babel-minify-webpack-plugin": "^0.2.0"
-  },
-  "devDependencies": {
+    "@neutrinojs/babel-minify-webpack-plugin": "^0.2.0",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -31,9 +31,7 @@
     "eslint-plugin-babel": "^4.1.2",
     "fluture": "^8.0.2",
     "lodash.clonedeep": "^4.5.0",
-    "ramda": "^0.25.0"
-  },
-  "devDependencies": {
+    "ramda": "^0.25.0",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -24,9 +24,7 @@
   "dependencies": {
     "deepmerge": "^1.5.2",
     "file-loader": "^1.1.11",
-    "url-loader": "^1.0.1"
-  },
-  "devDependencies": {
+    "url-loader": "^1.0.1",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -28,9 +28,7 @@
   "dependencies": {
     "deepmerge": "^1.5.2",
     "html-webpack-plugin": "^3.2.0",
-    "html-webpack-template": "^6.2.0"
-  },
-  "devDependencies": {
+    "html-webpack-template": "^6.2.0",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "deepmerge": "^1.5.2",
     "file-loader": "^1.1.11",
-    "url-loader": "^1.0.1"
+    "url-loader": "^1.0.1",
+    "webpack": "^3.12.0"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0"

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -29,9 +29,7 @@
     "imagemin-pngquant": "^5.1.0",
     "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.1.0",
-    "imagemin-webpack": "^1.1.2"
-  },
-  "devDependencies": {
+    "imagemin-webpack": "^1.1.2",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -28,9 +28,7 @@
     "css-loader": "^0.28.11",
     "deepmerge": "^1.5.2",
     "extract-text-webpack-plugin": "^3.0.2",
-    "style-loader": "^0.20.3"
-  },
-  "devDependencies": {
+    "style-loader": "^0.20.3",
     "webpack": "^3.12.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The `release/v8` equivalent of #847, since it looks really sloppy to have lots of unmet peer dependency warnings when installing - and I think the warnings contribute to things like #830.

The missing peer dependencies were found by scripting the `yarn add` of `neutrino <SINGLE_PRESET>` for each separate preset/middleware, so that cases where the parent preset hides missing peer deps of the lower level packages could be found.