### PR TITLE
Remove style minification from the web preset

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -210,9 +210,7 @@ module.exports = {
       minify: {
         // Javascript minification occurs only in production by default.
         // To change uglify-es options or switch to another minifier, see below.
-        source: process.env.NODE_ENV === 'production',
-        // Change options for @neutrinojs/style-minify
-        style: {}
+        source: process.env.NODE_ENV === 'production'
       },
 
       // Change options for `webpack-manifest-plugin`
@@ -429,7 +427,6 @@ _Note: Some plugins are only available in certain environments. To override them
 | `html-{MAIN_NAME}` | Automatically generates HTML files for configured entry points. `{MAIN_NAME}` corresponds to the entry point of each page. By default, there is only a single `index` main, so this would generate a plugin named `html-index`. From `@neutrinojs/html-template` | all |
 | `hot` | Enables Hot Module Replacement. From `@neutrinojs/hot`. | `start` command |
 | `clean` | Removes the `build` directory prior to building. From `@neutrinojs/clean`. | `build` command |
-| `optimize-css` | Minifies css using `OptimizeCssAssetsPlugin`. From `@neutrinojs/style-minify`. | `NODE_ENV production` |
 | `manifest` | Create a manifest file, via webpack-manifest-plugin. | `build` command |
 
 ### Override configuration

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -7,7 +7,6 @@ const env = require('@neutrinojs/env');
 const hot = require('@neutrinojs/hot');
 const htmlTemplate = require('@neutrinojs/html-template');
 const clean = require('@neutrinojs/clean');
-const styleMinify = require('@neutrinojs/style-minify');
 const loaderMerge = require('@neutrinojs/loader-merge');
 const devServer = require('@neutrinojs/dev-server');
 const { resolve } = require('url');
@@ -36,8 +35,7 @@ module.exports = (neutrino, opts = {}) => {
       paths: [neutrino.options.output]
     },
     minify: {
-      source: mode === 'production',
-      style: {}
+      source: mode === 'production'
     },
     babel: {},
     targets: {},
@@ -51,6 +49,10 @@ module.exports = (neutrino, opts = {}) => {
 
   if ('image' in options.minify) {
     throw new Error('The minify.image option has been removed. To enable image minification use the @neutrinojs/image-minify preset.');
+  }
+
+  if ('style' in options.minify) {
+    throw new Error('The minify.style option has been removed. To enable style minification use the @neutrinojs/style-minify preset.');
   }
 
   if (typeof options.devServer.proxy === 'string') {
@@ -79,9 +81,6 @@ module.exports = (neutrino, opts = {}) => {
   Object.assign(options, {
     style: options.style && merge(options.style, {
       extract: options.style.extract === true ? {} : options.style.extract
-    }),
-    minify: options.minify && merge(options.minify, {
-      style: options.minify.style === true ? {} : options.minify.style
     }),
     babel: compileLoader.merge({
       plugins: [
@@ -206,7 +205,6 @@ module.exports = (neutrino, opts = {}) => {
       });
     })
     .when(mode === 'production', (config) => {
-      config.when(options.minify.style, () => neutrino.use(styleMinify, options.minify.style));
       config.when(options.clean, () => neutrino.use(clean, options.clean));
 
       if (options.manifest) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,7 +37,6 @@
     "@neutrinojs/image-loader": "^8.2.0",
     "@neutrinojs/loader-merge": "^8.2.0",
     "@neutrinojs/style-loader": "^8.2.0",
-    "@neutrinojs/style-minify": "^8.2.0",
     "deepmerge": "^1.5.2",
     "html-webpack-include-sibling-chunks-plugin": "^0.1.4",
     "webpack-manifest-plugin": "^2.0.2",

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -77,3 +77,10 @@ test('throws when minify.image defined', async t => {
   const err = t.throws(() => api.use(require('..'), { minify: { image: true } }));
   t.true(err.message.includes('The minify.image option has been removed'));
 });
+
+test('throws when minify.style defined', async t => {
+  const api = new Neutrino();
+
+  const err = t.throws(() => api.use(require('..'), { minify: { style: false } }));
+  t.true(err.message.includes('The minify.style option has been removed'));
+});


### PR DESCRIPTION
Since:
* `optimize-css-assets-webpack-plugin` doesn't support `[contenthash]` properly, meaning that filename hashes aren't always updated even when the file content has changed.
* `optimize-css-assets-webpack-plugin` doesn't support caching or parallelisation (unlike `uglifyjs-webpack-plugin`), meaning that for large projects, style minification can double the build time.
* the file size reduction is often not significant (given that many stylesheets are already available in minified form, eg bootstrap), and so not worth the correctness/performance penalty.
* it's easy enough for people to add `@neutrinojs/style-minify` to their project if they still want minification.

webpack 5+ will likely be including CSS minification out of the box, and so in the future hopefully these issues should be resolved and so we can re-enable it by default.

Fixes #678.
Refs #713.