### PR TITLE
eslint: Enable ESLint CLI and eslint-loader caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ node_modules
 # Project metadata
 .idea
 /.vscode
+
+# ESlint CLI cache
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
-    "lint": "eslint --ext js,jsx --report-unused-disable-directives \".*.js\" packages",
+    "lint": "eslint --cache --ext js,jsx --report-unused-disable-directives \".*.js\" packages",
     "precommit": "lint-staged",
     "release": "lerna publish --force-publish=*",
     "release:preview": "lerna publish --force-publish=* --skip-git --skip-npm",

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -81,7 +81,7 @@ module.exports = class Project extends Generator {
     // here should have an accompanying change there as well. We can't pull
     // in neutrino here as that would potentially give us conflicting versions
     // in node_modules.
-    const lint = 'eslint --ext js,jsx,vue,ts,tsx,mjs src';
+    const lint = 'eslint --cache --ext js,jsx,vue,ts,tsx,mjs src';
 
     if (this.data.testRunner) {
       if (this.data.testRunner.includes('jest')) {

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -42,6 +42,7 @@ neutrino.use(eslint, {
   include: [neutrino.options.source, neutrino.options.tests],
   exclude: [],
   eslint: {
+    cache: true,
     failOnError: neutrino.config.get('mode') === 'production',
     cwd: neutrino.options.root,
     useEslintrc: false,

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -31,6 +31,7 @@ const eslintrc = (neutrino, override) => {
     // Remove keys that are eslint-loader specific, since they'll be rejected by the .eslintrc schema:
     // https://github.com/eslint/eslint/blob/v4.19.1/conf/config-schema.js
     [
+      'cache',
       'failOnError',
       'emitWarning',
       'emitError',
@@ -82,6 +83,7 @@ module.exports = (neutrino, opts = {}) => {
   const defaults = {
     include: !opts.include ? [neutrino.options.source, neutrino.options.tests] : undefined,
     eslint: {
+      cache: true,
       failOnError: neutrino.config.get('mode') === 'production',
       cwd: neutrino.options.root,
       useEslintrc: false,


### PR DESCRIPTION
This significantly improves the performance when using ESLint via its CLI (ie the `yarn lint` command configured by create-project), and also via `eslint-loader` (when using `yarn start` or `yarn build`):
https://eslint.org/docs/user-guide/command-line-interface#caching
https://github.com/webpack-contrib/eslint-loader#cache-default-false

Fixes #954.