### PR TITLE
Fix Neutrino usage of yargs

### DIFF
--- a/packages/neutrino/bin/neutrino.js
+++ b/packages/neutrino/bin/neutrino.js
@@ -2,9 +2,9 @@
 
 const yargs = require('yargs');
 
-const args = yargs.parse(process.argv);
+const { argv } = yargs;
 
-if (args.inspect) {
+if (argv.inspect) {
   // eslint-disable-next-line global-require
   require('../')().inspect();
 }

--- a/packages/neutrino/index.js
+++ b/packages/neutrino/index.js
@@ -7,8 +7,8 @@ const configPrefix = 'neutrino.config';
 
 module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
   const neutrino = new Neutrino(options);
-  const args = yargs.parse(process.argv);
-  const mode = args.mode || 'production';
+  const { argv } = yargs;
+  const mode = argv.mode || 'production';
 
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = mode;


### PR DESCRIPTION
To prevent the `TypeError` seen when running `yarn start`.

Fixes #974.