### PR TITLE
Stop leaking pluginId into the options passed to plugins

### DIFF
--- a/packages/banner/index.js
+++ b/packages/banner/index.js
@@ -1,8 +1,8 @@
 const { BannerPlugin } = require('webpack');
 
-module.exports = (neutrino, options = {}) => {
+module.exports = (neutrino, { pluginId = 'banner', ...options } = {}) => {
   neutrino.config
-    .plugin(options.pluginId || 'banner')
+    .plugin(pluginId)
     .use(BannerPlugin, [{
       banner: 'require(\'source-map-support\').install();',
       test: neutrino.regexFromExtensions(),

--- a/packages/clean/index.js
+++ b/packages/clean/index.js
@@ -1,17 +1,11 @@
 const CleanPlugin = require('clean-webpack-plugin');
 
-module.exports = (neutrino, opts = {}) => {
+module.exports = (neutrino, { pluginId = 'clean', paths = [], ...opts } = {}) => {
   const options = {
-    pluginId: 'clean',
-    paths: [],
     root: neutrino.options.root,
     verbose: neutrino.options.debug,
     ...opts
   };
-  const { paths, pluginId } = options;
-
-  delete options.paths;
-  delete options.pluginId;
 
   neutrino.config
     .plugin(pluginId)

--- a/packages/copy/index.js
+++ b/packages/copy/index.js
@@ -1,13 +1,13 @@
 const CopyPlugin = require('copy-webpack-plugin');
-const merge = require('deepmerge');
 
-module.exports = (neutrino, opts = {}) => {
-  const { patterns, options } = merge({
-    patterns: [],
-    options: { debug: neutrino.options.debug }
-  }, opts);
-
+module.exports = (neutrino, { pluginId = 'copy', patterns = [], options = {} } = {}) => {
   neutrino.config
-    .plugin(options.pluginId || 'copy')
-    .use(CopyPlugin, [patterns, options]);
+    .plugin(pluginId)
+    .use(CopyPlugin, [
+      patterns,
+      {
+        debug: neutrino.options.debug,
+        ...options
+      }
+    ]);
 };

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -23,8 +23,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "copy-webpack-plugin": "^4.5.1",
-    "deepmerge": "^1.5.2"
+    "copy-webpack-plugin": "^4.5.1"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0",

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -2,20 +2,22 @@ const HtmlPlugin = require('html-webpack-plugin');
 const template = require('html-webpack-template');
 const merge = require('deepmerge');
 
-module.exports = ({ config }, options = {}) => config
-  .plugin(options.pluginId || 'html')
-  .use(HtmlPlugin, [
-    merge({
-      template,
-      inject: false,
-      appMountId: 'root',
-      xhtml: true,
-      mobile: true,
-      minify: {
-        useShortDoctype: true,
-        keepClosingSlash: true,
-        collapseWhitespace: true,
-        preserveLineBreaks: true
-      }
-    }, options)
-  ]);
+module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
+  neutrino.config
+    .plugin(pluginId)
+    .use(HtmlPlugin, [
+      merge({
+        template,
+        inject: false,
+        appMountId: 'root',
+        xhtml: true,
+        mobile: true,
+        minify: {
+          useShortDoctype: true,
+          keepClosingSlash: true,
+          collapseWhitespace: true,
+          preserveLineBreaks: true
+        }
+      }, options)
+    ]);
+};

--- a/packages/pwa/index.js
+++ b/packages/pwa/index.js
@@ -1,13 +1,13 @@
 const OfflinePlugin = require('offline-plugin');
 const merge = require('deepmerge');
 
-module.exports = (neutrino, options = {}) => {
+module.exports = (neutrino, { pluginId = 'pwa', ...options } = {}) => {
   Object
     .keys(neutrino.options.mains)
     .forEach(key => neutrino.config.entry(key).add(require.resolve('./pwa')));
 
   neutrino.config
-    .plugin(options.pluginId || 'pwa')
+    .plugin(pluginId)
     .use(OfflinePlugin, [
       merge({
         ServiceWorker: {

--- a/packages/start-server/index.js
+++ b/packages/start-server/index.js
@@ -1,8 +1,10 @@
 const StartServerPlugin = require('start-server-webpack-plugin');
 
-module.exports = (neutrino, options = {}) => neutrino.config
-  .plugin(options.pluginId || 'start-server')
-  .use(StartServerPlugin, [{
-    name: options.name,
-    nodeArgs: neutrino.options.debug ? ['--inspect'] : []
-  }]);
+module.exports = (neutrino, { pluginId = 'start-server', ...options } = {}) => {
+  neutrino.config
+    .plugin(pluginId)
+    .use(StartServerPlugin, [{
+      name: options.name,
+      nodeArgs: neutrino.options.debug ? ['--inspect'] : []
+    }]);
+};

--- a/packages/style-minify/index.js
+++ b/packages/style-minify/index.js
@@ -1,13 +1,7 @@
 const OptimizeCssPlugin = require('optimize-css-assets-webpack-plugin');
 
-module.exports = ({ config }, opts = {}) => {
-  const options = {
-    pluginId: 'optimize-css',
-    plugin: {},
-    ...opts
-  };
-
-  config
-    .plugin(options.pluginId)
-    .use(OptimizeCssPlugin, [options.plugin]);
-}
+module.exports = (neutrino, { pluginId = 'optimize-css', plugin = {} } = {}) => {
+  neutrino.config
+    .plugin(pluginId)
+    .use(OptimizeCssPlugin, [plugin]);
+};

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -1,9 +1,8 @@
 const StylelintPlugin = require('stylelint-webpack-plugin');
 const { formatters } = require('stylelint');
 
-module.exports = (neutrino, opts = {}) => {
+module.exports = (neutrino, { pluginId = 'stylelint', ...opts } = {}) => {
   const options = {
-    pluginId: 'stylelint',
     configBasedir: neutrino.options.root,
     files: '**/*.+(css|scss|sass|less)',
     context: neutrino.options.source,
@@ -12,7 +11,7 @@ module.exports = (neutrino, opts = {}) => {
   };
 
   neutrino.config
-    .plugin(options.pluginId)
+    .plugin(pluginId)
     .use(StylelintPlugin, [options]);
 
   neutrino.register('stylelintrc', (neutrino, override) => override(


### PR DESCRIPTION
Previously the Neutrino-specific `pluginId` option was being passed along with the plugin-specific options to the plugin constructor in many of the Neutrino presets.

Fixes #929.