### PR TITLE
Monorepo linting improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,3 @@ packages/**/node_modules/
 
 # This file intentionally contains invalid syntax so results in a parse error.
 packages/neutrino/test/fixtures/test-module/errorMiddleware.js
-
-# The templates have any lint errors fixed during project creation,
-# since we don't know which ESLint preset the user will choose.
-packages/create-project/commands/init/templates/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,9 @@
 # ESLint only ignores the repo root node_modules by default.
 packages/**/node_modules/
-# TODO: Fix lint errors in our tests and remove this line
-packages/**/test/
+
+# This file intentionally contains invalid syntax so results in a parse error.
+packages/neutrino/test/fixtures/test-module/errorMiddleware.js
+
 # The templates have any lint errors fixed during project creation,
 # since we don't know which ESLint preset the user will choose.
 packages/create-project/commands/init/templates/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
+# ESLint only ignores the repo root node_modules by default.
 packages/**/node_modules/
-# Remove ignore of neutrinorc since ESLint ignores dotfiles by default
-!.neutrinorc.js
 # TODO: Fix lint errors in our tests and remove this line
 packages/**/test/
 # The templates have any lint errors fixed during project creation,

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,11 +1,8 @@
 module.exports = {
   use: [
     ['./packages/airbnb-base', {
-      // Excludes are managed via `.eslintignore` since `exclude` doesn't support globs.
-      include: [
-        '.*.js',
-        'packages/'
-      ],
+      // See the package.json `lint` script for which files are linted.
+      // Excludes are managed via `.eslintignore`.
       eslint: {
         baseConfig: {
           extends: [

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -17,20 +17,12 @@ module.exports = {
           'prettier'
         ],
         rules: {
-          // Algebraic and functional types should allow capital constructors without new
-          'babel/new-cap': 'off',
           // Disallow trailing commas on arrays, objects, functions, et al
           'comma-dangle': ['error', 'never'],
-          // Allow dynamic requires
-          'import/no-dynamic-require': 'off',
-          // Allow console during development, otherwise throw an error
+          // Allow using console since most of the code in this repo isn't run in a browser.
           'no-console': 'off',
-          // Allow return assign
-          'no-return-assign': 'off',
           // Allowing shadowing variable that share the same context as the outer scope
-          'no-shadow': 'off',
-          // It makes sense to have unused expressions to avoid imperative conditionals
-          'no-unused-expressions': 'off'
+          'no-shadow': 'off'
         }
       }
     }]

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -9,7 +9,12 @@ module.exports = {
             'prettier'
           ]
         },
-        envs: ['browser', 'commonjs', 'node'],
+        envs: [
+          'browser',
+          'jest',
+          'mocha',
+          'node'
+        ],
         plugins: [
           'prettier'
         ],
@@ -22,6 +27,14 @@ module.exports = {
           'no-shadow': 'off'
         },
         overrides: [
+          {
+            files: ['packages/create-project/commands/init/templates/**'],
+            rules: {
+              // The dependencies in create-project's templates are installed by
+              // by create-project and so are expected to be missing from package.json.
+              'import/no-extraneous-dependencies': 'off'
+            }
+          },
           {
             files: ['packages/*/test/*'],
             rules: {

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,6 +1,6 @@
 module.exports = {
   use: [
-    ['./packages/airbnb-base', {
+    ['./packages/airbnb', {
       // See the package.json `lint` script for which files are linted.
       // Excludes are managed via `.eslintignore`.
       eslint: {
@@ -33,6 +33,20 @@ module.exports = {
               // The dependencies in create-project's templates are installed by
               // by create-project and so are expected to be missing from package.json.
               'import/no-extraneous-dependencies': 'off'
+            }
+          },
+          {
+            files: ['packages/create-project/commands/init/templates/preact/**'],
+            settings: {
+              react: {
+                pragma: 'h'
+              }
+            },
+            rules: {
+              // With Preact the use of `class` is recommended over `className`,
+              // so we have to add `class` to the ignore list, to prevent:
+              // `Unknown property 'class' found, use 'className' instead`
+              'react/no-unknown-property': ['error', { ignore: ['class'] }]
             }
           },
           {

--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -20,7 +20,19 @@ module.exports = {
           'no-console': 'off',
           // Allowing shadowing variable that share the same context as the outer scope
           'no-shadow': 'off'
-        }
+        },
+        overrides: [
+          {
+            files: ['packages/*/test/*'],
+            rules: {
+              // The tests need to do non-global require() to test the presets.
+              'global-require': 'off',
+              // This rule doesn't handle devDependencies being defined
+              // in the monorepo root package.json.
+              'import/no-extraneous-dependencies': 'off'
+            }
+          }
+        ]
       }
     }]
   ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
-    "lint": "eslint --ext js,jsx \".*.js\" packages",
+    "lint": "eslint --ext js,jsx --report-unused-disable-directives \".*.js\" packages",
     "precommit": "lint-staged",
     "release": "lerna publish --force-publish=*",
     "release:preview": "lerna publish --force-publish=* --skip-git --skip-npm",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
-    "lint": "eslint \".*.js\" packages",
+    "lint": "eslint --ext js,jsx \".*.js\" packages",
     "precommit": "lint-staged",
     "release": "lerna publish --force-publish=*",
     "release:preview": "lerna publish --force-publish=* --skip-git --skip-npm",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
-    "lint": "eslint packages .neutrinorc.js",
+    "lint": "eslint \".*.js\" packages",
     "precommit": "lint-staged",
     "release": "lerna publish --force-publish=*",
     "release:preview": "lerna publish --force-publish=* --skip-git --skip-npm",

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -124,7 +124,7 @@ module.exports = class Project extends Generator {
 
     this
       .prompt(questions())
-      .then(answers => this.data = answers)
+      .then(answers => { this.data = answers; })
       .then(() => {
         this.log(`\n👌  ${chalk.white.bold('Looks like I have all the info I need. Give me a moment while I create your project!')}\n`);
         done();

--- a/packages/create-project/commands/init/templates/react-components/src/components/HelloWorld/index.jsx
+++ b/packages/create-project/commands/init/templates/react-components/src/components/HelloWorld/index.jsx
@@ -1,5 +1,5 @@
-import React, { PureComponent } from 'react'; // eslint-disable-line import/no-extraneous-dependencies
-import { string } from 'prop-types'; // eslint-disable-line import/no-extraneous-dependencies
+import React, { PureComponent } from 'react';
+import { string } from 'prop-types';
 
 const generateColor = () => `#${
   (0x1000000 + ((Math.random()) * 0xffffff))

--- a/packages/create-project/commands/init/templates/react-components/src/index.jsx
+++ b/packages/create-project/commands/init/templates/react-components/src/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { render } from 'react-dom';
 import HelloWorld from './components/HelloWorld';

--- a/packages/create-project/commands/init/templates/vue/src/index.js
+++ b/packages/create-project/commands/init/templates/vue/src/index.js
@@ -3,5 +3,5 @@ import App from './App.vue';
 
 export default new Vue({
   el: '#root',
-  render: (h) => h(App),
+  render: (h) => h(App)
 });

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -34,7 +34,7 @@ const tests = {
 };
 const project = (prompts) => helpers
   .run(require.resolve(join(__dirname, '../commands/init')))
-  .inTmpDir(function(dir) {
+  .inTmpDir(function setOptions(dir) {
     this.withOptions({
       directory: dir,
       name: 'testable',
@@ -47,11 +47,9 @@ const spawnP = (cmd, args, options) => new Promise((resolve, reject) => {
   const child = spawn(cmd, args, options);
   let output = '';
 
-  child.stdout.on('data', data => output += data.toString());
-  child.stderr.on('data', data => output += data.toString());
-  child.on('close', (code) => {
-    code === 0 ? resolve(code) : reject(output);
-  });
+  child.stdout.on('data', data => { output += data.toString(); });
+  child.stderr.on('data', data => { output += data.toString(); });
+  child.on('close', code => (code === 0 ? resolve(code) : reject(output)));
 });
 const buildable = async (t, dir) => {
   try {
@@ -80,11 +78,14 @@ const lintable = async (t, dir) => {
 
 Object.keys(tests).forEach(projectName => {
   const { linter, tester } = tests[projectName];
-  const projectType = projectName.includes('library')
-    ? 'library'
-    : projectName.includes('components')
-      ? 'components'
-      : 'application';
+  let projectType;
+  if (projectName.includes('library')) {
+    projectType = 'library';
+  } else if (projectName.includes('components')) {
+    projectType = 'components';
+  } else {
+    projectType = 'application';
+  }
   const testName = tester
     ? `${projectName} + ${linter} + ${tester}`
     : `${projectName} + ${linter}`;

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -121,7 +121,7 @@ module.exports = (neutrino, opts = {}) => {
 
   if (typeof loaderOptions.formatter === 'string') {
     const formatterPath = `eslint/lib/formatters/${loaderOptions.formatter}`;
-    // eslint-disable-next-line global-require
+    // eslint-disable-next-line global-require, import/no-dynamic-require
     loaderOptions.formatter = require(formatterPath);
     // Improve the stringified output when using --inspect.
     // eslint-disable-next-line no-underscore-dangle

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -59,7 +59,7 @@ test('exposes eslintrc config from method', t => {
 
 test('throws when used after a compile preset', async t => {
   const api = new Neutrino();
-  api.use(require('../../web'))
+  api.use(require('../../web'));
 
   t.throws(() => api.use(mw()), /Lint presets must be defined prior/);
 });

--- a/packages/image-minify/test/middleware_test.js
+++ b/packages/image-minify/test/middleware_test.js
@@ -22,7 +22,7 @@ test('uses with options', t => {
     const api = new Neutrino();
 
     api.config.mode('production');
-    api.use(mw(), options)
+    api.use(mw(), options);
   });
 });
 

--- a/packages/neutrino/Neutrino.js
+++ b/packages/neutrino/Neutrino.js
@@ -29,7 +29,8 @@ const requireFromRoot = (moduleId, root) => {
     }
   });
 
-  return require(path); // eslint-disable-line global-require
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  return require(path);
 };
 
 module.exports = class Neutrino {
@@ -69,7 +70,7 @@ module.exports = class Neutrino {
     });
 
     try {
-      // eslint-disable-next-line global-require
+      // eslint-disable-next-line global-require, import/no-dynamic-require
       options.packageJson = require(join(options.root, 'package.json'));
     } catch (err) {
       options.packageJson = null;

--- a/packages/neutrino/test/api_test.js
+++ b/packages/neutrino/test/api_test.js
@@ -167,7 +167,7 @@ test('creates a webpack config', t => {
   api.use(api => {
     api.config.module
       .rule('compile')
-      .test(api.regexFromExtensions(['js']))
+      .test(api.regexFromExtensions(['js']));
   });
 
   t.notDeepEqual(api.config.toConfig(), {});

--- a/packages/neutrino/test/fixtures/test-module/middleware.js
+++ b/packages/neutrino/test/fixtures/test-module/middleware.js
@@ -1,1 +1,1 @@
-module.exports = () => "root"
+module.exports = () => 'root';

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import Neutrino from '../Neutrino';
 import neutrino from '..';
 
 test('throws when vendor entrypoint defined', t => {

--- a/packages/neutrino/test/require_test.js
+++ b/packages/neutrino/test/require_test.js
@@ -4,7 +4,7 @@ import Neutrino from '../Neutrino';
 
 const testModulePath = join(__dirname, 'fixtures', 'test-module');
 
-test.before(t => {
+test.before(() => {
   process.chdir(testModulePath);
 });
 

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -32,6 +32,9 @@
     "@neutrinojs/web": "^8.2.0",
     "eslint-plugin-react": "^7.7.0"
   },
+  "devDependencies": {
+    "preact": "^8.2.9"
+  },
   "peerDependencies": {
     "neutrino": "^8.0.0",
     "webpack": "^4.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,8 @@
   },
   "devDependencies": {
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "react-hot-loader": "^4.3.1"
   },
   "peerDependencies": {
     "neutrino": "^8.0.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,6 +31,9 @@
     "vue-loader": "^14.2.3",
     "vue-template-compiler": "^2.5.16"
   },
+  "devDependencies": {
+    "vue": "^2.5.16"
+  },
   "peerDependencies": {
     "neutrino": "^8.0.0",
     "webpack": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12794,6 +12794,10 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
+vue@^2.5.16:
+  version "2.5.16"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4898,7 +4898,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
@@ -5517,7 +5517,7 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-global@4.3.2:
+global@4.3.2, global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
@@ -5902,6 +5902,10 @@ hoek@2.x.x:
 hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -9965,6 +9969,10 @@ postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.21, postcss@^6.0.
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+preact@^8.2.9:
+  version "8.2.9"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -10064,7 +10072,7 @@ promisify-call@^2.0.2:
   dependencies:
     with-callback "^1.0.2"
 
-prop-types@^15.6.0:
+prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -10252,6 +10260,21 @@ react-dom@*:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-hot-loader@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.1.tgz#47f59fe09b97ec655e77a1f90819785eda513a86"
+  dependencies:
+    fast-levenshtein "^2.0.6"
+    global "^4.3.0"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.0.2"
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react@*:
   version "16.4.0"
@@ -11094,6 +11117,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
* Reduces the number of non-style AirBnB rules that are disabled.
* Removes redundant `include` from `.neutrinorc.js`.
* Adds tests, create-project templates and the repo root `.eslintrc.js` to the list of monorepo files being linted.
* Enables `--report-unused-disable-directives`.

See individual commits for more details.

At some point after this PR we should also deal with the pre-existing issue of having the style AirBnB rules disabled (due to the `extends: ['prettier']`), but yet we don't actually have Prettier enabled to replace them. However doing so causes a lot more diff churn / need for discussion, so I've left that out of this PR.