### PR TITLE
Correctly configure the eslint-plugin-babel replacement rules

### DIFF
--- a/packages/airbnb-base/index.js
+++ b/packages/airbnb-base/index.js
@@ -1,4 +1,6 @@
 const lint = require('@neutrinojs/eslint');
+const { rules: airbnbBaseStyle } = require('eslint-config-airbnb-base/rules/style');
+const { rules: airbnbBaseBestPractices } = require('eslint-config-airbnb-base/rules/best-practices');
 
 module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
@@ -7,18 +9,21 @@ module.exports = (neutrino, opts = {}) => {
         extends: ['airbnb-base']
       },
       rules: {
-        // handled by babel rules
+        // Disable rules for which there are eslint-plugin-babel replacements:
+        // https://github.com/babel/eslint-plugin-babel#rules
         'new-cap': 'off',
-        // handled by babel rules
-        'quotes': 'off',
-        // handled by babel rules
+        'no-invalid-this': 'off',
         'object-curly-spacing': 'off',
-        // require a capital letter for constructors
-        'babel/new-cap': ['error', { newIsCap: true }],
-        // require padding inside curly braces
-        'babel/object-curly-spacing': ['error', 'always'],
-        // require single quotes for strings (with support for JSX Fragment syntax)
-        'babel/quotes': ['error', 'single', { avoidEscape: true }]
+        'quotes': 'off',
+        'semi': 'off',
+        'no-unused-expressions': 'off',
+        // Ensure the replacement rules use the options set by airbnb-base rather than ESLint defaults.
+        'babel/new-cap': airbnbBaseStyle['new-cap'],
+        'babel/no-invalid-this': airbnbBaseBestPractices['no-invalid-this'],
+        'babel/object-curly-spacing': airbnbBaseStyle['object-curly-spacing'],
+        'babel/quotes': airbnbBaseStyle.quotes,
+        'babel/semi': airbnbBaseStyle.semi,
+        'babel/no-unused-expressions': airbnbBaseBestPractices['no-unused-expressions']
       }
     }
   },

--- a/packages/airbnb/index.js
+++ b/packages/airbnb/index.js
@@ -1,4 +1,6 @@
 const lint = require('@neutrinojs/eslint');
+const { rules: airbnbBaseStyle } = require('eslint-config-airbnb-base/rules/style');
+const { rules: airbnbBaseBestPractices } = require('eslint-config-airbnb-base/rules/best-practices');
 
 module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
@@ -7,18 +9,21 @@ module.exports = (neutrino, opts = {}) => {
         extends: ['airbnb']
       },
       rules: {
-        // handled by babel rules
+        // Disable rules for which there are eslint-plugin-babel replacements:
+        // https://github.com/babel/eslint-plugin-babel#rules
         'new-cap': 'off',
-        // handled by babel rules
-        'quotes': 'off',
-        // handled by babel rules
+        'no-invalid-this': 'off',
         'object-curly-spacing': 'off',
-        // require a capital letter for constructors
-        'babel/new-cap': ['error', { newIsCap: true }],
-        // require padding inside curly braces
-        'babel/object-curly-spacing': ['error', 'always'],
-        // require single quotes for strings (with support for JSX Fragment syntax)
-        'babel/quotes': ['error', 'single', { avoidEscape: true }]
+        'quotes': 'off',
+        'semi': 'off',
+        'no-unused-expressions': 'off',
+        // Ensure the replacement rules use the options set by airbnb rather than ESLint defaults.
+        'babel/new-cap': airbnbBaseStyle['new-cap'],
+        'babel/no-invalid-this': airbnbBaseBestPractices['no-invalid-this'],
+        'babel/object-curly-spacing': airbnbBaseStyle['object-curly-spacing'],
+        'babel/quotes': airbnbBaseStyle.quotes,
+        'babel/semi': airbnbBaseStyle.semi,
+        'babel/no-unused-expressions': airbnbBaseBestPractices['no-unused-expressions']
       }
     }
   },

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@neutrinojs/eslint": "^8.2.0",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0"

--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -1,4 +1,5 @@
 const lint = require('@neutrinojs/eslint');
+const { rules: standardRules } = require('eslint-config-standard');
 
 module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
@@ -8,14 +9,24 @@ module.exports = (neutrino, opts = {}) => {
       },
       plugins: ['standard'],
       rules: {
-        // handled by babel rules
+        // Disable rules for which there are eslint-plugin-babel replacements:
+        // https://github.com/babel/eslint-plugin-babel#rules
         'new-cap': 'off',
-        // handled by babel rules
+        'no-invalid-this': 'off',
         'object-curly-spacing': 'off',
-        // require a capital letter for constructors
-        'babel/new-cap': ['error', { newIsCap: true }],
-        // require padding inside curly braces
-        'babel/object-curly-spacing': ['error', 'always']
+        'quotes': 'off',
+        'semi': 'off',
+        'no-unused-expressions': 'off',
+        // Ensure the replacement rules use the options set by airbnb rather than ESLint defaults.
+        'babel/new-cap': standardRules['new-cap'],
+        // eslint-config-standard doesn't currently have an explicit value for these two rules, so
+        // they default to off. The fallbacks are not added to the other rules, so changes in the
+        // preset configuration layout doesn't silently cause rules to be disabled.
+        'babel/no-invalid-this': standardRules['no-invalid-this'] || 'off',
+        'babel/object-curly-spacing': standardRules['object-curly-spacing'] || 'off',
+        'babel/quotes': standardRules.quotes,
+        'babel/semi': standardRules.semi,
+        'babel/no-unused-expressions': standardRules['no-unused-expressions']
       }
     }
   },


### PR DESCRIPTION
Previously the `babel/*` rules provided by `eslint-plugin-babel` were being set to ESLint defaults, rather than inheriting what the `airbnb`, `airbnb-base` or `standardjs` presets had set for the original rule that they were replacing.

In addition, all missing `eslint-plugin-babel` rules have been added:
https://github.com/babel/eslint-plugin-babel#rules

The style preset rule definitions can be found here:
https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v16.1.0/packages/eslint-config-airbnb-base/rules/style.js
https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v16.1.0/packages/eslint-config-airbnb-base/rules/best-practices.js
https://github.com/standard/eslint-config-standard/blob/v11.0.0/eslintrc.json

Fixes #881.

Diff of `eslint --print-config .eslintrc.js` for `@neutrinojs/airbnb`:

<details>
<summary>Click to expand...</summary>

```diff
--- before.js
+++ after.js
@@ -1113,7 +1113,7 @@
     "no-throw-literal": "error",
     "no-unmodified-loop-condition": "off",
     "no-unused-expressions": [
-      "error",
+      "off",
       {
         "allowShortCircuit": false,
         "allowTernary": false,
@@ -1655,7 +1655,7 @@
     ],
     "require-jsdoc": "off",
     "semi": [
-      "error",
+      "off",
       "always"
     ],
     "semi-spacing": [
@@ -2506,9 +2506,17 @@
     "babel/new-cap": [
       "error",
       {
-        "newIsCap": true
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "capIsNew": false,
+        "capIsNewExceptions": [
+          "Immutable.Map",
+          "Immutable.Set",
+          "Immutable.List"
+        ]
       }
     ],
+    "babel/no-invalid-this": "off",
     "babel/object-curly-spacing": [
       "error",
       "always"
@@ -2519,6 +2527,18 @@
       {
         "avoidEscape": true
       }
+    ],
+    "babel/semi": [
+      "error",
+      "always"
+    ],
+    "babel/no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": false,
+        "allowTernary": false,
+        "allowTaggedTemplates": false
+      }
     ]
   },
   "parserOptions": {
```

</details>
<br/>

And the same but for `@neutrinojs/standard`:

<details>
<summary>Click to expand...</summary>

```diff
--- before.js
+++ after.js
@@ -1156,7 +1156,7 @@
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",
     "no-unused-expressions": [
-      "error",
+      "off",
       {
         "allowShortCircuit": true,
         "allowTernary": true,
@@ -1219,7 +1219,7 @@
     ],
     "prefer-promise-reject-errors": "error",
     "quotes": [
-      "error",
+      "off",
       "single",
       {
         "avoidEscape": true,
@@ -1231,7 +1231,7 @@
       "never"
     ],
     "semi": [
-      "error",
+      "off",
       "never"
     ],
     "semi-spacing": [
@@ -1377,16 +1377,36 @@
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/self-closing-comp": "error",
+    "no-invalid-this": "off",
     "object-curly-spacing": "off",
     "babel/new-cap": [
       "error",
       {
-        "newIsCap": true
+        "newIsCap": true,
+        "capIsNew": false
       }
     ],
-    "babel/object-curly-spacing": [
+    "babel/no-invalid-this": "off",
+    "babel/object-curly-spacing": "off",
+    "babel/quotes": [
       "error",
-      "always"
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
+    "babel/semi": [
+      "error",
+      "never"
+    ],
+    "babel/no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": true
+      }
     ]
   },
   "parserOptions": {
```

</details>