### PR TITLE
eslint: Use require.resolve() for parser and presets

### DIFF
--- a/packages/airbnb-base/index.js
+++ b/packages/airbnb-base/index.js
@@ -6,7 +6,7 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
     eslint: {
       baseConfig: {
-        extends: ['airbnb-base']
+        extends: [require.resolve('eslint-config-airbnb-base')]
       },
       rules: {
         // Disable rules for which there are eslint-plugin-babel replacements:

--- a/packages/airbnb/index.js
+++ b/packages/airbnb/index.js
@@ -6,7 +6,7 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
     eslint: {
       baseConfig: {
-        extends: ['airbnb']
+        extends: [require.resolve('eslint-config-airbnb')]
       },
       rules: {
         // Disable rules for which there are eslint-plugin-babel replacements:

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -95,10 +95,13 @@ module.exports = (neutrino, opts = {}) => {
       // eslint-loader uses executeOnText(), which ignores the `extensions` setting.
       // However it's still needed for the lint command, as it uses executeOnFiles().
       extensions: neutrino.options.extensions,
+      // Unfortunately we can't `require.resolve('eslint-plugin-babel')` due to:
+      // https://github.com/eslint/eslint/issues/6237
+      // ...so we have no choice but to rely on it being hoisted.
       plugins: ['babel'],
       baseConfig: {},
       envs: ['es6'],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2017,
         sourceType: 'module',

--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -5,8 +5,14 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.use(lint, lint.merge({
     eslint: {
       baseConfig: {
-        extends: ['standard', 'standard-jsx']
+        extends: [
+          require.resolve('eslint-config-standard'),
+          require.resolve('eslint-config-standard-jsx')
+        ]
       },
+      // Unfortunately we can't `require.resolve('eslint-plugin-standard')` due to:
+      // https://github.com/eslint/eslint/issues/6237
+      // ...so we have no choice but to rely on it being hoisted.
       plugins: ['standard'],
       rules: {
         // Disable rules for which there are eslint-plugin-babel replacements:


### PR DESCRIPTION
This ensures that they can be found (and the expected version used), even when using `yarn link`.

Unfortunately the `plugins` option does not support filepaths, so it's still necessary to install/link the plugin packages when running ESLint in a project that uses linked Neutrino monorepo packages:
https://github.com/eslint/eslint/issues/6237

...however this at least reduces the number that need to be installed.