### PR TITLE
node: Target the version of Node.js used to run webpack

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -8,7 +8,8 @@
 ## Features
 
 - Zero upfront configuration necessary to start developing and building a Node.js project
-- Modern Babel compilation supporting ES modules, Node.js 8.3+, async functions, and dynamic imports
+- Modern Babel compilation supporting ES modules, async functions, and dynamic imports
+- By default targets the version of Node.js used to run webpack
 - Supports automatically-wired sourcemaps
 - Tree-shaking to create smaller bundles
 - Hot Module Replacement with source-watching during development
@@ -271,7 +272,8 @@ module.exports = {
         // Override options for @babel/preset-env, showing defaults:
         presets: [
           ['@babel/preset-env', {
-            targets: { node: '8.3' },
+            // Targets the version of Node.js used to run webpack.
+            targets: { node: 'current' },
             modules: false,
             useBuiltIns: true,
           }]

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -27,7 +27,8 @@ module.exports = (neutrino, opts = {}) => {
   const options = merge({
     hot: true,
     targets: {
-      node: '8.3'
+      // Targets the version of Node.js used to run webpack.
+      node: 'current'
     },
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]


### PR DESCRIPTION
Instead of always targetting Node.js 8.3. This means users running newer Node.js will have fewer Babel transforms enabled, reducing build times and improving runtime performance.

Fixes #985.