### PR TITLE
eslint: Throw if preset used after compile rule already defined

### DIFF
--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -80,6 +80,10 @@ const eslintrc = (neutrino, override) => {
 };
 
 module.exports = (neutrino, opts = {}) => {
+  if (neutrino.config.module.rules.has('compile')) {
+    throw new Error('Lint presets must be defined prior to any other presets in .neutrinorc.js.');
+  }
+
   const defaults = {
     include: !opts.include ? [neutrino.options.source] : undefined,
     eslint: {

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -56,3 +56,10 @@ test('exposes eslintrc method', t => {
 test('exposes eslintrc config from method', t => {
   t.is(typeof neutrino(mw()).eslintrc(), 'object');
 });
+
+test('throws when used after a compile preset', async t => {
+  const api = new Neutrino();
+  api.use(require('../../web'))
+
+  t.throws(() => api.use(mw()), /Lint presets must be defined prior/);
+});


### PR DESCRIPTION
Presets such as `@neutrinojs/web` and `@neutrinojs/react` check to see if a `lint` rule is defined, and if so, adapt its settings to suit the particular environment/framework. This means that the lint presets must be defined prior to the compile presets or the final eslint configuration will not be correct.

Previously if the ordering was incorrect there would be no error message, causing confusion when eslint wasn't behaving as expected.

Fixes #800.
Refs #763.