### PR TITLE
Add `transform-object-rest-spread` plugin for Node

### DIFF
--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -39,7 +39,8 @@ module.exports = (neutrino, opts = {}) => {
     include: [neutrino.options.source, neutrino.options.tests],
     babel: compile.merge({
       plugins: [
-        require.resolve('@babel/plugin-syntax-dynamic-import')
+        require.resolve('@babel/plugin-syntax-dynamic-import'),
+        require.resolve('transform-object-rest-spread')
       ],
       presets: [
         [require.resolve('@babel/preset-env'), {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,6 +30,7 @@
     "@neutrinojs/clean": "9.0.0-0",
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/start-server": "9.0.0-0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0",
     "webpack-node-externals": "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,9 +1839,16 @@ babel-plugin-jest-hoist@^23.0.0, babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-polyfill@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
Since the Node preset already includes support for most modern Ecmascript features including async functions, `import`, etc., the lack of support for the spread operator is confusing and seems out of place.  This commit adds support for the spread operator by default, allowing for it to be parsed properly when users use it in their source code.