### PR TITLE
dev-server: Suppress unhelpful stack trace for compile failures

### DIFF
--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -42,7 +42,6 @@ module.exports = (neutrino, opts = {}) => {
         chunks: false,
         colors: true,
         errors: true,
-        errorDetails: true,
         hash: false,
         modules: false,
         publicPath: false,


### PR DESCRIPTION
This restores the webpack default of not outputting the full stack trace for compile errors, since it's typically pretty spammy and doesn't really help with understanding the error.

Fixes #875 for dev-server (#852 already fixed it for `yarn build`).

(Note we have #897 for assessing our `stats` usage in general, however this is low-hanging fruit in the meantime - plus I'll backport this PR to `release/v8`.)

Before:

```
$ webpack-dev-server --mode development
i ｢wds｣: Project is running at http://localhost:5000/
i ｢wds｣: webpack output is served from /
i ｢wds｣: Content not from webpack is served from C:\Users\Ed\src\test-master\src
i ｢wds｣: 404s will fallback to /index.html
× ｢wdm｣: Built at: 2018-06-07 11:37:00
Entrypoint index = runtime.js vendors~index.js index.js

ERROR in ./src/index.jsx
Module not found: Error: Can't resolve './zzzz' in 'C:\Users\Ed\src\test-master\src'
resolve './zzzz' in 'C:\Users\Ed\src\test-master\src'
  using description file: C:\Users\Ed\src\test-master\package.json (relative path: ./src)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: C:\Users\Ed\src\test-master\package.json (relative path: ./src/zzzz)
      no extension
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz doesn't exist
      .js
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.js doesn't exist
      .jsx
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.jsx doesn't exist
      .vue
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.vue doesn't exist
      .ts
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.ts doesn't exist
      .tsx
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.tsx doesn't exist
      .mjs
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.mjs doesn't exist
      .json
        Field 'browser' doesn't contain a valid alias configuration
        C:\Users\Ed\src\test-master\src\zzzz.json doesn't exist
      as directory
        C:\Users\Ed\src\test-master\src\zzzz doesn't exist
[C:\Users\Ed\src\test-master\src\zzzz]
[C:\Users\Ed\src\test-master\src\zzzz.js]
[C:\Users\Ed\src\test-master\src\zzzz.jsx]
[C:\Users\Ed\src\test-master\src\zzzz.vue]
[C:\Users\Ed\src\test-master\src\zzzz.ts]
[C:\Users\Ed\src\test-master\src\zzzz.tsx]
[C:\Users\Ed\src\test-master\src\zzzz.mjs]
[C:\Users\Ed\src\test-master\src\zzzz.json]
 @ ./src/index.jsx 4:0-25 5:27-30
 @ multi (webpack)-dev-server/client?http://localhost:5000 webpack/hot/dev-server ./src/index
i ｢wdm｣: Failed to compile.
```

After:

```
$ webpack-dev-server --mode development
i ｢wds｣: Project is running at http://localhost:5000/
i ｢wds｣: webpack output is served from /
i ｢wds｣: Content not from webpack is served from C:\Users\Ed\src\test-master\src
i ｢wds｣: 404s will fallback to /index.html
× ｢wdm｣: Built at: 2018-06-07 11:37:29
Entrypoint index = runtime.js vendors~index.js index.js

ERROR in ./src/index.jsx
Module not found: Error: Can't resolve './zzzz' in 'C:\Users\Ed\src\test-master\src'
 @ ./src/index.jsx 4:0-25 5:27-30
 @ multi (webpack)-dev-server/client?http://localhost:5000 webpack/hot/dev-server ./src/index
i ｢wdm｣: Failed to compile.
```