### PR TITLE
loader-merge: Fix usage of `object-rest-spread`

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -350,7 +350,7 @@ neutrino.config.module
   .rule('compile')
   .loader('babel', 'babel-loader', {
     options: {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }
   });
 
@@ -359,7 +359,7 @@ neutrino.config.module
   .rule('compile')
   .use('babel')
     .loader('babel-loader')
-    .options({ plugins: ['object-rest-spread'] });
+    .options({ plugins: ['your-babel-plugin'] });
 ```
 
 - Updates to config for modifying loaders (from webpack-chain v3 upgrade). The function now gets its options directly
@@ -371,7 +371,7 @@ neutrino.config.module
   .rule('compile')
   .loader('babel', props => merge(props, {
     options: {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }
   }));
 
@@ -379,7 +379,7 @@ neutrino.config.module
 neutrino.config.module
   .rule('compile')
     .use('babel')
-      .tap(options => merge(options, { plugins: ['object-rest-spread'] }));
+      .tap(options => merge(options, { plugins: ['your-babel-plugin'] }));
 ```
 
 - Updates to `include` and `exclude` for rules (from webpack-chain v3). In the previous webpack-chain

--- a/packages/loader-merge/README.md
+++ b/packages/loader-merge/README.md
@@ -38,7 +38,7 @@ and plug it into Neutrino:
 const loaderMerge = require('@neutrinojs/loader-merge');
 
 neutrino.use(loaderMerge('compile', 'babel'), {
-  plugins: ['object-rest-spread']
+  plugins: ['your-babel-plugin']
 });
 
 // Equivalent to:
@@ -46,7 +46,7 @@ neutrino.config.module
   .rule('compile')
   .use('babel')
     .tap(options => require('deepmerge')(options, {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }));
 ```
 


### PR DESCRIPTION
According to the current version of babel, the usage of the object rest spread plugin name should be prefixed with `transform`

```json
{
  "plugins": [
    ["transform-object-rest-spread", { "useBuiltIns": true }]
  ]
}
```

https://babeljs.io/docs/plugins/transform-object-rest-spread/#via-node-api