### PR TITLE
Improve stringified config output by --inspect

### DIFF
--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -110,12 +110,16 @@ module.exports = (neutrino, opts = {}) => {
     }
   };
   const options = merge(defaults, opts);
-  const loaderOptions = typeof options.eslint.formatter === 'string'
-    ? deepmerge(options.eslint, {
-      // eslint-disable-next-line global-require
-      formatter: require(`eslint/lib/formatters/${options.eslint.formatter}`)
-    })
-    : options.eslint;
+  const loaderOptions = options.eslint;
+
+  if (typeof loaderOptions.formatter === 'string') {
+    const formatterPath = `eslint/lib/formatters/${loaderOptions.formatter}`;
+    // eslint-disable-next-line global-require
+    loaderOptions.formatter = require(formatterPath);
+    // Improve the stringified output when using --inspect.
+    // eslint-disable-next-line no-underscore-dangle
+    loaderOptions.formatter.__expression = `require('${formatterPath}')`;
+  }
 
   neutrino.config
     .module

--- a/packages/neutrino/index.js
+++ b/packages/neutrino/index.js
@@ -1,10 +1,9 @@
-const stringify = require('javascript-stringify');
-const sort = require('deep-sort-object');
 const yargs = require('yargs');
 const Neutrino = require('./Neutrino');
 const webpack = require('./webpack');
 
 const IDENTITY = a => a;
+const configPrefix = 'neutrino.config';
 
 module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
   const neutrino = new Neutrino(options);
@@ -25,7 +24,7 @@ module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
   const adapter = {
     output(name, override = IDENTITY) {
       if (name === 'inspect') {
-        console.log(stringify(sort(neutrino.config.toConfig()), null, 2));
+        console.log(neutrino.config.toString({ configPrefix }));
         process.exit();
       }
 

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -25,12 +25,10 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deep-sort-object": "^1.0.2",
     "deepmerge": "^1.5.2",
     "is-plain-object": "^2.0.4",
-    "javascript-stringify": "^1.6.0",
     "lodash.clonedeep": "^4.5.0",
-    "webpack-chain": "^4.6.0",
+    "webpack-chain": "^4.8.0",
     "yargs": "^11.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,12 +3742,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deep-sort-object@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/deep-sort-object/-/deep-sort-object-1.0.2.tgz#3892dcef5dfd0efc2d6fa96beabccb33cd8ef91f"
-  dependencies:
-    is-plain-object "^2.0.1"
-
 deepmerge@^1.5.1, deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
@@ -12853,7 +12847,7 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-webpack-chain@^4.6.0:
+webpack-chain@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-4.8.0.tgz#06fc3dbb9f2707d4c9e899fc6250fbcf2afe6fd1"
   dependencies:


### PR DESCRIPTION
This take advantage of the new webpack-chain `toString()` added in mozilla-neutrino/webpack-chain#53.

The output from `neutrino --inspect` now lists the correct plugin declarations and arguments, annotates plugins/loaders with hints about how to reference them in a custom Neutrino config, and supports using `__expression` to override the stringified output when needed.

The usage of `deep-sort-object` has been removed since it breaks the new `toString()` comment annotations, and really if sorted output is considered important, it should be handled by webpack-chain itself.

Example output for Treeherder's WIP Neutrino 9 config:
https://emorley.pastebin.mozilla.org/9086982

After this merges, I was thinking we could backport this to Neutrino 8 under a separate flag (eg `--inspect-v9`) which would make it easier for people to diff Neutrino 8 and 9 configs.

Fixes #328.
Refs #96.