### PR TITLE
[v8.x] loader-merge: Replace `object-rest-spread` example

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -350,7 +350,7 @@ neutrino.config.module
   .rule('compile')
   .loader('babel', 'babel-loader', {
     options: {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }
   });
 
@@ -359,7 +359,7 @@ neutrino.config.module
   .rule('compile')
   .use('babel')
     .loader('babel-loader')
-    .options({ plugins: ['object-rest-spread'] });
+    .options({ plugins: ['your-babel-plugin'] });
 ```
 
 - Updates to config for modifying loaders (from webpack-chain v3 upgrade). The function now gets its options directly
@@ -371,7 +371,7 @@ neutrino.config.module
   .rule('compile')
   .loader('babel', props => merge(props, {
     options: {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }
   }));
 
@@ -379,7 +379,7 @@ neutrino.config.module
 neutrino.config.module
   .rule('compile')
     .use('babel')
-      .tap(options => merge(options, { plugins: ['object-rest-spread'] }));
+      .tap(options => merge(options, { plugins: ['your-babel-plugin'] }));
 ```
 
 - Updates to `include` and `exclude` for rules (from webpack-chain v3). In the previous webpack-chain

--- a/docs/packages/loader-merge/README.md
+++ b/docs/packages/loader-merge/README.md
@@ -39,7 +39,7 @@ and plug it into Neutrino:
 const loaderMerge = require('@neutrinojs/loader-merge');
 
 neutrino.use(loaderMerge('compile', 'babel'), {
-  plugins: ['object-rest-spread']
+  plugins: ['your-babel-plugin']
 });
 
 // Equivalent to:
@@ -47,7 +47,7 @@ neutrino.config.module
   .rule('compile')
   .use('babel')
     .tap(options => require('deepmerge')(options, {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }));
 ```
 

--- a/packages/loader-merge/README.md
+++ b/packages/loader-merge/README.md
@@ -39,7 +39,7 @@ and plug it into Neutrino:
 const loaderMerge = require('@neutrinojs/loader-merge');
 
 neutrino.use(loaderMerge('compile', 'babel'), {
-  plugins: ['object-rest-spread']
+  plugins: ['your-babel-plugin']
 });
 
 // Equivalent to:
@@ -47,7 +47,7 @@ neutrino.config.module
   .rule('compile')
   .use('babel')
     .tap(options => require('deepmerge')(options, {
-      plugins: ['object-rest-spread']
+      plugins: ['your-babel-plugin']
     }));
 ```
 


### PR DESCRIPTION
Backport of 991590461b9b81f1d95f137e18ef416dc0194702 (#890).