### PR TITLE
Only test against Node 9 on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ language: node_js
 cache: yarn
 node_js:
 - '8'
-- '9'
 - '10'
+jobs:
+  include:
+    - if: type != pull_request AND branch = master
+      node_js: '9'
 before_install:
 # Use newer yarn than that pre-installed in the Travis image.
 - curl -sSfL https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
Since it's very unlikely we're ever going to have a Node 9 only CI failure if Node 8 and Node 10 both pass. This means each PR/branch only uses 2 jobs rather than 3, out of our 5 concurrent job allowance - but yet we still have coverage once they are merged to `master`.

Node 9 will also no longer be supported after the end of June.