### PR TITLE
[v8.x] Backport stringified config improvements as --inspect-new

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -708,6 +708,11 @@ inspect(api.config.toConfig(), api)
   );
 ```
 
+### `inspectNew(webpackConfig, neutrinoApi)`
+
+The `inspectNew()` function is equivalent to `inspect()`, except the output is in the improved
+format that will be the default in Neutrino 9+.
+
 ## Helper Methods
 
 ### `regexFromExtensions`

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -94,6 +94,14 @@ index 3356802..d4d82ef 100644
    },
 ```
 
+## `--inspect-new`
+
+The `--inspect-new` flag provide the same functionality as `--inspect`, except the output
+more accurately represents the actual webpack config, and also includes inline comments
+containing the Neutrino plugin and rules names, for easier customisation.
+
+This new output format will be the default in Neutrino 9.
+
 ## --require
 
 Require one or more modules prior to invoking any Neutrino commands. These can be an npm package or a relative path to

--- a/packages/neutrino/bin/inspect.js
+++ b/packages/neutrino/bin/inspect.js
@@ -1,5 +1,5 @@
 const { defaultTo } = require('ramda');
-const { inspect } = require('../src');
+const { inspect, inspectNew } = require('../src');
 const base = require('./base');
 
 const envs = {
@@ -13,7 +13,7 @@ module.exports = (middleware, args, cli) => base({
   middleware,
   args,
   NODE_ENV: defaultTo('development', envs[args._[0]]),
-  commandHandler: inspect,
+  commandHandler: args.inspectNew ? inspectNew : inspect,
   commandName: 'inspect',
   successHandler(output) {
     if (!args.quiet && output) {

--- a/packages/neutrino/bin/neutrino.js
+++ b/packages/neutrino/bin/neutrino.js
@@ -31,6 +31,12 @@ const cli = yargs
     default: false,
     global: true
   })
+  .option('inspect-new', {
+    description: 'Output an improved string representation of the configuration used by webpack (will be the default in Neutrino 9+) and exit',
+    boolean: true,
+    default: false,
+    global: true
+  })
   .option('use', {
     description: 'A list of Neutrino middleware used to configure the build',
     array: true,
@@ -84,7 +90,7 @@ const cli = yargs
 const args = cli.argv;
 const command = args._[0];
 const rc = '.neutrinorc.js';
-const cmd = args.inspect ? 'inspect' : command;
+const cmd = args.inspect || args.inspectNew ? 'inspect' : command;
 const hasRc = exists(process.cwd(), rc);
 const middleware = [...new Set(hasRc ? [rc] : args.use)];
 

--- a/packages/neutrino/src/index.js
+++ b/packages/neutrino/src/index.js
@@ -2,7 +2,7 @@ const Neutrino = require('./api');
 const build = require('./build');
 const start = require('./start');
 const test = require('./test');
-const inspect = require('./inspect');
+const { inspect, inspectNew } = require('./inspect');
 
 module.exports = {
   Neutrino,
@@ -11,5 +11,6 @@ module.exports = {
   test,
   inspect(args) {
     return args.customInspect ? this : inspect(args);
-  }
+  },
+  inspectNew
 };

--- a/packages/neutrino/src/inspect.js
+++ b/packages/neutrino/src/inspect.js
@@ -2,8 +2,15 @@ const Future = require('fluture');
 const stringify = require('javascript-stringify');
 const sort = require('deep-sort-object');
 const { partialRight, pipe } = require('ramda');
+const { toString } = require('webpack-chain');
 
 // inspect :: Object config -> Future () String
 const inspect = pipe(sort, partialRight(stringify, [null, 2]), Future.of);
 
-module.exports = inspect;
+const configPrefix = 'neutrino.config';
+
+// Uses the new webpack-chain 4.8.0+ toString() support to generate more helpful output.
+// This output style will be the default in Neutrino 9+.
+const inspectNew = config => Future.of(toString(config, { configPrefix }));
+
+module.exports = { inspect, inspectNew };


### PR DESCRIPTION
This backports #928 to `release/v8` under a new argument name, to prevent it from being a breaking change. This will allow Neutrino 8 users to benefit from the stringifed config improvements sooner, as well as providing a way to compare v8 and v9 configurations.

I've not backported the eslint `formatter.__expression` change, since it would require a fair amount of refactoring, increasing risk for little benefit.

Fixes #328 for `release/v8`.