### PR TITLE
create-project: Install a matching version of 'neutrino' too

### DIFF
--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -23,8 +23,9 @@ module.exports = class Project extends Generator {
   static _processDependencies(dependencies) {
     // For dependencies that are Neutrino monorepo packages, install the
     // same major version as found in create-project's package.json.
+    const neutrinoPackages = Object.values(packages);
     return dependencies.map(dependency =>
-      dependency in presets ? `${dependency}@^${neutrinoVersion}` : dependency
+      neutrinoPackages.includes(dependency) ? `${dependency}@^${neutrinoVersion}` : dependency
     ).sort();
   }
 


### PR DESCRIPTION
Follow-up to #957 that fixes the "is a monorepo package" check to also include the main `neutrino` package, and not just the monorepo presets themselves.

Before:
`Installing devDependencies: @neutrinojs/react@^9.0.0-0, neutrino, ...`

After:
`Installing devDependencies: @neutrinojs/react@^9.0.0-0, neutrino@^9.0.0-0, ...`