### PR TITLE
html-loader: Add 'link:href' to attrs so favicons are parsed

### DIFF
--- a/packages/html-loader/index.js
+++ b/packages/html-loader/index.js
@@ -3,4 +3,11 @@ module.exports = (neutrino, options = {}) => neutrino.config.module
   .test(neutrino.regexFromExtensions(['html']))
   .use('html')
     .loader(require.resolve('html-loader'))
-    .options(options);
+    .options({
+      // Override html-loader's default attrs of `['img:src']`
+      // so it also parses favicon images (`<link href="...">`).
+      // TODO: Remove once html-loader 1.0.0 is released:
+      // https://github.com/webpack-contrib/html-loader/issues/17
+      attrs: ['img:src', 'link:href'],
+      ...options
+    });


### PR DESCRIPTION
By default `html-loader@0.x` has a default `attrs` of `['img:src']`, which means only `<img src="...">` tags are followed when parsing the HTML:
https://github.com/webpack-contrib/html-loader/blob/v0.5.5/README.md#usage
https://github.com/webpack-contrib/html-loader/blob/v0.5.5/index.js#L29

With this change, favicons are included too, and have all the benefits of being included in the webpack build - such as being being inlined by url-loader (if small enough), or else being copied to the output directory automatically and given hashed filenames.

This matches the default that will be used in `html-loader` v1.0.0:
webpack-contrib/html-loader#17

...and saves projects from having to resort to the manual Neutrino API to adjust the options used by `html-loader` (see #865).