### PR TITLE
eslint: Lint the tests directory by default too

### DIFF
--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -38,14 +38,14 @@ const eslint = require('@neutrinojs/eslint');
 
 // Usage shows default values
 neutrino.use(eslint, {
-  test: /\.(js|jsx)$/,
-  include: [], /* Should specify either include or exclude */
-  exclude: [], /* Should specify either include or exclude */
+  test: neutrino.regexFromExtensions(), // Uses extensions from neutrino.options.extensions
+  include: [neutrino.options.source, neutrino.options.tests],
+  exclude: [],
   eslint: {
+    failOnError: neutrino.config.get('mode') === 'production',
     cwd: neutrino.options.root,
     useEslintrc: false,
     root: true,
-    extensions: neutrino.options.extensions,
     plugins: ['babel'],
     baseConfig: {},
     envs: ['es6'],

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -28,12 +28,8 @@ const eslintrc = (neutrino, override) => {
         .use('eslint')
         .get('options')
     ),
-    // We remove these keys since they are needed when running the lint command
-    // but not the eslintrc command. The lint command uses ESLint's CLIEngine,
-    // but the ESLint RC format does not match the CLIEngine format exactly. We
-    // must remove anything we add that does not comply with ESLint's schemas.
-    // https://github.com/eslint/eslint/blob/9d1df92628dd4dd1e70fbb19454008e146387435/conf/config-schema.js
-    // https://github.com/eslint/eslint/blob/9d1df92628dd4dd1e70fbb19454008e146387435/lib/config/config-validator.js#L167
+    // Remove keys that are eslint-loader specific, since they'll be rejected by the .eslintrc schema:
+    // https://github.com/eslint/eslint/blob/v4.19.1/conf/config-schema.js
     [
       'failOnError',
       'emitWarning',
@@ -41,7 +37,6 @@ const eslintrc = (neutrino, override) => {
       'cwd',
       'useEslintrc',
       'fix',
-      'extensions',
       'formatter'
     ]
   );
@@ -85,16 +80,13 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   const defaults = {
-    include: !opts.include ? [neutrino.options.source] : undefined,
+    include: !opts.include ? [neutrino.options.source, neutrino.options.tests] : undefined,
     eslint: {
       failOnError: neutrino.config.get('mode') === 'production',
       cwd: neutrino.options.root,
       useEslintrc: false,
       root: true,
       formatter: 'codeframe',
-      // eslint-loader uses executeOnText(), which ignores the `extensions` setting.
-      // However it's still needed for the lint command, as it uses executeOnFiles().
-      extensions: neutrino.options.extensions,
       // Unfortunately we can't `require.resolve('eslint-plugin-babel')` due to:
       // https://github.com/eslint/eslint/issues/6237
       // ...so we have no choice but to rely on it being hoisted.


### PR DESCRIPTION
The `tests` directory was already added to the `lint` script command by create-project, however it was not yet listed in the `include` for `eslint-loader`.

The testing presets already update `envs` accordingly, to prevent errors from mocha/jest/... globals.

The redundant `eslint.extensions` option has been removed, since that was only used by the ESLint Node API, which we no longer use.

Fixes #331.