### PR TITLE
[v8.x] Correct the URL used for the devServer 'open' feature

### DIFF
--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -62,7 +62,7 @@ module.exports = (neutrino, opts = {}) => {
     neutrino.options.https ? { https: neutrino.options.https } : {}
   ]);
   const protocol = options.https ? 'https' : 'http';
-  const url = `${protocol}://${publicHost}:${options.port}`;
+  const url = `${protocol}://${publicHost}`;
 
   neutrino.config
     .devServer

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -16,7 +16,9 @@ const getPublic = (neutrino, options) => {
   }
 
   if (neutrino.options.host) {
-    return isLocal(neutrino.options.host) ? 'localhost' : neutrino.options.host;
+    return isLocal(neutrino.options.host)
+      ? `localhost:${port}`
+      : `${neutrino.options.host}:${port}`;
   }
 
   return !options.host || isLocal(options.host) ?


### PR DESCRIPTION
Previously the port was listed twice in the URL, eg:
`http://localhost:5000:5000`

This PR fixes the issue on `release/v8` and `master` is already fixed due to the #852 refactor.

Fixes #927.