### PR TITLE
Improve mode/NODE_ENV defaults and interaction

### DIFF
--- a/packages/create-project/commands/init/templates/jest/jest.config.js
+++ b/packages/create-project/commands/init/templates/jest/jest.config.js
@@ -1,3 +1,5 @@
 const neutrino = require('neutrino');
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
 module.exports = neutrino().jest();

--- a/packages/create-project/commands/init/templates/karma/karma.conf.js
+++ b/packages/create-project/commands/init/templates/karma/karma.conf.js
@@ -1,3 +1,5 @@
 const neutrino = require('neutrino');
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
 module.exports = neutrino().karma();

--- a/packages/create-project/commands/init/templates/mocha/mocha.config.js
+++ b/packages/create-project/commands/init/templates/mocha/mocha.config.js
@@ -1,1 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
 require('neutrino')().mocha();

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -43,7 +43,7 @@ neutrino.use(eslint, {
   exclude: [],
   eslint: {
     cache: true,
-    failOnError: neutrino.config.get('mode') === 'production',
+    failOnError: process.env.NODE_ENV !== 'development',
     cwd: neutrino.options.root,
     useEslintrc: false,
     root: true,

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -84,7 +84,8 @@ module.exports = (neutrino, opts = {}) => {
     include: !opts.include ? [neutrino.options.source, neutrino.options.tests] : undefined,
     eslint: {
       cache: true,
-      failOnError: neutrino.config.get('mode') === 'production',
+      // Make errors fatal not just for 'production' but also 'test'.
+      failOnError: process.env.NODE_ENV !== 'development',
       cwd: neutrino.options.root,
       useEslintrc: false,
       root: true,

--- a/packages/font-loader/README.md
+++ b/packages/font-loader/README.md
@@ -41,7 +41,7 @@ neutrino.use(fonts);
 
 // Usage showing default options
 neutrino.use(fonts, {
-  name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
+  name: process.env.NODE_ENV === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -57,7 +57,7 @@ module.exports = {
 module.exports = {
   use: [
     ['@neutrinojs/font-loader', {
-      name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
+      name: process.env.NODE_ENV === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
     }]
   ]
 };

--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,5 +1,5 @@
 module.exports = (neutrino, options = {}) => {
-  const isProduction = neutrino.config.get('mode') === 'production';
+  const isProduction = process.env.NODE_ENV === 'production';
   const defaultOptions = {
     name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'
   };

--- a/packages/image-loader/README.md
+++ b/packages/image-loader/README.md
@@ -42,7 +42,7 @@ neutrino.use(images);
 // Usage showing default options
 neutrino.use(images, {
   limit: 8192,
-  name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
+  name: process.env.NODE_ENV === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
 });
 ```
 
@@ -59,7 +59,7 @@ module.exports = {
   use: [
     ['@neutrinojs/image-loader', {
       limit: 8192,
-      name: mode === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
+      name: process.env.NODE_ENV === 'production' ? '[name].[hash:8].[ext]' : '[name].[ext]'
     }]
   ]
 };

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -1,5 +1,5 @@
 module.exports = (neutrino, options = {}) => {
-  const isProduction = neutrino.config.get('mode') === 'production';
+  const isProduction = process.env.NODE_ENV === 'production';
   const defaultOptions = {
     limit: 8192,
     name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -10,7 +10,7 @@ const imageminLoader = require.resolve('imagemin-webpack/imagemin-loader');
 
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
-    enabled: neutrino.config.get('mode') === 'production',
+    enabled: process.env.NODE_ENV === 'production',
     imagemin: {
       plugins: [
         gifsicle(),

--- a/packages/image-minify/test/middleware_test.js
+++ b/packages/image-minify/test/middleware_test.js
@@ -3,6 +3,12 @@ import Neutrino from '../../neutrino/Neutrino';
 
 const mw = () => require('..');
 const options = { rules: ['image'] };
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -12,7 +18,6 @@ test('uses middleware', t => {
   t.notThrows(() => {
     const api = new Neutrino();
 
-    api.config.mode('production');
     api.use(mw());
   });
 });
@@ -21,15 +26,14 @@ test('uses with options', t => {
   t.notThrows(() => {
     const api = new Neutrino();
 
-    api.config.mode('production');
     api.use(mw(), options);
   });
 });
 
 test('instantiates', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
 
-  api.config.mode('production');
   api.use(mw());
 
   t.true(api.config.plugins.has('imagemin'));
@@ -37,9 +41,9 @@ test('instantiates', t => {
 });
 
 test('instantiates with options', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
 
-  api.config.mode('production');
   api.use(mw(), options);
 
   t.true(api.config.plugins.has('imagemin'));
@@ -47,9 +51,9 @@ test('instantiates with options', t => {
 });
 
 test('disabled in development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
 
-  api.config.mode('development');
   api.use(mw(), options);
 
   t.false(api.config.plugins.has('imagemin'));

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -3,6 +3,12 @@ import Neutrino from '../../neutrino/Neutrino';
 import neutrino from '../../neutrino';
 
 const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -11,25 +17,28 @@ test('loads middleware', t => {
 test('uses middleware', t => {
   t.notThrows(() => {
     const api = new Neutrino();
-
-    api.config.mode('production');
     api.use(mw());
   });
 });
 
 test('instantiates', t => {
   const api = new Neutrino();
-
-  api.config.mode('production');
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
 });
 
 test('instantiates in development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
+  api.use(mw());
 
-  api.config.mode('development');
+  t.notThrows(() => api.config.toConfig());
+});
+
+test('instantiates in production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
@@ -37,7 +46,6 @@ test('instantiates in development', t => {
 
 test('exposes jest output handler', t => {
   const api = new Neutrino();
-
   api.use(mw());
 
   const handler = api.outputHandlers.get('jest');

--- a/packages/karma/test/karma_test.js
+++ b/packages/karma/test/karma_test.js
@@ -3,6 +3,12 @@ import Neutrino from '../../neutrino/Neutrino';
 import neutrino from '../../neutrino';
 
 const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -11,25 +17,28 @@ test('loads middleware', t => {
 test('uses middleware', t => {
   t.notThrows(() => {
     const api = new Neutrino();
-
-    api.config.mode('production');
     api.use(mw());
   });
 });
 
 test('instantiates', t => {
   const api = new Neutrino();
-
-  api.config.mode('production');
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
 });
 
 test('instantiates in development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
+  api.use(mw());
 
-  api.config.mode('development');
+  t.notThrows(() => api.config.toConfig());
+});
+
+test('instantiates in production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
@@ -37,7 +46,6 @@ test('instantiates in development', t => {
 
 test('exposes karma output handler', t => {
   const api = new Neutrino();
-
   api.use(mw());
 
   const handler = api.outputHandlers.get('karma');

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -66,8 +66,6 @@ module.exports = (neutrino, opts = {}) => {
     .keys(neutrino.options.mains)
     .forEach(key => neutrino.config.entry(key).add(neutrino.options.mains[key]));
 
-  const mode = neutrino.config.get('mode');
-
   neutrino.config
     .when(hasSourceMap, () => neutrino.use(banner))
     .devtool('source-map')
@@ -122,7 +120,7 @@ module.exports = (neutrino, opts = {}) => {
         neutrino.use(loaderMerge('lint', 'eslint'), { envs: ['browser', 'commonjs'] });
       }
     })
-    .when(mode === 'production', (config) => {
+    .when(process.env.NODE_ENV === 'production', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 };

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -2,30 +2,37 @@ import test from 'ava';
 import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
+const mw = () => require('..');
 const expectedExtensions = ['.js', '.jsx', '.vue', '.ts', '.tsx', '.mjs', '.json'];
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads preset', t => {
-  t.notThrows(() => require('..'));
+  t.notThrows(mw);
 });
 
 test('uses preset', t => {
   const api = new Neutrino();
 
-  t.notThrows(() => api.use(require('..'), { name: 'alpha' }));
+  t.notThrows(() => api.use(mw(), { name: 'alpha' }));
 });
 
 test('throws when missing library name', t => {
   const api = new Neutrino();
 
-  const err = t.throws(() => api.use(require('..')));
+  const err = t.throws(() => api.use(mw()));
   t.true(err.message.includes('You must specify a library name'));
 });
 
 test('valid preset production', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
 
-  api.config.mode('production');
-  api.use(require('..'), { name: 'alpha' });
+  api.use(mw(), { name: 'alpha' });
   const config = api.config.toConfig();
 
   // Common
@@ -35,7 +42,6 @@ test('valid preset production', t => {
   t.is(config.devServer, undefined);
 
   // NODE_ENV/command specific
-  t.is(config.mode, 'production');
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
 
@@ -44,10 +50,10 @@ test('valid preset production', t => {
 });
 
 test('valid preset development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
 
-  api.config.mode('development');
-  api.use(require('..'), { name: 'alpha' });
+  api.use(mw(), { name: 'alpha' });
   const config = api.config.toConfig();
 
   // Common
@@ -57,7 +63,6 @@ test('valid preset development', t => {
   t.is(config.devServer, undefined);
 
   // NODE_ENV/command specific
-  t.is(config.mode, 'development');
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
 
@@ -67,9 +72,7 @@ test('valid preset development', t => {
 
 test('valid preset Node.js target', t => {
   const api = new Neutrino();
-
-  api.config.mode('development');
-  api.use(require('..'), { name: 'alpha', target: 'node' });
+  api.use(mw(), { name: 'alpha', target: 'node' });
 
   const errors = validate(api.config.toConfig());
 
@@ -78,9 +81,7 @@ test('valid preset Node.js target', t => {
 
 test('valid preset commonjs2 libraryTarget', t => {
   const api = new Neutrino();
-
-  api.config.mode('development');
-  api.use(require('..'), { name: 'alpha', libraryTarget: 'commonjs2' });
+  api.use(mw(), { name: 'alpha', libraryTarget: 'commonjs2' });
 
   const errors = validate(api.config.toConfig());
 

--- a/packages/mocha/test/mocha_test.js
+++ b/packages/mocha/test/mocha_test.js
@@ -3,6 +3,12 @@ import Neutrino from '../../neutrino/Neutrino';
 import neutrino from '../../neutrino';
 
 const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -11,25 +17,28 @@ test('loads middleware', t => {
 test('uses middleware', t => {
   t.notThrows(() => {
     const api = new Neutrino();
-
-    api.config.mode('production');
     api.use(mw());
   });
 });
 
 test('instantiates', t => {
   const api = new Neutrino();
-
-  api.config.mode('production');
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
 });
 
 test('instantiates in development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
+  api.use(mw());
 
-  api.config.mode('development');
+  t.notThrows(() => api.config.toConfig());
+});
+
+test('instantiates in production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
   api.use(mw());
 
   t.notThrows(() => api.config.toConfig());
@@ -37,7 +46,6 @@ test('instantiates in development', t => {
 
 test('exposes mocha output handler', t => {
   const api = new Neutrino();
-
   api.use(mw());
 
   const handler = api.outputHandlers.get('mocha');

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -1,6 +1,38 @@
 import test from 'ava';
 import neutrino from '..';
 
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+test('default mode derived from production NODE_ENV', t => {
+  process.env.NODE_ENV = 'production';
+  const webpackConfig = neutrino().output('webpack')();
+  t.is(webpackConfig.mode, 'production');
+});
+
+test('default mode derived from development NODE_ENV', t => {
+  process.env.NODE_ENV = 'development';
+  const webpackConfig = neutrino().output('webpack')();
+  t.is(webpackConfig.mode, 'development');
+});
+
+test('default mode derived from test NODE_ENV', t => {
+  process.env.NODE_ENV = 'test';
+  const webpackConfig = neutrino().output('webpack')();
+  t.is(webpackConfig.mode, 'development');
+});
+
+test('undefined mode and NODE_ENV sets only NODE_ENV', t => {
+  delete process.env.NODE_ENV;
+  const webpackConfig = neutrino().output('webpack')();
+  t.is(process.env.NODE_ENV, 'production');
+  t.false('mode' in webpackConfig);
+});
+
 test('throws when vendor entrypoint defined', t => {
   const err = t.throws(() => {
     const webpackConfig = neutrino(neutrino => {

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -56,8 +56,6 @@ module.exports = (neutrino, opts = {}) => {
     .keys(neutrino.options.mains)
     .forEach(key => neutrino.config.entry(key).add(neutrino.options.mains[key]));
 
-  const mode = neutrino.config.get('mode');
-
   neutrino.config
     .when(sourceMap, () => neutrino.use(banner))
     .performance
@@ -90,7 +88,7 @@ module.exports = (neutrino, opts = {}) => {
         }
       });
     })
-    .when(mode === 'development', (config) => {
+    .when(process.env.NODE_ENV === 'development', (config) => {
       const mainKeys = Object.keys(neutrino.options.mains);
 
       neutrino.use(startServer, {
@@ -110,7 +108,7 @@ module.exports = (neutrino, opts = {}) => {
           });
         });
     })
-    .when(mode === 'production', (config) => {
+    .when(process.env.NODE_ENV === 'production', (config) => {
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 };

--- a/packages/preact/test/preact_test.js
+++ b/packages/preact/test/preact_test.js
@@ -2,19 +2,26 @@ import test from 'ava';
 import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
+const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
 test('loads preset', t => {
-  t.notThrows(() => require('..'));
+  t.notThrows(mw);
 });
 
 test('uses preset', t => {
-  t.notThrows(() => new Neutrino().use(require('..')));
+  t.notThrows(() => new Neutrino().use(mw()));
 });
 
 test('valid preset production', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
-
-  api.config.mode('production');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 
@@ -22,10 +29,9 @@ test('valid preset production', t => {
 });
 
 test('valid preset development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
-
-  api.config.mode('development');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -6,18 +6,17 @@ const { extname, join, basename } = require('path');
 const { readdirSync } = require('fs');
 
 module.exports = (neutrino, opts = {}) => {
-  const mode = neutrino.config.get('mode');
   const options = merge({
-    html: mode === 'development' && {
+    html: process.env.NODE_ENV === 'development' && {
       title: 'React Preview'
     },
-    manifest: mode === 'development',
+    manifest: process.env.NODE_ENV === 'development',
     externals: opts.externals !== false && {},
     style: { extract: { plugin: { filename: '[name].css' } } }
   }, opts);
 
   neutrino.config.when(
-    mode === 'development',
+    process.env.NODE_ENV === 'development',
     () => {
       neutrino.use(react, options);
     },

--- a/packages/react-components/test/components_test.js
+++ b/packages/react-components/test/components_test.js
@@ -2,21 +2,29 @@ import test from 'ava';
 import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
+const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
 test('loads preset', t => {
-  t.notThrows(() => require('..'));
+  t.notThrows(mw);
 });
 
 test('uses preset', t => {
   const api = new Neutrino({ root: __dirname });
 
-  t.notThrows(() => api.use(require('..'), { name: 'alpha' }));
+  t.notThrows(() => api.use(mw(), { name: 'alpha' }));
 });
 
 test('valid preset production', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino({ root: __dirname });
 
-  api.config.mode('production');
-  api.use(require('..'));
+  api.use(mw());
   const config = api.config.toConfig();
 
   // Common
@@ -25,7 +33,6 @@ test('valid preset production', t => {
   t.is(config.optimization.splitChunks, false);
 
   // NODE_ENV/command specific
-  t.is(config.mode, 'production');
   t.true(config.optimization.minimize);
   t.is(config.devtool, 'source-map');
   t.is(config.devServer, undefined);
@@ -35,10 +42,10 @@ test('valid preset production', t => {
 });
 
 test('valid preset development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino({ root: __dirname });
 
-  api.config.mode('development');
-  api.use(require('..'));
+  api.use(mw());
   const config = api.config.toConfig();
 
   // Common

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -4,7 +4,6 @@ const loaderMerge = require('@neutrinojs/loader-merge');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
-  const mode = neutrino.config.get('mode');
   const options = merge({
     hot: true,
     babel: {}
@@ -20,7 +19,7 @@ module.exports = (neutrino, opts = {}) => {
     babel: compileLoader.merge({
       plugins: [
         ...(
-          mode === 'development' && options.hot && reactHotLoader
+          process.env.NODE_ENV === 'development' && options.hot && reactHotLoader
             ? [reactHotLoader]
             : []
         ),
@@ -33,7 +32,7 @@ module.exports = (neutrino, opts = {}) => {
           require.resolve('@babel/preset-react'),
           {
             // Enable development helpers both in development and testing.
-            development: mode !== 'production',
+            development: process.env.NODE_ENV !== 'production',
             // Use the native built-in instead of polyfilling.
             useBuiltIns: true
           }

--- a/packages/react/test/react_test.js
+++ b/packages/react/test/react_test.js
@@ -2,19 +2,26 @@ import test from 'ava';
 import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
+const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
 test('loads preset', t => {
-  t.notThrows(() => require('..'));
+  t.notThrows(mw);
 });
 
 test('uses preset', t => {
-  t.notThrows(() => new Neutrino().use(require('..')));
+  t.notThrows(() => new Neutrino().use(mw()));
 });
 
 test('valid preset production', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
-
-  api.config.mode('production');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 
@@ -22,10 +29,9 @@ test('valid preset production', t => {
 });
 
 test('valid preset development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
-
-  api.config.mode('development');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -63,7 +63,7 @@ neutrino.use(styles, {
   extract: {
     plugin: {},
     loader: {
-      filename: mode === 'production' ? '[name].[contenthash:8].css' : '[name].css'
+      filename: process.env.NODE_ENV === 'production' ? '[name].[contenthash:8].css' : '[name].css'
     }
   }
 });
@@ -95,7 +95,7 @@ module.exports = {
       extract: {
         plugin: {},
         loader: {
-          filename: mode === 'production' ? '[name].[contenthash:8].css' : '[name].css'
+          filename: process.env.NODE_ENV === 'production' ? '[name].[contenthash:8].css' : '[name].css'
         }
       }
     }]

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -22,7 +22,7 @@ module.exports = (neutrino, opts = {}) => {
     extract: {
       loader: {},
       plugin: {
-        filename: neutrino.config.get('mode') === 'production'
+        filename: process.env.NODE_ENV === 'production'
           ? '[name].[contenthash:8].css'
           : '[name].css'
       }

--- a/packages/stylelint/README.md
+++ b/packages/stylelint/README.md
@@ -41,7 +41,7 @@ neutrino.use(stylelint, {
   pluginId: 'stylelint',
   files: '**/*.+(css|scss|sass|less)',
   context: neutrino.options.source,
-  failOnError: neutrino.options.command !== 'start'
+  failOnError: process.env.NODE_ENV !== 'development'
 });
 ```
 Options are passed to `stylelint-webpack-plugin`. See the [stylelint Node API](https://stylelint.io/user-guide/node-api/#options) for all available options.
@@ -90,6 +90,8 @@ _Example: Create a .stylelintrc.js file in the root of the project, using `.neut
 ```js
 // .stylelintrc.js
 const { Neutrino } = require('neutrino');
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'lint';
 
 // Specify middleware to Neutrino prior to calling stylelintrc.
 // Even if using .neutrinorc.js, you must specify it when using

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -6,6 +6,8 @@ module.exports = (neutrino, { pluginId = 'stylelint', ...opts } = {}) => {
     configBasedir: neutrino.options.root,
     files: '**/*.+(css|scss|sass|less)',
     context: neutrino.options.source,
+    // Fail for all of 'production', 'lint' and 'test'.
+    failOnError: process.env.NODE_ENV !== 'development',
     formatter: formatters.string,
     ...opts
   };

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -12,7 +12,7 @@ module.exports = (neutrino, opts = {}) => {
     style: {
       ruleId: 'style',
       styleUseId: 'style',
-      extract: neutrino.config.get('mode') === 'production',
+      extract: process.env.NODE_ENV === 'production',
       exclude: [],
       modulesTest: neutrino.regexFromExtensions(['css']),
       modulesSuffix: ''

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -2,19 +2,26 @@ import test from 'ava';
 import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
+const mw = () => require('..');
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
 test('loads preset', t => {
-  t.notThrows(() => require('..'));
+  t.notThrows(mw);
 });
 
 test('uses preset', t => {
-  t.notThrows(() => new Neutrino().use(require('..')));
+  t.notThrows(() => new Neutrino().use(mw()));
 });
 
 test('valid preset production', t => {
+  process.env.NODE_ENV = 'production';
   const api = new Neutrino();
-
-  api.config.mode('production');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 
@@ -22,10 +29,9 @@ test('valid preset production', t => {
 });
 
 test('valid preset development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
-
-  api.config.mode('development');
-  api.use(require('..'));
+  api.use(mw());
 
   const errors = validate(api.config.toConfig());
 


### PR DESCRIPTION
Previously the only way to override `mode` was by passing `--mode` on the command line. However this is not possible with all tools, since some (such as karma) reject unrecognised arguments.

Now:
* `mode` is derived from `NODE_ENV` if `--mode` wasn't passed, and !production `NODE_ENV` falls back to mode `development`.
* if `--mode` is passed, it takes priority over `NODE_ENV`.
* if neither `mode` nor `NODE_ENV is defined, then `NODE_ENV` is set to `production`, however `mode` is left undefined, which causes webpack to output a helpful warning about relying on defaults.
* the template test runner configs set a default `NODE_ENV` of `test`.
* `@neutrinojs/stylelint` now also correctly sets `failOnError`.

Fixes #900.
Fixes #971.
Closes #955.