### PR TITLE
[v8.x] Add object rest spread support to web & library presets

### DIFF
--- a/docs/packages/library/README.md
+++ b/docs/packages/library/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a JavaScript library
-- Modern Babel compilation supporting ES modules, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, async functions, object rest spread syntax, and dynamic imports
 - Defaults to UMD-based output for consumption in a variety of environments
 - Supports automatically-wired sourcemaps
 - Tree-shaking to create smaller bundles

--- a/docs/packages/preact/README.md
+++ b/docs/packages/preact/README.md
@@ -9,12 +9,12 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a Preact web app
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](../web/README.md).
 - Write JSX in .js or .jsx files
 - Automatic import of `Preact.h`, no need to import `h` or `createElement` yourself
 - Compatibility and pre-configured aliasing for React-based modules and packages
 - Extends from [@neutrinojs/web](../web/README.md)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/docs/packages/react-components/README.md
+++ b/docs/packages/react-components/README.md
@@ -11,12 +11,12 @@ other Neutrino middleware, so you can build, test, and publish multiple React co
 
 - Extends partially from [@neutrinojs/react](../react/README.md)
 - Zero upfront configuration necessary to start developing and building React components.
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](../web/README.md).
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Support for importing web workers with `.worker.*` file extensions
-- Extends partially from [@neutrinojs/web](../web)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+- Extends partially from [@neutrinojs/web](../web/README.md)
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets

--- a/docs/packages/react/README.md
+++ b/docs/packages/react/README.md
@@ -9,12 +9,12 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a React web app
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](../web/README.md).
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Automatic import of `React.createElement`, no need to import `react` or `React.createElement` yourself
 - Extends from [@neutrinojs/web](../web/README.md)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/docs/packages/vue/README.md
+++ b/docs/packages/vue/README.md
@@ -9,7 +9,7 @@
 - Zero upfront configuration necessary to start developing and building a Vue web app
 - Modern Babel compilation.
 - Extends from [@neutrinojs/web](../web/README.md)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a web app
-- Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
 - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
 - webpack Dev Server during development
 - Automatic creation of HTML pages, no templating necessary

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a JavaScript library
-- Modern Babel compilation supporting ES modules, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, async functions, object rest spread syntax, and dynamic imports
 - Defaults to UMD-based output for consumption in a variety of environments
 - Supports automatically-wired sourcemaps
 - Tree-shaking to create smaller bundles

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -33,7 +33,8 @@ module.exports = (neutrino, opts = {}) => {
         ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
         options.target === 'node' ?
           require.resolve('babel-plugin-dynamic-import-node') :
-          require.resolve('babel-plugin-syntax-dynamic-import')
+          require.resolve('babel-plugin-syntax-dynamic-import'),
+        require.resolve('babel-plugin-transform-object-rest-spread')
       ],
       presets: [
         [require.resolve('babel-preset-env'), {

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -39,6 +39,7 @@
     "@neutrinojs/loader-merge": "^8.2.3",
     "@neutrinojs/minify": "^8.2.3",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "deepmerge": "^1.5.2",
     "fast-async": "^6.3.7",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -9,12 +9,12 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a Preact web app
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](https://neutrinojs.org/packages/web/).
 - Write JSX in .js or .jsx files
 - Automatic import of `Preact.h`, no need to import `h` or `createElement` yourself
 - Compatibility and pre-configured aliasing for React-based modules and packages
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -21,7 +21,6 @@ module.exports = (neutrino, opts = {}) => {
           export: 'h',
           import: 'h'
         }],
-        require.resolve('babel-plugin-transform-object-rest-spread'),
         [require.resolve('babel-plugin-transform-class-properties'), { spec: true }],
         process.env.NODE_ENV === 'development'
           ? require.resolve('babel-plugin-transform-es2015-classes')

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -30,7 +30,6 @@
     "babel-plugin-jsx-pragmatic": "^1.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "deepmerge": "^1.5.2",
     "eslint": "^4.19.1",

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -11,12 +11,12 @@ other Neutrino middleware, so you can build, test, and publish multiple React co
 
 - Extends partially from [@neutrinojs/react](https://neutrinojs.org/packages/@neutrinojs/react)
 - Zero upfront configuration necessary to start developing and building React components.
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](https://neutrinojs.org/packages/@neutrinojs/web).
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Support for importing web workers with `.worker.*` file extensions
 - Extends partially from [@neutrinojs/web](https://neutrinojs.org/packages/@neutrinojs/web)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,12 +9,12 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a React web app
-- Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
+- Modern Babel compilation adding JSX and class properties support to the features provided by [@neutrinojs/web](https://neutrinojs.org/packages/web/).
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
 - Automatic import of `React.createElement`, no need to import `react` or `React.createElement` yourself
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -28,7 +28,6 @@ module.exports = (neutrino, opts = {}) => {
             import: 'createElement'
           }
         ],
-        require.resolve('babel-plugin-transform-object-rest-spread'),
         ...(
           process.env.NODE_ENV === 'development'
             ? [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,6 @@
     "babel-plugin-jsx-pragmatic": "^1.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "deepmerge": "^1.5.2",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -9,7 +9,7 @@
 - Zero upfront configuration necessary to start developing and building a Vue web app
 - Modern Babel compilation.
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
-  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+  - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
   - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a web app
-- Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, object rest spread syntax, and dynamic imports
 - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
 - webpack Dev Server during development
 - Automatic creation of HTML pages, no templating necessary

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -89,7 +89,8 @@ module.exports = (neutrino, opts = {}) => {
     babel: compileLoader.merge({
       plugins: [
         ...(options.polyfills.async ? [[require.resolve('fast-async'), { spec: true }]] : []),
-        require.resolve('babel-plugin-syntax-dynamic-import')
+        require.resolve('babel-plugin-syntax-dynamic-import'),
+        require.resolve('babel-plugin-transform-object-rest-spread')
       ],
       presets: [
         [require.resolve('babel-preset-env'), {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,6 +41,7 @@
     "@neutrinojs/minify": "^8.2.3",
     "@neutrinojs/style-loader": "^8.2.3",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "deepmerge": "^1.5.2",
     "fast-async": "^6.3.7",


### PR DESCRIPTION
Previously for `release/v8`, the `babel-plugin-transform-object-rest-spread` plugin was only enabled for `@neutrinojs/react` and `@neutrinojs/preact`, and not `@neutrinojs/web` or any of the other presets that inherit from it.

This inconsistency is both confusing for users, and means having to manually add the plugin when ideally support for object rest spread syntax would be enabled out of the box now that it's stage 4 (when Neutrino 8 was released, it was stage 3):
https://github.com/tc39/proposal-object-rest-spread#status-of-this-proposal

Duplicate plugin instances didn't cause errors when I tested locally, so this should be backwards compatible for users/presets that already manually add the plugin.

This change isn't needed on `master`, since Babel 7's `preset-env` ships with `proposal-object-rest-spread` built in.

Refs #883.