### PR TITLE
create-project: Install a matching version of Neutrino packages

### DIFF
--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -7,6 +7,7 @@ const Generator = require('yeoman-generator');
 const questions = require('./questions');
 const { packages, presets } = require('./matrix');
 const { isYarn } = require('./utils');
+const { version: neutrinoVersion } = require('../../package.json');
 
 /* eslint-disable no-underscore-dangle */
 module.exports = class Project extends Generator {
@@ -17,6 +18,14 @@ module.exports = class Project extends Generator {
      | | | ||  __/| |_| || |_ | |   | || | | || (_) |
      |_| |_| \\___| \\__,_| \\__||_|   |_||_| |_| \\___/
     `;
+  }
+
+  static _processDependencies(dependencies) {
+    // For dependencies that are Neutrino monorepo packages, install the
+    // same major version as found in create-project's package.json.
+    return dependencies.map(dependency =>
+      dependency in presets ? `${dependency}@^${neutrinoVersion}` : dependency
+    ).sort();
   }
 
   _getProjectMiddleware() {
@@ -56,15 +65,10 @@ module.exports = class Project extends Generator {
         { dependencies: [], devDependencies: [] }
       );
 
-    if (deps.dependencies.length && deps.devDependencies.length) {
-      return deps;
-    } else if (deps.dependencies.length) {
-      return { dependencies: deps.dependencies };
-    } else if (deps.devDependencies.length) {
-      return { devDependencies: deps.devDependencies };
-    }
-
-    return {};
+    return {
+      dependencies: Project._processDependencies(deps.dependencies),
+      devDependencies: Project._processDependencies(deps.devDependencies)
+    };
   }
 
   _initialPackageJson() {
@@ -158,13 +162,11 @@ module.exports = class Project extends Generator {
     const install = isYarn ? 'add' : 'install';
     const devFlag = isYarn ? '--dev' : '--save-dev';
     const { dependencies, devDependencies } = this._getDependencies();
-    const sortedDependencies = dependencies && dependencies.sort();
-    const sortedDevDependencies = devDependencies && devDependencies.sort();
 
     this.log('');
 
-    if (dependencies) {
-      this.log(`${chalk.green('⏳  Installing dependencies:')} ${chalk.yellow(sortedDependencies.join(', '))}`);
+    if (dependencies.length) {
+      this.log(`${chalk.green('⏳  Installing dependencies:')} ${chalk.yellow(dependencies.join(', '))}`);
       this.spawnCommandSync(
         packageManager,
         [
@@ -174,7 +176,7 @@ module.exports = class Project extends Generator {
               ? ['--registry', this.options.registry] :
               []
           ),
-          ...sortedDependencies
+          ...dependencies
         ],
         {
           cwd: this.options.directory,
@@ -184,8 +186,8 @@ module.exports = class Project extends Generator {
       );
     }
 
-    if (devDependencies) {
-      this.log(`${chalk.green('⏳  Installing devDependencies:')} ${chalk.yellow(sortedDevDependencies.join(', '))}`);
+    if (devDependencies.length) {
+      this.log(`${chalk.green('⏳  Installing devDependencies:')} ${chalk.yellow(devDependencies.join(', '))}`);
       this.spawnCommandSync(
         packageManager,
         [
@@ -196,7 +198,7 @@ module.exports = class Project extends Generator {
               ? ['--registry', this.options.registry] :
               []
           ),
-          ...sortedDevDependencies
+          ...devDependencies
         ],
         {
           cwd: this.options.directory,

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -5,7 +5,8 @@ const stringify = require('javascript-stringify');
 const merge = require('deepmerge');
 const Generator = require('yeoman-generator');
 const questions = require('./questions');
-const { projects, packages, isYarn } = require('./utils');
+const { packages, presets } = require('./matrix');
+const { isYarn } = require('./utils');
 
 /* eslint-disable no-underscore-dangle */
 module.exports = class Project extends Generator {
@@ -51,7 +52,7 @@ module.exports = class Project extends Generator {
   _getDependencies() {
     const deps = [this.data.project, this.data.testRunner, this.data.linter]
       .reduce(
-        (deps, project) => merge(deps, projects[project] || {}),
+        (deps, preset) => merge(deps, presets[preset] || {}),
         { dependencies: [], devDependencies: [] }
       );
 

--- a/packages/create-project/commands/init/matrix.js
+++ b/packages/create-project/commands/init/matrix.js
@@ -22,7 +22,7 @@ const WEBPACK = 'webpack@^4';
 const WEBPACK_CLI = 'webpack-cli@^2';
 const WEBPACK_DEV_SERVER = 'webpack-dev-server@^3';
 
-const projects = {
+const presets = {
   [AIRBNB]: {
     type: LINTING,
     devDependencies: [AIRBNB, ESLINT]
@@ -115,4 +115,4 @@ const packages = {
   STANDARDJS
 };
 
-module.exports = { projects, packages };
+module.exports = { presets, packages };

--- a/packages/create-project/commands/init/questions.js
+++ b/packages/create-project/commands/init/questions.js
@@ -1,4 +1,4 @@
-const { packages } = require('./utils');
+const { packages } = require('./matrix');
 
 const NONE = { name: 'None', value: false };
 const APPLICATION = { name: 'A web or Node.js application', value: 'application' };

--- a/packages/create-project/commands/init/utils.js
+++ b/packages/create-project/commands/init/utils.js
@@ -1,10 +1,7 @@
 const commandExists = require('command-exists');
-const { packages, projects } = require('./matrix');
 
 const isYarn = commandExists.sync('yarnpkg');
 
 module.exports = {
-  packages,
-  projects,
   isYarn
 };

--- a/scripts/test-create-project-ci.sh
+++ b/scripts/test-create-project-ci.sh
@@ -12,15 +12,14 @@ yarn verdaccio --config verdaccio.yml &
 while ! nc -zw 1 localhost 4873; do sleep 1; done
 
 # Publish all monorepo packages to the verdaccio registry.
-# Canary mode ensures no git or working directory changes are made, but we
-# have to override the tag from `canary` to `latest` so create-project works.
-# The minor version will be bumped and a `-alpha.GIT_SHA` suffix added, which
-# should help avoid errors from clashing with an already-published version.
+# The version will be bumped to the next pre-release suffix (`-0`) and the
+# package.json changes left in the working directory so that create-project
+# can read the correct version for installing matching monorepo packages.
 yarn release \
   --registry http://localhost:4873/ \
   --yes \
-  --canary \
-  --npm-tag latest
+  --skip-git \
+  --cd-version prerelease
 
 # Run the integration tests, which will install packages
 # from the verdaccio registry


### PR DESCRIPTION
Now create-project always installs the same major version of Neutrino monorepo packages as found in create-project's `package.json`. This avoids problems where the preset's templates, script entries or other dependencies have changed in a non-backwards-compatible way between Neutrino major versions.

See individual commits for more details.