### PR TITLE
Update to verdaccio 3.0.0-beta.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nyc": "^11.7.1",
     "prettier": "^1.12.1",
     "stylelint": "^8.4.0",
-    "verdaccio": "3.0.0-beta.10",
+    "verdaccio": "3.0.0-beta.12",
     "verdaccio-memory": "^1.0.1",
     "webpack": "^4.8.3",
     "webpack-dev-server": "^3.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,7 +1981,7 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
-body-parser@^1.16.1:
+body-parser@1.18.3, body-parser@^1.16.1:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   dependencies:
@@ -10652,6 +10652,32 @@ request@2.85.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
+request@2.86.0:
+  version "2.86.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.86.0.tgz#2b9497f449b0a32654c081a5cf426bbfb5bf5b69"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
 request@^2.0.0, request@^2.74.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -12529,6 +12555,15 @@ vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
 
+verdaccio-audit@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/verdaccio-audit/-/verdaccio-audit-0.1.0.tgz#4cc2e9a61c71492962f1a623bd099c51f5ca745a"
+  dependencies:
+    body-parser "1.18.3"
+    compression "1.7.2"
+    express "4.16.3"
+    request "2.86.0"
+
 verdaccio-htpasswd@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/verdaccio-htpasswd/-/verdaccio-htpasswd-0.2.2.tgz#6873fe42cd83ff03d260b21483941635f320c8ba"
@@ -12546,9 +12581,9 @@ verdaccio-memory@^1.0.1:
     http-errors "1.6.3"
     memory-fs "^0.4.1"
 
-verdaccio@3.0.0-beta.10:
-  version "3.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-3.0.0-beta.10.tgz#40be1c27b09aef4fb5abb52118b2efcec7ddbc97"
+verdaccio@3.0.0-beta.12:
+  version "3.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-3.0.0-beta.12.tgz#3f2f4a8ef36189a01246357bbed2d3c066adb5b4"
   dependencies:
     "@verdaccio/file-locking" "0.0.7"
     "@verdaccio/local-storage" "1.0.3"
@@ -12580,6 +12615,7 @@ verdaccio@3.0.0-beta.10:
     pkginfo "0.4.1"
     request "2.85.0"
     semver "5.5.0"
+    verdaccio-audit "0.1.0"
     verdaccio-htpasswd "0.2.2"
 
 verror@1.10.0:


### PR DESCRIPTION
This includes the fix for the incorrect 'bad version' warnings.

Having to do so manually due to:
renovateapp/renovate#1988