### PR TITLE
Library package compiles down to ES5

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -31,7 +31,7 @@ module.exports = (neutrino, opts = {}) => {
           useBuiltIns: 'entry',
           targets: options.target === 'node' ?
             { node: '8.3' } :
-            { browsers: [] }
+            { uglify: true, browsers: [] }
         }]
       ]
     }, options.babel)


### PR DESCRIPTION
This solves #781 by using [`babel-preset-env#uglify`](https://babeljs.io/docs/plugins/preset-env#targetsuglify) to compile the library package down to ES5