### PR TITLE
Speed and reliability improvements to Verdaccio configuration

### DIFF
--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -2,8 +2,8 @@ store:
   memory:
     limit: 10000
 uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
+  yarnpkg:
+    url: https://registry.yarnpkg.com/
     # Make request fail sooner if NPM being flaky (default is 30s).
     timeout: 10s
     # Increase number of failed requests before disabling uplink (default 2).
@@ -18,6 +18,6 @@ packages:
   '**':
     access: $anonymous
     publish: $anonymous
-    proxy: npmjs
+    proxy: yarnpkg
 logs:
   - {type: stdout, format: pretty, level: warn}

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -8,6 +8,8 @@ uplinks:
     max_fails: 5
     # Increase the time before cached package metadata is re-fetched (default 2m).
     maxage: 10m
+    # Disable caching of package tarballs since it duplicates the local yarn cache.
+    cache: false
 packages:
   'neutrino':
     access: $anonymous

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -1,5 +1,7 @@
 store:
+  # Use ephemeral verdaccio-memory storage instead of the default of filesystem.
   memory:
+    # Increase maximum number of packages that can be stored (default 1000).
     limit: 10000
 uplinks:
   yarnpkg:
@@ -19,7 +21,6 @@ packages:
     publish: $anonymous
   '**':
     access: $anonymous
-    publish: $anonymous
     proxy: yarnpkg
 logs:
   - {type: stdout, format: pretty, level: warn}

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -4,10 +4,8 @@ store:
 uplinks:
   yarnpkg:
     url: https://registry.yarnpkg.com/
-    # Make request fail sooner if NPM being flaky (default is 30s).
-    timeout: 10s
     # Increase number of failed requests before disabling uplink (default 2).
-    max_fails: 20
+    max_fails: 5
 packages:
   'neutrino':
     access: $anonymous

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -6,6 +6,8 @@ uplinks:
     url: https://registry.yarnpkg.com/
     # Increase number of failed requests before disabling uplink (default 2).
     max_fails: 5
+    # Increase the time before cached package metadata is re-fetched (default 2m).
+    maxage: 10m
 packages:
   'neutrino':
     access: $anonymous


### PR DESCRIPTION
1. Switch Verdaccio from the NPM registry to Yarn's
  -> For consistency with standard yarn usage & to hopefully avoid NPM registry specific infra issues in the future.
2. Tweak `timeout` / `max_fails`
  -> Since 10s might not be long enough to connect, and 20 retries before giving up means the broken jobs take ages to appear as complete in Travis.
3. Increase Verdaccio `maxage` to 10m
  -> So that Verdaccio doesn't try and refresh package metadata when we're only partway through through the ~6 minute CI run.
4. Disable Verdaccio's caching of tarballs
  -> Since it duplicates the local yarn cache and won't be kept once Verdaccio is restarted anyway.
5. Clean up Verdaccio config
  -> Add comments and remove unused publish permission.

This PR reduces the overall duration of each Travis job by about 1 minute - mainly due to the `maxage` change. 

See:
https://www.verdaccio.org/docs/en/uplinks.html
https://www.verdaccio.org/docs/en/packages.html

I also tried many other permutations of tmpfs for temp directory or yarn cache directory, but it gave virtually no improvement. Ultimately I think double digit yarn invocations during the create-project matrix is just slow due to there being no `yarn.lock` in the new projects, so each time it has to do a lot of module resolution / graph generation.