### PR TITLE
[v8.x] Changes for neutrino.js.org to neutrinojs.org transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/release/v8/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrino.js.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.
@@ -24,7 +24,7 @@ cover.
 
 ## Documentation
 
-See the [Neutrino docs](https://neutrino.js.org/)
+See the [Neutrino docs](https://neutrinojs.org/)
 for details on installation, getting started, usage, and customizing.
 
 ### Contributing
@@ -33,8 +33,8 @@ Thank you for wanting to help out with Neutrino! We are very happy that you want
 this guide to help you get started. We want to do our best to help you make successful contributions and be part of our
 community.
 
-- [Contributing to Neutrino](https://neutrino.js.org/contributing/)
-- [Participation Guidelines](https://neutrino.js.org/contributing/code-of-conduct.html)
+- [Contributing to Neutrino](https://neutrinojs.org/contributing/)
+- [Participation Guidelines](https://neutrinojs.org/contributing/code-of-conduct.html)
 
 [npm-image]: https://img.shields.io/npm/v/neutrino.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino.svg

--- a/book.json
+++ b/book.json
@@ -4,7 +4,7 @@
   "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs", "npmsearchlist"],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/docs",
+      "base": "https://github.com/mozilla-neutrino/neutrino-dev/tree/release/v8/docs",
       "label": "Edit page"
     },
     "github": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,11 +22,6 @@ your own presets by extending the Neutrino core ones to be shared across your ow
 Presets can even be manipulated on a project-by-project basis to handle almost any build situation your preset doesn't
 cover.
 
-## Documentation
-
-See the [Neutrino docs](https://neutrino.js.org/)
-for details on installation, getting started, usage, and customizing.
-
 [npm-image]: https://img.shields.io/npm/v/neutrino.svg
 [npm-downloads]: https://img.shields.io/npm/dt/neutrino.svg
 [npm-url]: https://npmjs.org/package/neutrino

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/release/v8/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrino.js.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -405,7 +405,7 @@ The `call` method will invoke the registered command with two arguments: a webpa
 instance of the Neutrino API. The return value of using `call` will be the return value of invoking the registered
 handler with these two arguments.
 
-For a concrete example, the [eslint middleware](../packages/eslint) registers an `eslintrc`
+For a concrete example, the [eslint middleware](../packages/eslint/README.md) registers an `eslintrc`
 command. The results of this command can be returned with `call`, which is loaded within
 `.neutrinorc.js` in this example:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -180,7 +180,7 @@ Options:
 ```
 
 Using the command `neutrino test` will execute every test file located in your
-[testing directory](../project-layout#Testing). You may also provide to this command the specific test files you wish
+[testing directory](../project-layout.md#testing). You may also provide to this command the specific test files you wish
 to run individually. It is important to note that when combined with the `--use` parameter, you should use two
 dashes after the last preset to denote the end of the presets and the beginning of the test files.
 

--- a/docs/installation/create-new-project.md
+++ b/docs/installation/create-new-project.md
@@ -2,8 +2,8 @@
 
 Neutrino can help you quickly start new projects by scaffolding your initial project structure.
 `@neutrinojs/create-project` uses middleware and presets behind the scene to build projects. If you are not
-familiar with them, take a moment to explore [middleware](../../middleware)
-and [presets](../../presets).
+familiar with them, take a moment to explore [middleware](../middleware/README.md)
+and [presets](../presets/README.md).
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][npm-downloads]][npm-url]
@@ -35,13 +35,13 @@ of that project to scaffold. Each project type harnesses the power of middleware
 
 | Project | Project Type | Middleware |
 | --- | --- | --- |
-| React | Application | [`@neutrinojs/react`](../packages/react) |
-| Preact | Application | [`@neutrinojs/preact`](../packages/preact) |
-| Vue | Application | [`@neutrinojs/vue`](../packages/vue) |
-| Web | Application | [`@neutrinojs/web`](../packages/web) |
-| Node.js | Application | [`@neutrinojs/node`](../packages/node) |
-| Web | Library | [`@neutrinojs/library`](../packages/library) |
-| React Components | Components | [`@neutrinojs/react-components`](../packages/react-components) |
+| React | Application | [`@neutrinojs/react`](../packages/react/README.md) |
+| Preact | Application | [`@neutrinojs/preact`](../packages/preact/README.md) |
+| Vue | Application | [`@neutrinojs/vue`](../packages/vue/README.md) |
+| Web | Application | [`@neutrinojs/web`](../packages/web/README.md) |
+| Node.js | Application | [`@neutrinojs/node`](../packages/node/README.md) |
+| Web | Library | [`@neutrinojs/library`](../packages/library/README.md) |
+| React Components | Components | [`@neutrinojs/react-components`](../packages/react-components/README.md) |
 
 ## Test Runners
 
@@ -50,9 +50,9 @@ the scaffolding phase.
 
 | Test Runner | Middleware |
 | --- | --- |
-| Jest | [`@neutrinojs/jest`](../packages/jest) |
-| Karma | [`@neutrinojs/karma`](../packages/karma) |
-| Mocha | [`@neutrinojs/mocha`](../packages/mocha) |
+| Jest | [`@neutrinojs/jest`](../packages/jest/README.md) |
+| Karma | [`@neutrinojs/karma`](../packages/karma/README.md) |
+| Mocha | [`@neutrinojs/mocha`](../packages/mocha/README.md) |
 
 Be sure to check out the test runner preset to get more information on its features and how files should be named.
 
@@ -63,12 +63,12 @@ process. `@neutrinojs/create-project` currently offers two linting middleware ch
 
 | Linting style | Middleware |
 | --- | --- |
-| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](../packages/airbnb) <br /> Other projects: [`@neutrinojs/airbnb-base`](../packages/airbnb-base) |
-| StandardJS | [`@neutrinojs/standardjs`](../packages/standardjs) |
+| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](../packages/airbnb/README.md) <br /> Other projects: [`@neutrinojs/airbnb-base`](../packages/airbnb-base/README.md) |
+| StandardJS | [`@neutrinojs/standardjs`](../packages/standardjs/README.md) |
 
 ## Project Layout
 
-`@neutrinojs/create-project` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/create-project` follows the standard [project layout](../project-layout.md) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project. Neutrino will scaffold the project with the initial package.json, Neutrino set up,
@@ -90,7 +90,7 @@ on [customization](../customization/README.md).
 
 This project is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/create-project.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/create-project.svg

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -223,7 +223,7 @@ Neutrino()
   .fork(errorHandler, successHandler);
 ```
 
-See the [Neutrino API](./api) for details on the updated API.
+See the [Neutrino API](./api/README.md) for details on the updated API.
 
 - **BREAKING CHANGE** Since the Neutrino API has changed, creating a `.eslintrc.js` file has also changed. If you have
 your middleware defined in `.neutrinorc.js`, your `.eslintrc.js` file can be as simple as:

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -17,8 +17,8 @@ to v8, be sure to check this list for tasks you may need to perform to use this 
 for the full list of deprecated packages and the new scoped packages to migrate to. The core `neutrino` package
 remains available as is.
 - **BREAKING CHANGE** Removed `entry` option in order to support multiple main entry points via new `mains` options.
-See [Customization](https://neutrino.js.org/customization/#optionsmains) for usage of `mains` in
-`.neutrinorc.js`. See [API](https://neutrino.js.org/api/#optionsmains) for usage of `mains` from the API.
+See [Customization](./customization/README.md#optionsmains) for usage of `mains` in
+`.neutrinorc.js`. See [API](./api/README.md#optionsmains) for usage of `mains` from the API.
 ([#487](https://github.com/mozilla-neutrino/neutrino-dev/pull/487))
 - **BREAKING CHANGE** `*.css` files in mains chunks are no longer inlined into the JS bundle by default.
 They are moved into a separate CSS file. To disable CSS extraction, pass `options.extract = false` to

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -153,7 +153,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](../../packages/eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](../eslint/README.md).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.

--- a/docs/packages/airbnb-base/README.md
+++ b/docs/packages/airbnb-base/README.md
@@ -315,7 +315,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/airbnb-base.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/airbnb-base.svg

--- a/docs/packages/airbnb/README.md
+++ b/docs/packages/airbnb/README.md
@@ -40,7 +40,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/airbnb` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/airbnb` follows the standard [project layout](../../project-layout.md) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project.
 
@@ -150,7 +150,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](../eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](../eslint/README.md).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
@@ -173,7 +173,7 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](../../customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/airbnb` creates some conventions to make overriding the configuration easier once you are ready to
 make changes.
 
@@ -193,7 +193,7 @@ middleware.
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule and loader IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule and loader IDs above,
 you can also override or augment the build by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -241,7 +241,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 `@neutrinojs/eslint`, from which this preset inherits, also provides a method for getting the ESLint
 configuration suitable for use in an eslintrc file. Typically this is used for providing hints or fix solutions to the
 development environment, e.g. IDEs and text editors. Doing this requires
-[creating an instance of the Neutrino API](../../api) and providing the middleware it uses. If you keep all
+[creating an instance of the Neutrino API](../../api/README.md) and providing the middleware it uses. If you keep all
 this information in a `.neutrinorc.js`, this should be relatively straightforward. By providing all the middleware used
 to Neutrino, you can ensure all the linting options used across all middleware will be merged together for your
 development environment, without the need for copying, duplication, or loss of organization and separation.
@@ -312,7 +312,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/airbnb.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/airbnb.svg

--- a/docs/packages/babel-minify/README.md
+++ b/docs/packages/babel-minify/README.md
@@ -88,7 +88,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/babel-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/babel-minify.svg

--- a/docs/packages/banner/README.md
+++ b/docs/packages/banner/README.md
@@ -96,7 +96,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/banner.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/banner.svg

--- a/docs/packages/chunk/README.md
+++ b/docs/packages/chunk/README.md
@@ -69,7 +69,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/chunk.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/chunk.svg

--- a/docs/packages/clean/README.md
+++ b/docs/packages/clean/README.md
@@ -87,7 +87,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/clean.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/clean.svg

--- a/docs/packages/compile-loader/README.md
+++ b/docs/packages/compile-loader/README.md
@@ -163,7 +163,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/compile-loader.svg

--- a/docs/packages/copy/README.md
+++ b/docs/packages/copy/README.md
@@ -92,7 +92,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/copy.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/copy.svg

--- a/docs/packages/dev-server/README.md
+++ b/docs/packages/dev-server/README.md
@@ -134,7 +134,7 @@ may also specify the following options:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/dev-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/dev-server.svg

--- a/docs/packages/env/README.md
+++ b/docs/packages/env/README.md
@@ -81,7 +81,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/env.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/env.svg

--- a/docs/packages/eslint/README.md
+++ b/docs/packages/eslint/README.md
@@ -198,7 +198,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/eslint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/eslint.svg

--- a/docs/packages/font-loader/README.md
+++ b/docs/packages/font-loader/README.md
@@ -94,7 +94,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/font-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/font-loader.svg

--- a/docs/packages/fork/README.md
+++ b/docs/packages/fork/README.md
@@ -40,7 +40,7 @@ can be run simultaneously. Some typical use cases:
 - Generate multiple targets when building libraries
 
 _This middleware must be used in conjunction with a `.neutrinorc.js` file to inform Neutrino of which
-middleware should be split into another process. See the [customization docs](../../customization/)
+middleware should be split into another process. See the [customization docs](../../customization/README.md)
 for details on setting up a `.neutrinorc.js` file in your project if you do not already have one._
 
 _Important: The configuration options provided to the fork middleware needs to be serializable across
@@ -124,7 +124,7 @@ each running in their own process. Quitting Neutrino will cause all forked proce
 
 ## Paths
 
-Most middleware attempt to follow the standard [Neutrino project layout](../../project-layout)
+Most middleware attempt to follow the standard [Neutrino project layout](../../project-layout.md)
 to output their compiled output, but building multiple projects at once is bound to cause clashes with
 the directories each project uses. This could lead to:
 
@@ -234,7 +234,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/fork.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/fork.svg

--- a/docs/packages/hot/README.md
+++ b/docs/packages/hot/README.md
@@ -66,7 +66,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/hot.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/hot.svg

--- a/docs/packages/html-loader/README.md
+++ b/docs/packages/html-loader/README.md
@@ -83,7 +83,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/html-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/html-loader.svg

--- a/docs/packages/html-template/README.md
+++ b/docs/packages/html-template/README.md
@@ -114,7 +114,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/html-template.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/html-template.svg

--- a/docs/packages/image-loader/README.md
+++ b/docs/packages/image-loader/README.md
@@ -94,7 +94,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/image-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/image-loader.svg

--- a/docs/packages/image-minify/README.md
+++ b/docs/packages/image-minify/README.md
@@ -118,7 +118,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/image-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/image-minify.svg

--- a/docs/packages/jest/README.md
+++ b/docs/packages/jest/README.md
@@ -320,7 +320,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/jest.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/jest.svg

--- a/docs/packages/jest/README.md
+++ b/docs/packages/jest/README.md
@@ -283,7 +283,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule, and loader IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, and loader IDs above,
 you can override and augment testing by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 

--- a/docs/packages/karma/README.md
+++ b/docs/packages/karma/README.md
@@ -217,7 +217,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/karma.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/karma.svg

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -55,7 +55,7 @@ If you want to have automatically wired sourcemaps added to your project, add `s
 
 ## Project Layout
 
-`@neutrinojs/library` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/library` follows the standard [project layout](../../project-layout.md) specified by Neutrino. This
 means that by default all library source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files that would be available to your compiled project.
 
@@ -454,7 +454,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
@@ -475,7 +475,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/library.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/library.svg

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -304,14 +304,14 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/library` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your library, and this
 maps to the `index.*` file in the `src` directory. This means that this preset is optimized toward a single main entry
 to your library. Code not imported in the hierarchy of the `index` entry will not be output to the bundle. To overcome
-this you must either define more mains via [`options.mains`](https://neutrino.js.org/customization#optionsmains), import
+this you must either define more mains via [`options.mains`](../../customization/README.md#optionsmains), import
 the code path somewhere along the `index` hierarchy, or define multiple configurations in your `.neutrinorc.js`.
 
 ### External dependencies

--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -405,7 +405,7 @@ require(['redux', 'redux-example'], ({ createStore }, reduxExample) => {
 ## Generating multiple builds
 
 The `@neutrinojs/library` middleware can be used in conjunction with the
-[`@neutrinojs/fork` middleware](https://neutrinojs.org/packages/fork) to generate multiple library outputs
+[`@neutrinojs/fork` middleware](https://neutrinojs.org/packages/fork/) to generate multiple library outputs
 when building. Follow the instructions to install the fork middleware, and change your `.neutrinorc.js`
 format as follows:
 

--- a/docs/packages/loader-merge/README.md
+++ b/docs/packages/loader-merge/README.md
@@ -71,7 +71,7 @@ for extending the options for a rule loader which has created its own convention
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/loader-merge.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/loader-merge.svg

--- a/docs/packages/minify/README.md
+++ b/docs/packages/minify/README.md
@@ -95,7 +95,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/minify.svg

--- a/docs/packages/mocha/README.md
+++ b/docs/packages/mocha/README.md
@@ -174,7 +174,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule, and loader IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, and loader IDs above,
 you can override and augment testing by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 

--- a/docs/packages/mocha/README.md
+++ b/docs/packages/mocha/README.md
@@ -211,7 +211,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/mocha.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/mocha.svg

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -377,7 +377,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/node.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/node.svg

--- a/docs/packages/node/README.md
+++ b/docs/packages/node/README.md
@@ -238,7 +238,7 @@ modification during development.
 ## Debugging
 
 You can start the Node.js server in `inspect` mode to debug the process by setting `neutrino.options.debug` to `true`.
-This can be done from the [API](../../api#optionsdebug) or the [CLI using `--debug`](../../cli#-debug).
+This can be done from the [API](../../api/README.md#optionsdebug) or the [CLI using `--debug`](../../cli/README.md#-debug).
 
 ## Preset options
 
@@ -324,7 +324,7 @@ changes.
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your application, and this
 maps to the `index.*` file in the `src` directory. This means that this preset is optimized toward a single main entry
 to your application. Code not imported in the hierarchy of the `index` entry will not be output to the bundle. To overcome
-this you must either define more mains via [`options.mains`](../../customization#optionsmains), import the code path
+this you must either define more mains via [`options.mains`](../../customization/README.md#optionsmains), import the code path
 somewhere along the `index` hierarchy, or define multiple configurations in your `.neutrinorc.js`.
 
 ### Vendoring
@@ -358,7 +358,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 

--- a/docs/packages/preact/README.md
+++ b/docs/packages/preact/README.md
@@ -13,7 +13,7 @@
 - Write JSX in .js or .jsx files
 - Automatic import of `Preact.h`, no need to import `h` or `createElement` yourself
 - Compatibility and pre-configured aliasing for React-based modules and packages
-- Extends from [@neutrinojs/web](../web)
+- Extends from [@neutrinojs/web](../web/README.md)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -68,7 +68,7 @@ compatibility layer:
 
 ## Project Layout
 
-`@neutrinojs/preact` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/preact` follows the standard [project layout](../../project-layout.md) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project.
@@ -186,14 +186,14 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../copy).
+[@neutrinojs/copy](../copy/README.md).
 
 ## Paths
 
 The `@neutrinojs/preact` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 ## Preset options
 
@@ -202,7 +202,7 @@ preset builds. You can modify Preact preset settings from `.neutrinorc.js` by ov
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the Preact preset and override its options. See the
-[Web documentation](../web#preset-options) for specific options you can override with this object.
+[Web documentation](../web/README.md#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -244,14 +244,14 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](../../customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/preact` does not use any additional named rules, loaders, or plugins that aren't already in use by the
-Web preset. See the [Web documentation customization](../web#customizing)
+Web preset. See the [Web documentation customization](../web/README.md#customizing)
 for preset-specific configuration to override.
 
 ### Advanced configuration
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web`, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 
@@ -319,7 +319,7 @@ if (process.env.NODE_ENV === 'development') {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/preact.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/preact.svg

--- a/docs/packages/pwa/README.md
+++ b/docs/packages/pwa/README.md
@@ -124,7 +124,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/pwa.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/pwa.svg

--- a/docs/packages/react-components/README.md
+++ b/docs/packages/react-components/README.md
@@ -9,7 +9,7 @@ other Neutrino middleware, so you can build, test, and publish multiple React co
 
 ## Features
 
-- Extends partially from [@neutrinojs/react](../react)
+- Extends partially from [@neutrinojs/react](../react/README.md)
 - Zero upfront configuration necessary to start developing and building React components.
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
@@ -72,7 +72,7 @@ If you want to have automatically wired sourcemaps added to your project, add `s
 
 ## Project Layout
 
-`@neutrinojs/react-components` follows the standard [project layout](../../project-layout)
+`@neutrinojs/react-components` follows the standard [project layout](../../project-layout.md)
 specified by Neutrino. This means that by default all project source code should live in a directory named `src` in the
 root of the project. This includes JavaScript files that would be available to your compiled project.
 
@@ -210,24 +210,24 @@ const YourCustomComponent = require('your-custom-component').default;
 ```
 
 By default this preset creates an individual entry point for every top-level component found in `src/components`. These
-are set and accessible via the API at [`neutrino.options.mains`](../../api#optionsmains).
+are set and accessible via the API at [`neutrino.options.mains`](../../api/README.md#optionsmains).
 
 ## Hot Module Replacement
 
 While `@neutrinojs/react-components` supports Hot Module Replacement for your app, it does require some
 changes to the preview app in order to operate. The preview app should define split points for which to accept
 modules (Components) to reload using `module.hot`. See the
-[React preset docs](../react/#hot-module-replacement) for guidance.
+[React preset docs](../react/README.md#hot-module-replacement) for guidance.
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](../../customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/react-components` uses a few rules and plugins in addition to the ones in use by the React and Web presets.
-See the [Web documentation customization](../web#customizing)
+See the [Web documentation customization](../web/README.md#customizing)
 for preset-specific configuration to override.
 
 By default this preset creates an individual entry point for every top-level component found in `src/components`. These
-are set and accessible via the API at [`neutrino.options.mains`](../../api#optionsmains).
+are set and accessible via the API at [`neutrino.options.mains`](../../api/README.md#optionsmains).
 
 ### Rules
 
@@ -245,7 +245,7 @@ _Note: Some plugins are only available in certain environments. To override them
 | ---- | ----------- | ------------ |
 | `banner` | Injects source-map-support into the mains (entry points) of your application if detected in `dependencies` or `devDependencies` of your package.json. | all but `development` |
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -178,10 +178,10 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 For details on merging and overriding Babel configuration, such as supporting decorator syntax, read more
-about using the [`compile-loader` `merge`](../compile-loader#advanced-merging) once you
+about using the [`compile-loader` `merge`](../compile-loader/README.md#advanced-merging) once you
 are comfortable customizing your build.
 
 ## Preset options
@@ -239,7 +239,7 @@ Web preset. See the [Web documentation customization](../web/README.md#customizi
 for preset-specific configuration to override.
 
 For details on merging and overriding Babel configuration, such as supporting decorator syntax, read more
-about using the [`compile-loader` `merge`](../compile-loader#advanced-merging) once you
+about using the [`compile-loader` `merge`](../compile-loader/README.md#advanced-merging) once you
 are comfortable customizing your build.
 
 ### Advanced configuration

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -337,7 +337,7 @@ load();
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/react.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/react.svg

--- a/docs/packages/standardjs/README.md
+++ b/docs/packages/standardjs/README.md
@@ -40,7 +40,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/standardjs` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/standardjs` follows the standard [project layout](../../project-layout.md) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project.
 
@@ -151,7 +151,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](../eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](../eslint/README.md).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
@@ -174,7 +174,7 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](../../customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/standardjs` creates some conventions to make overriding the configuration easier once you are ready to
 make changes.
 
@@ -194,7 +194,7 @@ middleware.
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule and loader IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule and loader IDs above,
 you can also override or augment the build by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -242,7 +242,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 `@neutrinojs/eslint`, from which this preset inherits, also provides a method for getting the ESLint
 configuration suitable for use in an eslintrc file. Typically this is used for providing hints or fix solutions to the
 development environment, e.g. IDEs and text editors. Doing this requires
-[creating an instance of the Neutrino API](../../api) and providing the middleware it uses. If you keep all
+[creating an instance of the Neutrino API](../../api/README.md) and providing the middleware it uses. If you keep all
 this information in a `.neutrinorc.js`, this should be relatively straightforward. By providing all the middleware used
 to Neutrino, you can ensure all the linting options used across all middleware will be merged together for your
 development environment, without the need for copying, duplication, or loss of organization and separation.
@@ -310,7 +310,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/standardjs.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/standardjs.svg

--- a/docs/packages/start-server/README.md
+++ b/docs/packages/start-server/README.md
@@ -91,7 +91,7 @@ The following is a list of plugins and their identifiers which can be overridden
 ### Debugging
 
 You can start the Node.js server in `inspect` mode to debug the process by setting `neutrino.options.debug` to `true`.
-This can be done from the [API](../../api#optionsdebug) or the [CLI using `--debug`](../../cli#-debug).
+This can be done from the [API](../../api/README.md#optionsdebug) or the [CLI using `--debug`](../../cli/README.md#-debug).
 
 ## Contributing
 

--- a/docs/packages/start-server/README.md
+++ b/docs/packages/start-server/README.md
@@ -97,7 +97,7 @@ This can be done from the [API](../../api#optionsdebug) or the [CLI using `--deb
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/start-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/start-server.svg

--- a/docs/packages/style-loader/README.md
+++ b/docs/packages/style-loader/README.md
@@ -255,7 +255,7 @@ _Note: Some plugins may be only available in certain environments. To override t
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/style-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/style-loader.svg

--- a/docs/packages/style-minify/README.md
+++ b/docs/packages/style-minify/README.md
@@ -95,7 +95,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/style-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/style-minify.svg

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -77,7 +77,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 
 `@neutrinojs/stylelint` also provides a method for getting the stylelint configuration suitable for use in a stylelintrc
 file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
-editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+editors. Doing this requires [creating an instance of the Neutrino API](../../api/README.md) and providing the
 middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
 providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
 merged together for your development environment, without the need for copying, duplication, or loss of organization and

--- a/docs/packages/stylelint/README.md
+++ b/docs/packages/stylelint/README.md
@@ -125,7 +125,7 @@ changes in `.stylelint.js` over `.neutrinorc.js`.**
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/stylelint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/stylelint.svg

--- a/docs/packages/vue/README.md
+++ b/docs/packages/vue/README.md
@@ -8,7 +8,7 @@
 
 - Zero upfront configuration necessary to start developing and building a Vue web app
 - Modern Babel compilation.
-- Extends from [@neutrinojs/web](../web)
+- Extends from [@neutrinojs/web](../web/README.md)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -48,7 +48,7 @@ Vue development.
 
 ## Project Layout
 
-`@neutrinojs/vue` follows the standard [project layout](../../project-layout) specified by Neutrino. This
+`@neutrinojs/vue` follows the standard [project layout](../../project-layout.md) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project.
@@ -189,14 +189,14 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](../copy).
+[@neutrinojs/copy](../copy/README.md).
 
 ## Paths
 
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting Webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 
 ## Preset options
@@ -206,7 +206,7 @@ preset builds. You can modify Vue preset settings from `.neutrinorc.js` by overr
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the Vue preset and override its options. See the
-[Web documentation](../web#preset-options) for specific options you can override with this object.
+[Web documentation](../web/README.md#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -248,10 +248,10 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](../../customization).
+To override the build configuration, start with the documentation on [customization](../../customization/README.md).
 `@neutrinojs/vue` creates some conventions to make overriding the configuration easier once you are ready to make
 changes. Most of the configuration for `@neutrinojs/vue` is inherited from the
-[`@neutrinojs/web` preset](../web#customizing); continue to that documentation
+[`@neutrinojs/web` preset](../web/README.md#customizing); continue to that documentation
 for details on customization.
 
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your application, and
@@ -288,7 +288,7 @@ _This preset does not define any additional plugins from those already in use by
 
 ### Advanced configuration
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web` and above, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 
@@ -316,7 +316,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](../../contributing) for details.
+[contributing guide](../../contributing/README.md) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/vue.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/vue.svg

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -171,7 +171,7 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 ## Preset options
 
@@ -455,7 +455,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](../../customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](../../customization/README.md) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -483,7 +483,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/web.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/web.svg

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,7 @@ Putting this into your `package.json` will allow you to test your project using 
 ```
 
 Using the command `neutrino test` will execute every test file located in your
-[testing directory](./project-layout#Testing). You may also provide to this command the specific test files you wish
+[testing directory](./project-layout.md#testing). You may also provide to this command the specific test files you wish
 to run individually. It is important to note that when combined with the `--use` parameter, you should use two
 dashes after the last middleware to denote the end of the middleware and the beginning of the test files.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,15 @@
 [build]
   publish = "_book"
   command = "yarn docs:build"
+
+# Redirect requests to domain aliases to the primary domain.
+
+[[redirects]]
+  from = "https://neutrino.js.org/*"
+  to = "https://neutrinojs.org/:splat"
+  force = true
+
+[[redirects]]
+  from = "https://neutrinojs.netlify.com/*"
+  to = "https://neutrinojs.org/:splat"
+  force = true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "repository": "mozilla-neutrino/neutrino-dev",
   "engines": {

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -43,7 +43,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/airbnb-base` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/airbnb-base` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project.
 
@@ -153,7 +153,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrino.js.org/packages/eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrinojs.org/packages/eslint/).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
@@ -176,7 +176,7 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/airbnb-base` creates some conventions to make overriding the configuration easier once you are ready to
 make changes.
 
@@ -196,7 +196,7 @@ middleware.
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule and loader IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule and loader IDs above,
 you can also override or augment the build by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -244,7 +244,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 `@neutrinojs/eslint`, from which this preset inherits, also provides a method for getting the ESLint
 configuration suitable for use in an eslintrc file. Typically this is used for providing hints or fix solutions to the
 development environment, e.g. IDEs and text editors. Doing this requires
-[creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the middleware it uses. If you keep all
+[creating an instance of the Neutrino API](https://neutrinojs.org/api/) and providing the middleware it uses. If you keep all
 this information in a `.neutrinorc.js`, this should be relatively straightforward. By providing all the middleware used
 to Neutrino, you can ensure all the linting options used across all middleware will be merged together for your
 development environment, without the need for copying, duplication, or loss of organization and separation.
@@ -315,7 +315,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/airbnb-base.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/airbnb-base.svg

--- a/packages/airbnb-base/package.json
+++ b/packages/airbnb-base/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/airbnb-base",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -40,7 +40,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/airbnb` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/airbnb` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project.
 
@@ -150,7 +150,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrino.js.org/packages/eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrinojs.org/packages/eslint/).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
@@ -173,7 +173,7 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/airbnb` creates some conventions to make overriding the configuration easier once you are ready to
 make changes.
 
@@ -193,7 +193,7 @@ middleware.
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule and loader IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule and loader IDs above,
 you can also override or augment the build by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -241,7 +241,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 `@neutrinojs/eslint`, from which this preset inherits, also provides a method for getting the ESLint
 configuration suitable for use in an eslintrc file. Typically this is used for providing hints or fix solutions to the
 development environment, e.g. IDEs and text editors. Doing this requires
-[creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the middleware it uses. If you keep all
+[creating an instance of the Neutrino API](https://neutrinojs.org/api/) and providing the middleware it uses. If you keep all
 this information in a `.neutrinorc.js`, this should be relatively straightforward. By providing all the middleware used
 to Neutrino, you can ensure all the linting options used across all middleware will be merged together for your
 development environment, without the need for copying, duplication, or loss of organization and separation.
@@ -312,7 +312,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/airbnb.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/airbnb.svg

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/airbnb",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/babel-minify/README.md
+++ b/packages/babel-minify/README.md
@@ -88,7 +88,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/babel-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/babel-minify.svg

--- a/packages/babel-minify/package.json
+++ b/packages/babel-minify/package.json
@@ -15,7 +15,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/babel-minify",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -96,7 +96,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/banner.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/banner.svg

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/banner",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/chunk/README.md
+++ b/packages/chunk/README.md
@@ -69,7 +69,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/chunk.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/chunk.svg

--- a/packages/chunk/package.json
+++ b/packages/chunk/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/chunk",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/clean/README.md
+++ b/packages/clean/README.md
@@ -87,7 +87,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/clean.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/clean.svg

--- a/packages/clean/package.json
+++ b/packages/clean/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/clean",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/compile-loader/README.md
+++ b/packages/compile-loader/README.md
@@ -163,7 +163,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/compile-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/compile-loader.svg

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/compile-loader",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/copy/README.md
+++ b/packages/copy/README.md
@@ -92,7 +92,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/copy.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/copy.svg

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/copy",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/create-project/README.md
+++ b/packages/create-project/README.md
@@ -2,8 +2,8 @@
 
 Neutrino can help you quickly start new projects by scaffolding your initial project structure.
 `@neutrinojs/create-project` uses middleware and presets behind the scene to build projects. If you are not
-familiar with them, take a moment to explore [middleware](https://neutrino.js.org/middleware)
-and [presets](https://neutrino.js.org/presets).
+familiar with them, take a moment to explore [middleware](https://neutrinojs.org/middleware)
+and [presets](https://neutrinojs.org/presets).
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][npm-downloads]][npm-url]
@@ -35,13 +35,13 @@ of that project to scaffold. Each project type harnesses the power of middleware
 
 | Project | Project Type | Middleware |
 | --- | --- | --- |
-| React | Application | [`@neutrinojs/react`](https://neutrino.js.org/packages/react) |
-| Preact | Application | [`@neutrinojs/preact`](https://neutrino.js.org/packages/preact) |
-| Vue | Application | [`@neutrinojs/vue`](https://neutrino.js.org/packages/vue) |
-| Web | Application | [`@neutrinojs/web`](https://neutrino.js.org/packages/web) |
-| Node.js | Application | [`@neutrinojs/node`](https://neutrino.js.org/packages/node) |
-| Web | Library | [`@neutrinojs/library`](https://neutrino.js.org/packages/library) |
-| React Components | Components | [`@neutrinojs/react-components`](https://neutrino.js.org/packages/react-components) |
+| React | Application | [`@neutrinojs/react`](https://neutrinojs.org/packages/react/) |
+| Preact | Application | [`@neutrinojs/preact`](https://neutrinojs.org/packages/preact/) |
+| Vue | Application | [`@neutrinojs/vue`](https://neutrinojs.org/packages/vue/) |
+| Web | Application | [`@neutrinojs/web`](https://neutrinojs.org/packages/web/) |
+| Node.js | Application | [`@neutrinojs/node`](https://neutrinojs.org/packages/node/) |
+| Web | Library | [`@neutrinojs/library`](https://neutrinojs.org/packages/library/) |
+| React Components | Components | [`@neutrinojs/react-components`](https://neutrinojs.org/packages/react-components/) |
 
 ## Test Runners
 
@@ -50,9 +50,9 @@ the scaffolding phase.
 
 | Test Runner | Middleware |
 | --- | --- |
-| Jest | [`@neutrinojs/jest`](https://neutrino.js.org/packages/jest) |
-| Karma | [`@neutrinojs/karma`](https://neutrino.js.org/packages/karma) |
-| Mocha | [`@neutrinojs/mocha`](https://neutrino.js.org/packages/mocha) |
+| Jest | [`@neutrinojs/jest`](https://neutrinojs.org/packages/jest/) |
+| Karma | [`@neutrinojs/karma`](https://neutrinojs.org/packages/karma/) |
+| Mocha | [`@neutrinojs/mocha`](https://neutrinojs.org/packages/mocha/) |
 
 Be sure to check out the test runner preset to get more information on its features and how files should be named.
 
@@ -63,12 +63,12 @@ process. `@neutrinojs/create-project` currently offers two linting middleware ch
 
 | Linting style | Middleware |
 | --- | --- |
-| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](https://neutrino.js.org/packages/airbnb) <br /> Other projects: [`@neutrinojs/airbnb-base`](https://neutrino.js.org/packages/airbnb-base) |
-| StandardJS | [`@neutrinojs/standardjs`](https://neutrino.js.org/packages/standardjs) |
+| Airbnb | With React/Preact: [`@neutrinojs/airbnb`](https://neutrinojs.org/packages/airbnb/) <br /> Other projects: [`@neutrinojs/airbnb-base`](https://neutrinojs.org/packages/airbnb-base/) |
+| StandardJS | [`@neutrinojs/standardjs`](https://neutrinojs.org/packages/standardjs/) |
 
 ## Project Layout
 
-`@neutrinojs/create-project` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/create-project` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project. Neutrino will scaffold the project with the initial package.json, Neutrino set up,
@@ -84,13 +84,13 @@ No two JavaScript projects are ever the same, and as such there may be times whe
 to the way your Neutrino presets are building your project. Neutrino provides a mechanism to augment presets and
 middleware in the context of a project without resorting to creating and publishing an entirely independent preset.
 To override the build configuration, start with the documentation
-on [customization](https://neutrino.js.org/customization/).
+on [customization](https://neutrinojs.org/customization/).
 
 ## Contributing
 
 This project is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/create-project.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/create-project.svg

--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -119,7 +119,7 @@ By default this middleware will start a development server with Hot Module Repla
 preset or middleware.
 
 It is recommended to call this middleware only in development mode when `process.env.NODE_ENV === 'development'`.
-More information about usage of Neutrino middleware can be found in the [documentation](https://neutrino.js.org/middleware).
+More information about usage of Neutrino middleware can be found in the [documentation](https://neutrinojs.org/middleware).
 
 ## Middleware options
 
@@ -134,7 +134,7 @@ may also specify the following options:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/dev-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/dev-server.svg

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -15,7 +15,7 @@
   "author": "Constantine Genchevsky <const.gen@gmail.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/dev-server",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -81,7 +81,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/env.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/env.svg

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/env",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -127,7 +127,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 
 `@neutrinojs/eslint` also provides a method for getting the ESLint configuration suitable for use in an eslintrc
 file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
-editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+editors. Doing this requires [creating an instance of the Neutrino API](https://neutrinojs.org/api/) and providing the
 middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
 providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
 merged together for your development environment, without the need for copying, duplication, or loss of organization and
@@ -198,7 +198,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/eslint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/eslint.svg

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/eslint",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/font-loader/README.md
+++ b/packages/font-loader/README.md
@@ -94,7 +94,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/font-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/font-loader.svg

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/font-loader",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/fork/README.md
+++ b/packages/fork/README.md
@@ -40,7 +40,7 @@ can be run simultaneously. Some typical use cases:
 - Generate multiple targets when building libraries
 
 _This middleware must be used in conjunction with a `.neutrinorc.js` file to inform Neutrino of which
-middleware should be split into another process. See the [customization docs](https://neutrino.js.org/customization/)
+middleware should be split into another process. See the [customization docs](https://neutrinojs.org/customization/)
 for details on setting up a `.neutrinorc.js` file in your project if you do not already have one._
 
 _Important: The configuration options provided to the fork middleware needs to be serializable across
@@ -124,7 +124,7 @@ each running in their own process. Quitting Neutrino will cause all forked proce
 
 ## Paths
 
-Most middleware attempt to follow the standard [Neutrino project layout](https://neutrino.js.org/project-layout)
+Most middleware attempt to follow the standard [Neutrino project layout](https://neutrinojs.org/project-layout)
 to output their compiled output, but building multiple projects at once is bound to cause clashes with
 the directories each project uses. This could lead to:
 
@@ -234,7 +234,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/fork.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/fork.svg

--- a/packages/fork/package.json
+++ b/packages/fork/package.json
@@ -15,7 +15,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/fork",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/hot/README.md
+++ b/packages/hot/README.md
@@ -66,7 +66,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/hot.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/hot.svg

--- a/packages/hot/package.json
+++ b/packages/hot/package.json
@@ -14,7 +14,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/hot",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/html-loader/README.md
+++ b/packages/html-loader/README.md
@@ -83,7 +83,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/html-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/html-loader.svg

--- a/packages/html-loader/package.json
+++ b/packages/html-loader/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/html-loader",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -114,7 +114,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/html-template.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/html-template.svg

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/html-template",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/image-loader/README.md
+++ b/packages/image-loader/README.md
@@ -94,7 +94,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/image-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/image-loader.svg

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/image-loader",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/image-minify/README.md
+++ b/packages/image-minify/README.md
@@ -118,7 +118,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/image-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/image-minify.svg

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -12,7 +12,7 @@
   "author": "Tim Kelty <timkelty@gmail.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/image-minify",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -61,7 +61,7 @@ testing with this approach.
 
 ## Project Layout
 
-`@neutrinojs/jest` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/jest` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project test code should live in a directory named `test` in the root of the
 project. Test files end in either `_test.js`, `.test.js`, `_test.jsx`, or `.test.jsx`.
 
@@ -152,7 +152,7 @@ For more details on specific Jest usage, please refer to their [documentation](h
 ## Executing single tests
 
 By default this preset will execute every test file located in your test directory ending in the appropriate file
-extension. Use the command line [`files` parameters](https://neutrino.js.org/cli#neutrino-test) to execute individual tests.
+extension. Use the command line [`files` parameters](https://neutrinojs.org/cli#neutrino-test) to execute individual tests.
 
 ## Watching for changes
 
@@ -269,7 +269,7 @@ global.requestAnimationFrame = (callback) => {
 
 ## Customizing
 
-To override the test configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the test configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/jest` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
@@ -283,7 +283,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, and loader IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, and loader IDs above,
 you can override and augment testing by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -320,7 +320,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/jest.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/jest.svg

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -11,7 +11,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/jest",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/karma/README.md
+++ b/packages/karma/README.md
@@ -40,7 +40,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/karma` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/karma` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project test code should live in a directory named `test` in the root of the
 project. Test files end in `_test.js` by default.
 
@@ -139,7 +139,7 @@ For more details on specific Karma usage, please refer to their
 ## Executing single tests
 
 By default this preset will execute every test file located in your test directory ending in the appropriate file
-extension. Use the command line [`files` parameters](https://neutrino.js.org/cli#neutrino-test) to execute individual tests.
+extension. Use the command line [`files` parameters](https://neutrinojs.org/cli#neutrino-test) to execute individual tests.
 
 ## Watching for changes
 
@@ -217,7 +217,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/karma.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/karma.svg

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -88,7 +88,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -55,7 +55,7 @@ If you want to have automatically wired sourcemaps added to your project, add `s
 
 ## Project Layout
 
-`@neutrinojs/library` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/library` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all library source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files that would be available to your compiled project.
 
@@ -304,14 +304,14 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/library` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your library, and this
 maps to the `index.*` file in the `src` directory. This means that this preset is optimized toward a single main entry
 to your library. Code not imported in the hierarchy of the `index` entry will not be output to the bundle. To overcome
-this you must either define more mains via [`options.mains`](https://neutrino.js.org/customization#optionsmains), import
+this you must either define more mains via [`options.mains`](https://neutrinojs.org/customization/#optionsmains), import
 the code path somewhere along the `index` hierarchy, or define multiple configurations in your `.neutrinorc.js`.
 
 ### External dependencies
@@ -405,7 +405,7 @@ require(['redux', 'redux-example'], ({ createStore }, reduxExample) => {
 ## Generating multiple builds
 
 The `@neutrinojs/library` middleware can be used in conjunction with the
-[`@neutrinojs/fork` middleware](https://neutrinojs.org/packages/fork) to generate multiple library outputs
+[`@neutrinojs/fork` middleware](https://neutrinojs.org/packages/fork/) to generate multiple library outputs
 when building. Follow the instructions to install the fork middleware, and change your `.neutrinorc.js`
 format as follows:
 
@@ -454,7 +454,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
@@ -475,7 +475,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/library.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/library.svg

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -19,7 +19,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/library",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/loader-merge/README.md
+++ b/packages/loader-merge/README.md
@@ -71,7 +71,7 @@ for extending the options for a rule loader which has created its own convention
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/loader-merge.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/loader-merge.svg

--- a/packages/loader-merge/package.json
+++ b/packages/loader-merge/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/loader-merge",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/minify/README.md
+++ b/packages/minify/README.md
@@ -77,9 +77,9 @@ make changes.
 
 ### Options
 
-- `babel`: Set options for [@neutrinojs/babel-minify](https://neutrino.js.org/packages/babel-minify/README.md).
-- `image`: Set options for [@neutrinojs/image-minify](https://neutrino.js.org/packages/image-minify/README.md).
-- `style`: Set options for [@neutrinojs/style-minify](https://neutrino.js.org/packages/style-minify/README.md).
+- `babel`: Set options for [@neutrinojs/babel-minify](https://neutrinojs.org/packages/babel-minify/).
+- `image`: Set options for [@neutrinojs/image-minify](https://neutrinojs.org/packages/image-minify/).
+- `style`: Set options for [@neutrinojs/style-minify](https://neutrinojs.org/packages/style-minify/).
 
 ### Plugins
 
@@ -95,7 +95,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/minify.svg

--- a/packages/minify/package.json
+++ b/packages/minify/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/minify",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -38,7 +38,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/mocha` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/mocha` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project test code should live in a directory named `test` in the root of the
 project. Test files end in `_test.js` by default.
 
@@ -124,7 +124,7 @@ For more details on specific Mocha usage, please refer to their [documentation](
 ## Executing single tests
 
 By default this preset will execute every test file located in your test directory ending in `_test.js`.
-Use the command line [`files` parameters](https://neutrino.js.org/cli#neutrino-test) to execute individual tests.
+Use the command line [`files` parameters](https://neutrinojs.org/cli#neutrino-test) to execute individual tests.
 
 ## Preset options
 
@@ -160,7 +160,7 @@ module.exports = {
 
 ## Customizing
 
-To override the test configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the test configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/mocha` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
@@ -174,7 +174,7 @@ The following is a list of rules and their identifiers which can be overridden:
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, and loader IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, and loader IDs above,
 you can override and augment testing by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -211,7 +211,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/mocha.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/mocha.svg

--- a/packages/neutrino/README.md
+++ b/packages/neutrino/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrino.js.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.
@@ -21,7 +21,7 @@ cover.
 
 ## Documentation
 
-See the [Neutrino docs](https://neutrino.js.org/)
+See the [Neutrino docs](https://neutrinojs.org/)
 for details on installation, getting started, usage, and customizing.
 
 [npm-image]: https://img.shields.io/npm/v/neutrino.svg

--- a/packages/neutrino/README.md
+++ b/packages/neutrino/README.md
@@ -1,4 +1,4 @@
-<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/master/docs/assets/logo.png" height="150"></a></p></h1>
+<h1><p align="center"><a href="https://neutrinojs.org"><img src="https://raw.githubusercontent.com/mozilla-neutrino/neutrino-dev/release/v8/docs/assets/logo.png" height="150"></a></p></h1>
 
 ### Create and build modern JavaScript applications with zero initial configuration
 #### Neutrino combines the power of webpack with the simplicity of presets.

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -16,7 +16,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/neutrino",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "scripts": {
     "test": "ava test"

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -88,7 +88,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -55,7 +55,7 @@ If you want to have automatically wired sourcemaps added to your project, add `s
 
 ## Project Layout
 
-`@neutrinojs/node` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/node` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files that would be available to your compiled project.
 
@@ -238,7 +238,7 @@ modification during development.
 ## Debugging
 
 You can start the Node.js server in `inspect` mode to debug the process by setting `neutrino.options.debug` to `true`.
-This can be done from the [API](https://neutrino.js.org/api#optionsdebug) or the [CLI using `--debug`](https://neutrino.js.org/cli#-debug).
+This can be done from the [API](https://neutrinojs.org/api#optionsdebug) or the [CLI using `--debug`](https://neutrinojs.org/cli#-debug).
 
 ## Preset options
 
@@ -317,14 +317,14 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/node` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your application, and this
 maps to the `index.*` file in the `src` directory. This means that this preset is optimized toward a single main entry
 to your application. Code not imported in the hierarchy of the `index` entry will not be output to the bundle. To overcome
-this you must either define more mains via [`options.mains`](https://neutrino.js.org/customization#optionsmains), import
+this you must either define more mains via [`options.mains`](https://neutrinojs.org/customization/#optionsmains), import
 the code path somewhere along the `index` hierarchy, or define multiple configurations in your `.neutrinorc.js`.
 
 ### Vendoring
@@ -358,7 +358,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
@@ -377,7 +377,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/node.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/node.svg

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/node",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -102,7 +102,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation
@@ -193,7 +193,7 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/preact` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 ## Preset options
 

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -13,7 +13,7 @@
 - Write JSX in .js or .jsx files
 - Automatic import of `Preact.h`, no need to import `h` or `createElement` yourself
 - Compatibility and pre-configured aliasing for React-based modules and packages
-- Extends from [@neutrinojs/web](https://neutrino.js.org/packages/web)
+- Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -68,7 +68,7 @@ compatibility layer:
 
 ## Project Layout
 
-`@neutrinojs/preact` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/preact` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project.
@@ -186,7 +186,7 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+[@neutrinojs/copy](https://neutrinojs.org/packages/copy/).
 
 ## Paths
 
@@ -202,7 +202,7 @@ preset builds. You can modify Preact preset settings from `.neutrinorc.js` by ov
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the Preact preset and override its options. See the
-[Web documentation](https://neutrino.js.org/packages/web#preset-options) for specific options you can override with this object.
+[Web documentation](https://neutrinojs.org/packages/web#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -244,14 +244,14 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/preact` does not use any additional named rules, loaders, or plugins that aren't already in use by the
-Web preset. See the [Web documentation customization](https://neutrino.js.org/packages/web#customizing)
+Web preset. See the [Web documentation customization](https://neutrinojs.org/packages/web#customizing)
 for preset-specific configuration to override.
 
 ### Advanced configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web`, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 
@@ -319,7 +319,7 @@ if (process.env.NODE_ENV === 'development') {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/preact.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/preact.svg

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -13,7 +13,7 @@
   "author": "Fahad Hossain <8bit.demoncoder@gmail.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/preact",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -124,7 +124,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/pwa.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/pwa.svg

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -15,7 +15,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/pwa",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,13 +9,13 @@ other Neutrino middleware, so you can build, test, and publish multiple React co
 
 ## Features
 
-- Extends partially from [@neutrinojs/react](https://neutrino.js.org/packages/@neutrinojs/react)
+- Extends partially from [@neutrinojs/react](https://neutrinojs.org/packages/@neutrinojs/react)
 - Zero upfront configuration necessary to start developing and building React components.
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Support for importing web workers with `.worker.*` file extensions
-- Extends partially from [@neutrinojs/web](https://neutrino.js.org/packages/@neutrinojs/web)
+- Extends partially from [@neutrinojs/web](https://neutrinojs.org/packages/@neutrinojs/web)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -72,7 +72,7 @@ If you want to have automatically wired sourcemaps added to your project, add `s
 
 ## Project Layout
 
-`@neutrinojs/react-components` follows the standard [project layout](https://neutrino.js.org/project-layout)
+`@neutrinojs/react-components` follows the standard [project layout](https://neutrinojs.org/project-layout)
 specified by Neutrino. This means that by default all project source code should live in a directory named `src` in the
 root of the project. This includes JavaScript files that would be available to your compiled project.
 
@@ -210,24 +210,24 @@ const YourCustomComponent = require('your-custom-component').default;
 ```
 
 By default this preset creates an individual entry point for every top-level component found in `src/components`. These
-are set and accessible via the API at [`neutrino.options.mains`](https://neutrino.js.org/api#optionsmains).
+are set and accessible via the API at [`neutrino.options.mains`](https://neutrinojs.org/api#optionsmains).
 
 ## Hot Module Replacement
 
 While `@neutrinojs/react-components` supports Hot Module Replacement for your app, it does require some
 changes to the preview app in order to operate. The preview app should define split points for which to accept
 modules (Components) to reload using `module.hot`. See the
-[React preset docs](https://neutrino.js.org/packages/react/#hot-module-replacement) for guidance.
+[React preset docs](https://neutrinojs.org/packages/react/#hot-module-replacement) for guidance.
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/react-components` uses a few rules and plugins in addition to the ones in use by the React and Web presets.
-See the [Web documentation customization](https://neutrino.js.org/packages/web#customizing)
+See the [Web documentation customization](https://neutrinojs.org/packages/web#customizing)
 for preset-specific configuration to override.
 
 By default this preset creates an individual entry point for every top-level component found in `src/components`. These
-are set and accessible via the API at [`neutrino.options.mains`](https://neutrino.js.org/api#optionsmains).
+are set and accessible via the API at [`neutrino.options.mains`](https://neutrinojs.org/api#optionsmains).
 
 ### Rules
 
@@ -245,7 +245,7 @@ _Note: Some plugins are only available in certain environments. To override them
 | ---- | ----------- | ------------ |
 | `banner` | Injects source-map-support into the mains (entry points) of your application if detected in `dependencies` or `devDependencies` of your package.json. | all but `development` |
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -107,7 +107,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -178,10 +178,10 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 For details on merging and overriding Babel configuration, such as supporting decorator syntax, read more
-about using the [`compile-loader` `merge`](../compile-loader#advanced-merging) once you
+about using the [`compile-loader` `merge`](../compile-loader/README.md#advanced-merging) once you
 are comfortable customizing your build.
 
 ## Preset options

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,7 @@
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Automatic import of `React.createElement`, no need to import `react` or `React.createElement` yourself
-- Extends from [@neutrinojs/web](https://neutrino.js.org/packages/web)
+- Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -53,7 +53,7 @@ React development.
 
 ## Project Layout
 
-`@neutrinojs/react` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/react` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project.
@@ -171,7 +171,7 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+[@neutrinojs/copy](https://neutrinojs.org/packages/copy/).
 
 ## Paths
 
@@ -191,7 +191,7 @@ preset builds. You can modify React preset settings from `.neutrinorc.js` by ove
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the React preset and override its options. See the
-[Web documentation](https://neutrino.js.org/packages/web#preset-options) for specific options you can override with this object.
+[Web documentation](https://neutrinojs.org/packages/web#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -233,18 +233,18 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/react` does not use any additional named rules, loaders, or plugins that aren't already in use by the
-Web preset. See the [Web documentation customization](https://neutrino.js.org/packages/web#customizing)
+Web preset. See the [Web documentation customization](https://neutrinojs.org/packages/web#customizing)
 for preset-specific configuration to override.
 
 For details on merging and overriding Babel configuration, such as supporting decorator syntax, read more
-about using the [`compile-loader` `merge`](https://neutrino.js.org/packages/compile-loader#advanced-merging) once you
+about using the [`compile-loader` `merge`](https://neutrinojs.org/packages/compile-loader#advanced-merging) once you
 are comfortable customizing your build.
 
 ### Advanced configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web`, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 
@@ -337,7 +337,7 @@ load();
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/react.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/react.svg

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/react",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -40,7 +40,7 @@ another Neutrino preset for building your application source code.
 
 ## Project Layout
 
-`@neutrinojs/standardjs` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/standardjs` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project.
 
@@ -151,7 +151,7 @@ module.exports = {
 
 ## Middleware options
 
-This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrino.js.org/packages/eslint).
+This preset uses the same middleware options as [@neutrinojs/eslint](https://neutrinojs.org/packages/eslint/).
 If you wish to customize what is included, excluded, or any ESLint options, you can provide an options object with the
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
@@ -174,7 +174,7 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/standardjs` creates some conventions to make overriding the configuration easier once you are ready to
 make changes.
 
@@ -194,7 +194,7 @@ middleware.
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule and loader IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule and loader IDs above,
 you can also override or augment the build by providing a function to your `.neutrinorc.js` use array. You can also
 make this change from the Neutrino API when using the `use` method.
 
@@ -242,7 +242,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 `@neutrinojs/eslint`, from which this preset inherits, also provides a method for getting the ESLint
 configuration suitable for use in an eslintrc file. Typically this is used for providing hints or fix solutions to the
 development environment, e.g. IDEs and text editors. Doing this requires
-[creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the middleware it uses. If you keep all
+[creating an instance of the Neutrino API](https://neutrinojs.org/api/) and providing the middleware it uses. If you keep all
 this information in a `.neutrinorc.js`, this should be relatively straightforward. By providing all the middleware used
 to Neutrino, you can ensure all the linting options used across all middleware will be merged together for your
 development environment, without the need for copying, duplication, or loss of organization and separation.
@@ -310,7 +310,7 @@ in the [ESLint user guide](http://eslint.org/docs/user-guide/configuring#ignorin
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/standardjs.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/standardjs.svg

--- a/packages/standardjs/package.json
+++ b/packages/standardjs/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/standardjs",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/start-server/README.md
+++ b/packages/start-server/README.md
@@ -91,14 +91,14 @@ The following is a list of plugins and their identifiers which can be overridden
 ### Debugging
 
 You can start the Node.js server in `inspect` mode to debug the process by setting `neutrino.options.debug` to `true`.
-This can be done from the [API](https://neutrino.js.org/api#optionsdebug) or the
-[CLI using `--debug`](https://neutrino.js.org/cli#-debug).
+This can be done from the [API](https://neutrinojs.org/api#optionsdebug) or the
+[CLI using `--debug`](https://neutrinojs.org/cli#-debug).
 
 ## Contributing
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/start-server.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/start-server.svg

--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/start-server",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -255,7 +255,7 @@ _Note: Some plugins may be only available in certain environments. To override t
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/style-loader.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/style-loader.svg

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -13,7 +13,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/style-loader",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/style-minify/README.md
+++ b/packages/style-minify/README.md
@@ -95,7 +95,7 @@ The following is a list of plugins and their identifiers which can be overridden
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/style-minify.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/style-minify.svg

--- a/packages/style-minify/package.json
+++ b/packages/style-minify/package.json
@@ -14,7 +14,7 @@
   "author": "Tim Kelty <timkelty@gmail.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/style-minify",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -77,7 +77,7 @@ If you cannot or do not wish to use Neutrino to execute one-off linting, you can
 
 `@neutrinojs/stylelint` also provides a method for getting the stylelint configuration suitable for use in a stylelintrc
 file. Typically this is used for providing hints or fix solutions to the development environment, e.g. IDEs and text
-editors. Doing this requires [creating an instance of the Neutrino API](https://neutrino.js.org/api) and providing the
+editors. Doing this requires [creating an instance of the Neutrino API](https://neutrinojs.org/api/) and providing the
 middleware it uses. If you keep all this information in a `.neutrinorc.js`, this should be relatively straightforward. By
 providing all the middleware used to Neutrino, you can ensure all the linting options used across all middleware will be
 merged together for your development environment, without the need for copying, duplication, or loss of organization and
@@ -125,7 +125,7 @@ changes in `.stylelint.js` over `.neutrinorc.js`.**
 
 This middleware is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/stylelint.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/stylelint.svg

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/stylelint",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -82,7 +82,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation
@@ -196,7 +196,7 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting Webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 
 ## Preset options

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -8,7 +8,7 @@
 
 - Zero upfront configuration necessary to start developing and building a Vue web app
 - Modern Babel compilation.
-- Extends from [@neutrinojs/web](https://neutrino.js.org/packages/web)
+- Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
@@ -48,7 +48,7 @@ Vue development.
 
 ## Project Layout
 
-`@neutrinojs/vue` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/vue` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to import your compiled project.
@@ -189,7 +189,7 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy).
+[@neutrinojs/copy](https://neutrinojs.org/packages/copy/).
 
 ## Paths
 
@@ -206,7 +206,7 @@ preset builds. You can modify Vue preset settings from `.neutrinorc.js` by overr
 an array pair instead of a string to supply these options in `.neutrinorc.js`.
 
 The following shows how you can pass an options object to the Vue preset and override its options. See the
-[Web documentation](https://neutrino.js.org/packages/web#preset-options) for specific options you can override with this object.
+[Web documentation](https://neutrinojs.org/packages/web#preset-options) for specific options you can override with this object.
 
 ```js
 module.exports = {
@@ -248,10 +248,10 @@ module.exports = {
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/vue` creates some conventions to make overriding the configuration easier once you are ready to make
 changes. Most of the configuration for `@neutrinojs/vue` is inherited from the
-[`@neutrinojs/web` preset](https://neutrino.js.org/packages/web#customizing); continue to that documentation
+[`@neutrinojs/web` preset](https://neutrinojs.org/packages/web#customizing); continue to that documentation
 for details on customization.
 
 By default Neutrino, and therefore this preset, creates a single **main** `index` entry point to your application, and
@@ -288,7 +288,7 @@ _This preset does not define any additional plugins from those already in use by
 
 ### Advanced configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs from
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs from
 `@neutrinojs/web` and above, you can override and augment the build by providing a function to your `.neutrinorc.js` use
 array. You can also make these changes from the Neutrino API in custom middleware.
 
@@ -316,7 +316,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/vue.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/vue.svg

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -45,7 +45,7 @@
 
 ## Project Layout
 
-`@neutrinojs/web` follows the standard [project layout](https://neutrino.js.org/project-layout) specified by Neutrino. This
+`@neutrinojs/web` follows the standard [project layout](https://neutrinojs.org/project-layout) specified by Neutrino. This
 means that by default all project source code should live in a directory named `src` in the root of the
 project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
 to your compiled project.
@@ -164,7 +164,7 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code, you can place
 them in a directory within `src` called `static`. All files in this directory will be copied from `src/static`
 to `build/static`. To change this behavior, specify your own patterns with
-[@neutrinojs/copy](https://neutrino.js.org/packages/copy/README.md).
+[@neutrinojs/copy](https://neutrinojs.org/packages/copy/).
 
 ## Paths
 
@@ -389,7 +389,7 @@ modification during development.
 
 ## Customizing
 
-To override the build configuration, start with the documentation on [customization](https://neutrino.js.org/customization).
+To override the build configuration, start with the documentation on [customization](https://neutrinojs.org/customization/).
 `@neutrinojs/web` creates some conventions to make overriding the configuration easier once you are ready to make
 changes.
 
@@ -455,7 +455,7 @@ _Note: Some plugins are only available in certain environments. To override them
 
 ### Override configuration
 
-By following the [customization guide](https://neutrino.js.org/customization) and knowing the rule, loader, and plugin IDs above,
+By following the [customization guide](https://neutrinojs.org/customization/) and knowing the rule, loader, and plugin IDs above,
 you can override and augment the build by by providing a function to your `.neutrinorc.js` use array. You can also
 make these changes from the Neutrino API in custom middleware.
 
@@ -483,7 +483,7 @@ module.exports = {
 
 This preset is part of the [neutrino-dev](https://github.com/mozilla-neutrino/neutrino-dev) repository, a monorepo
 containing all resources for developing Neutrino and its core presets and middleware. Follow the
-[contributing guide](https://neutrino.js.org/contributing) for details.
+[contributing guide](https://neutrinojs.org/contributing/) for details.
 
 [npm-image]: https://img.shields.io/npm/v/@neutrinojs/web.svg
 [npm-downloads]: https://img.shields.io/npm/dt/@neutrinojs/web.svg

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -79,7 +79,7 @@ _Note: The `create` command is a shorthand that helps you do two things at once.
 ```
 
 The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](../create-project) section
+up a test runner as well as linting to your project. Refer to the [Create new project](../create-project/README.md) section
 for details on all available options.
 
 ### Manual Installation
@@ -171,7 +171,7 @@ to `build/static`. To change this behavior, specify your own patterns with
 The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
 [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `./`. If you wish to load
 assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#Customizing) section below.
+override `output.publicPath`. See the [Customizing](#customizing) section below.
 
 ## Preset options
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla-neutrino/neutrino-dev/tree/master/packages/web",
-  "homepage": "https://neutrino.js.org",
+  "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/mozilla-neutrino/neutrino-dev/issues",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
* Adds an HTTP 301 redirect from https://neutrino.js.org to https://neutrinojs.org (same as `master`, but needed on this branch since that's what's deployed in production at the moment).
* Replaces all links to https://neutrino.js.org with https://neutrinojs.org.
* Uses `/release/v8/` for resource links rather than `/master/`.
* Fixes a number of broken/non-canonical internal links.
* Removes redundant docs section from docs front page.

See individual commits for more details.