### PR TITLE
Fix the Netlify build after #852

### DIFF
--- a/docs/packages/fork.md
+++ b/docs/packages/fork.md
@@ -1,1 +1,0 @@
-../../packages/fork/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ pages:
     - env: './packages/env.md'
     - eslint: './packages/eslint.md'
     - font-loader: './packages/font-loader.md'
-    - fork: './packages/fork.md'
     - hot: './packages/hot.md'
     - html-loader: './packages/html-loader.md'
     - html-template: './packages/html-template.md'


### PR DESCRIPTION
The `fork` preset was removed by #852, but it still referenced by the mkdocs configuration added the commit before.

(Race condition between the landings of #852 and #898)