### PR TITLE
karma: Use 'minimal' rather than 'errors-only' for stats

### DIFF
--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -52,7 +52,8 @@ module.exports = neutrino => {
         [sources]: ['webpack']
       },
       webpackMiddleware: {
-        stats: 'errors-only'
+        // Using minimal rather than 'errors-only' so that warnings are still shown.
+        stats: 'minimal'
       },
       webpack: merge(
         omit(neutrino.config.toConfig(), ['plugins', 'entry']),


### PR DESCRIPTION
Since otherwise warnings are not even printed (such as those that are emitted by `eslint-loader` when `failOnError` is `false`).