### PR TITLE
[v8.x] dev-server: Suppress unhelpful stack trace for compile failures

### DIFF
--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -49,7 +49,6 @@ module.exports = (neutrino, opts = {}) => {
         chunks: false,
         colors: true,
         errors: true,
-        errorDetails: true,
         hash: false,
         modules: false,
         publicPath: false,


### PR DESCRIPTION
Backport of 878ac0dc4a84480c9bb0d7db65d6301a8f791d4c (#936).