### PR TITLE
karma: Correctly suppress webpack compile information

### DIFF
--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -51,7 +51,9 @@ module.exports = neutrino => {
         [tests]: ['webpack'],
         [sources]: ['webpack']
       },
-      webpackMiddleware: { noInfo: true },
+      webpackMiddleware: {
+        stats: 'errors-only'
+      },
       webpack: merge(
         omit(neutrino.config.toConfig(), ['plugins', 'entry']),
         // Work around `yarn test` hanging under webpack 4:


### PR DESCRIPTION
The `noInfo` option does not do anything, and presumably came from the karma-webpack README, which was incorrect prior to:
webpack-contrib/karma-webpack#105

The stats are now adjusted using the updated approach from here:
https://github.com/webpack-contrib/karma-webpack/blob/master/README.md#usage

Fixes #925.

Before:

```
$ karma start --single-run

START:
(node:8732) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
i ｢wdm｣: Hash: aada469d61c2655800ac
Version: webpack 4.10.2
Time: 11074ms
Built at: 2018-06-07 12:25:45
i ｢wdm｣: Compiled successfully.
i ｢wdm｣: Compiling...
i ｢wdm｣: Hash: be340ae1ed5606c7e87c
Version: webpack 4.10.2
Time: 12919ms
Built at: 2018-06-07 12:25:47
              Asset      Size  Chunks             Chunk Names
test/simple_test.js  13.6 KiB       0  [emitted]  test/simple_test.js
Entrypoint test/simple_test.js = test/simple_test.js
[0] ../neutrino-dev/node_modules/webpack/buildin/global.js 489 bytes {0} [built]
[1] ../neutrino-dev/node_modules/assert/assert.js 15.1 KiB {0} [built]
[2] ../neutrino-dev/node_modules/util/node_modules/inherits/inherits_browser.js 672 bytes {0} [built]
[3] ../neutrino-dev/node_modules/util/support/isBufferBrowser.js 203 bytes {0} [built]
[4] ../neutrino-dev/node_modules/process/browser.js 5.29 KiB {0} [built]
[5] ../neutrino-dev/node_modules/util/util.js 15.2 KiB {0} [built]
[6] ./test/simple_test.js 128 bytes {0} [built]
i ｢wdm｣: Compiled successfully.
07 06 2018 12:25:47.686:INFO [karma]: Karma v2.0.2 server started at http://0.0.0.0:9876/
07 06 2018 12:25:47.688:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
07 06 2018 12:25:47.695:INFO [launcher]: Starting browser ChromeHeadless
07 06 2018 12:25:48.290:INFO [HeadlessChrome 0.0.0 (Windows 10 0.0.0)]: Connected on socket Ij39Hqs3dV4iGUI5AAAA with id 66228515
  simple
    √ should be sane

Finished in 0.009 secs / 0 secs @ 12:25:48 GMT+0100 (GMT Summer Time)

SUMMARY:
√ 1 test completed
Done in 5.97s.
```

After:

```
$ karma start --single-run

START:
(node:5088) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
i ｢wdm｣:
i ｢wdm｣: Compiled successfully.
i ｢wdm｣: Compiling...
i ｢wdm｣:
i ｢wdm｣: Compiled successfully.
07 06 2018 12:27:13.665:INFO [karma]: Karma v2.0.2 server started at http://0.0.0.0:9876/
07 06 2018 12:27:13.668:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
07 06 2018 12:27:13.687:INFO [launcher]: Starting browser ChromeHeadless
07 06 2018 12:27:14.289:INFO [HeadlessChrome 0.0.0 (Windows 10 0.0.0)]: Connected on socket 12A6TwBZ34jEc5mkAAAA with id 37590533
  simple
    √ should be sane

Finished in 0.008 secs / 0 secs @ 12:27:14 GMT+0100 (GMT Summer Time)

SUMMARY:
√ 1 test completed
Done in 5.58s.
```