### PR TITLE
Adjust hashes used in production asset filenames

### DIFF
--- a/packages/font-loader/README.md
+++ b/packages/font-loader/README.md
@@ -41,7 +41,7 @@ neutrino.use(fonts);
 
 // Usage showing default options
 neutrino.use(fonts, {
-  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
+  name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -57,7 +57,7 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/font-loader', {
-      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
+      name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
     }]
   ]
 };

--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,7 +1,7 @@
 module.exports = (neutrino, options = {}) => {
   const isProduction = neutrino.config.get('mode') === 'production';
   const defaultOptions = {
-    name: isProduction ? '[name].[hash].[ext]' : '[name].[ext]'
+    name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'
   };
 
   neutrino.config.module

--- a/packages/image-loader/README.md
+++ b/packages/image-loader/README.md
@@ -42,7 +42,7 @@ neutrino.use(images);
 // Usage showing default options
 neutrino.use(images, {
   limit: 8192,
-  name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
+  name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -59,7 +59,7 @@ module.exports = {
   use: [
     ['@neutrinojs/image-loader', {
       limit: 8192,
-      name: neutrino.options.command === 'build' ? '[name].[hash].[ext]' : '[name].[ext]'
+      name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
     }]
   ]
 };

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -2,7 +2,7 @@ module.exports = (neutrino, options = {}) => {
   const isProduction = neutrino.config.get('mode') === 'production';
   const defaultOptions = {
     limit: 8192,
-    name: isProduction ? '[name].[hash].[ext]' : '[name].[ext]'
+    name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'
   };
 
   neutrino.config.module

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -74,7 +74,7 @@ module.exports = (neutrino, opts = {}) => {
       .path(neutrino.options.output)
       .filename('[name].js')
       .libraryTarget('commonjs2')
-      .chunkFilename('[id].[hash:5]-[chunkhash:7].js')
+      .chunkFilename('[name].js')
       .end()
     .resolve
       .extensions

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -63,7 +63,7 @@ neutrino.use(styles, {
   extract: {
     plugin: {},
     loader: {
-      filename: neutrino.options.command === 'build' ? '[name].[contenthash].css' : '[name].css'
+      filename: mode === 'production' ? '[name].[contenthash:8].css' : '[name].css'
     }
   }
 });
@@ -95,7 +95,7 @@ module.exports = {
       extract: {
         plugin: {},
         loader: {
-          filename: neutrino.options.command === 'build' ? '[name].[contenthash].css' : '[name].css'
+          filename: mode === 'production' ? '[name].[contenthash:8].css' : '[name].css'
         }
       }
     }]

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -23,7 +23,7 @@ module.exports = (neutrino, opts = {}) => {
       loader: {},
       plugin: {
         filename: neutrino.config.get('mode') === 'production'
-          ? '[name].[contenthash].css'
+          ? '[name].[contenthash:8].css'
           : '[name].css'
       }
     }

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -135,6 +135,8 @@ module.exports = (neutrino, opts = {}) => {
           });
     });
 
+  const jsFilename = mode === 'production' ? '[name].[contenthash:8].js' : '[name].js';
+
   neutrino.config
     .optimization
       .minimize(options.minify.source)
@@ -145,9 +147,9 @@ module.exports = (neutrino, opts = {}) => {
         // https://github.com/webpack/webpack/issues/7064
         chunks: 'all',
         // By default the generated files use names that reference the chunk names, eg:
-        // `vendors~index~page2.b694ee990c08e6be6a33.js`. Setting to `false` causes them to
-        // use the chunk ID instead (eg `1.ceddedc0defa56bec89f.js`), which prevents cache-
-        // busting when a new page is added with the same shared vendor dependencies.
+        // `vendors~index~page2.b694ee99.js`. Setting to `false` causes them to use the
+        // chunk ID instead (eg `1.ceddedc0.js`), which prevents cache-busting when a
+        // new page is added with the same shared vendor dependencies.
         name: mode !== 'production'
       })
       // Create a separate chunk for the webpack runtime, so it can be cached separately
@@ -162,8 +164,8 @@ module.exports = (neutrino, opts = {}) => {
     .output
       .path(neutrino.options.output)
       .publicPath(options.publicPath)
-      .filename('[name].js')
-      .chunkFilename('[name].[chunkhash].js')
+      .filename(jsFilename)
+      .chunkFilename(jsFilename)
       .end()
     .resolve
       .extensions
@@ -211,7 +213,5 @@ module.exports = (neutrino, opts = {}) => {
         neutrino.config.plugin('manifest')
           .use(ManifestPlugin, [options.manifest]);
       }
-
-      config.output.filename('[name].[chunkhash].js');
     });
 };


### PR DESCRIPTION
* Switches from `[chunkhash]` to `[contenthash]` to prevent unnecessary cache-busting of JS files when only extracted CSS has changed.
* Limits all hashes to 8 characters to make build console output more readable, and for parity with CRA/vue-cli. (By default `[hash]` gives a 32 character hash, and `[{chunk,content}hash]` 20 characters.)
* Removes unnecessary hashing in `chunkFilename` for the node preset (since generated assets won't be cached regardless).

See:
https://webpack.js.org/configuration/output/#output-filename
https://webpack.js.org/configuration/output/#output-chunkfilename
https://github.com/webpack/webpack/blob/v4.11.0/lib/WebpackOptionsDefaulter.js#L91-L104
(Note the docs are out of date: webpack/webpack.js.org#2221)

Fixes #844.