### PR TITLE
Simplify the output handler API

### DIFF
--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -14,12 +14,12 @@ module.exports = (neutrino, options = {}) => {
       ...(options.babel || {})
     });
 
-  neutrino.register('babel', (neutrino, override) => override(
+  neutrino.register('babel', (neutrino) =>
     neutrino.config.module
       .rule('compile')
       .use('babel')
       .get('options')
-  ));
+  );
 };
 
 module.exports.merge = babelMerge;

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -20,7 +20,7 @@ const merge = (source, destination) => {
 
   return options;
 };
-const eslintrc = (neutrino, override) => {
+const eslintrc = (neutrino) => {
   const options = omit(
     clone(
       neutrino.config.module
@@ -72,7 +72,7 @@ const eslintrc = (neutrino, override) => {
     });
   }
 
-  return override(options);
+  return options;
 };
 
 module.exports = (neutrino, opts = {}) => {

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -18,7 +18,7 @@ module.exports = neutrino => {
     });
   });
 
-  neutrino.register('jest', (neutrino, override) => {
+  neutrino.register('jest', (neutrino) => {
     const usingBabel = neutrino.config.module.rules.has('compile');
 
     if (usingBabel) {
@@ -76,7 +76,7 @@ module.exports = neutrino => {
     const modulesConfig = neutrino.config.resolve.modules.values();
     const aliases = neutrino.config.resolve.alias.entries() || {};
 
-    return override({
+    return {
       rootDir: root,
       moduleDirectories: modulesConfig.length ? modulesConfig : ['node_modules'],
       moduleFileExtensions: neutrino.config.resolve.extensions
@@ -111,6 +111,6 @@ module.exports = neutrino => {
       globals: {
         BABEL_OPTIONS: babelOptions
       }
-    });
+    };
   });
 };

--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -11,7 +11,7 @@ module.exports = neutrino => {
     });
   }
 
-  neutrino.register('karma', (neutrino, override) => config => {
+  neutrino.register('karma', (neutrino) => (config) => {
     if (neutrino.config.module.rules.has('compile')) {
       neutrino.config.module
         .rule('compile')
@@ -76,6 +76,6 @@ module.exports = neutrino => {
       }
     });
 
-    return override(config);
+    return config;
   });
 };

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -9,7 +9,7 @@ module.exports = neutrino => {
     });
   }
 
-  neutrino.register('mocha', (neutrino, override) => {
+  neutrino.register('mocha', (neutrino) => {
     const baseOptions = neutrino.config.module.rules.has('compile')
       ? neutrino.config.module.rule('compile').use('babel').get('options')
       : {};
@@ -27,6 +27,6 @@ module.exports = neutrino => {
     );
 
     // eslint-disable-next-line global-require
-    require('@babel/register')(override(options));
+    require('@babel/register')(options);
   });
 };

--- a/packages/neutrino/index.js
+++ b/packages/neutrino/index.js
@@ -2,7 +2,6 @@ const yargs = require('yargs');
 const Neutrino = require('./Neutrino');
 const webpack = require('./webpack');
 
-const IDENTITY = a => a;
 const configPrefix = 'neutrino.config';
 
 module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
@@ -34,14 +33,10 @@ module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
   }
 
   const adapter = {
-    output(name, override = IDENTITY) {
+    output(name) {
       if (name === 'inspect') {
         console.log(neutrino.config.toString({ configPrefix }));
         process.exit();
-      }
-
-      if (typeof override !== 'function') {
-        throw new Error(`The output override for "${name}" must be a function`);
       }
 
       const handler = neutrino.outputHandlers.get(name);
@@ -50,7 +45,7 @@ module.exports = (middleware = { use: ['.neutrinorc.js'] }, options = {}) => {
         throw new Error(`Unable to find an output handler named "${name}"`);
       }
 
-      return handler(neutrino, override);
+      return handler(neutrino);
     }
   };
 

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -10,49 +10,37 @@ test.afterEach(() => {
 
 test('default mode derived from production NODE_ENV', t => {
   process.env.NODE_ENV = 'production';
-  const webpackConfig = neutrino().output('webpack')();
+  const webpackConfig = neutrino().output('webpack');
   t.is(webpackConfig.mode, 'production');
 });
 
 test('default mode derived from development NODE_ENV', t => {
   process.env.NODE_ENV = 'development';
-  const webpackConfig = neutrino().output('webpack')();
+  const webpackConfig = neutrino().output('webpack');
   t.is(webpackConfig.mode, 'development');
 });
 
 test('default mode derived from test NODE_ENV', t => {
   process.env.NODE_ENV = 'test';
-  const webpackConfig = neutrino().output('webpack')();
+  const webpackConfig = neutrino().output('webpack');
   t.is(webpackConfig.mode, 'development');
 });
 
 test('undefined mode and NODE_ENV sets only NODE_ENV', t => {
   delete process.env.NODE_ENV;
-  const webpackConfig = neutrino().output('webpack')();
+  const webpackConfig = neutrino().output('webpack');
   t.is(process.env.NODE_ENV, 'production');
   t.false('mode' in webpackConfig);
 });
 
 test('throws when vendor entrypoint defined', t => {
   const err = t.throws(() => {
-    const webpackConfig = neutrino(neutrino => {
+    neutrino(neutrino => {
       neutrino.config.entry('vendor').add('lodash');
     }).output('webpack');
-
-    // webpackConfig is a function that is called by webpack,
-    // so we need to call it to force its evaluation
-    webpackConfig();
   });
 
   t.true(err.message.includes('Remove the manual `vendor` entrypoint'));
-});
-
-test('throws when trying to override with a non-function', t => {
-  const err = t.throws(() =>
-    neutrino(Function.prototype).output('webpack', { bad: 'override' })
-  );
-
-  t.true(err.message.includes('must be a function'));
 });
 
 test('throws when trying to use a non-registered output', t => {
@@ -78,11 +66,8 @@ test('exposes webpack output handler', t => {
 });
 
 test('exposes webpack config from output', t => {
-  // The webpack handler returns a function to be used by webpack-cli
-  // and webpack-command. Force evaluation by calling this function.
   const handler = neutrino(Function.prototype).output('webpack');
-
-  t.is(typeof handler(), 'object');
+  t.is(typeof handler, 'object');
 });
 
 test('exposes webpack method', t => {
@@ -90,9 +75,6 @@ test('exposes webpack method', t => {
 });
 
 test('exposes webpack config from method', t => {
-  // The webpack handler returns a function to be used by webpack-cli
-  // and webpack-command. Force evaluation by calling this function.
   const handler = neutrino(Function.prototype).webpack();
-
-  t.is(typeof handler(), 'object');
+  t.is(typeof handler, 'object');
 });

--- a/packages/neutrino/webpack.js
+++ b/packages/neutrino/webpack.js
@@ -1,9 +1,9 @@
-module.exports = (neutrino, override) => (...args) => {
+module.exports = (neutrino) => {
   if (neutrino.config.entryPoints.has('vendor')) {
     throw new Error('Vendor chunks are now automatically generated. ' +
       'Remove the manual `vendor` entrypoint.'
     );
   }
 
-  return override(neutrino.config.toConfig(), ...args);
+  return neutrino.config.toConfig();
 };

--- a/packages/stylelint/index.js
+++ b/packages/stylelint/index.js
@@ -16,9 +16,9 @@ module.exports = (neutrino, { pluginId = 'stylelint', ...opts } = {}) => {
     .plugin(pluginId)
     .use(StylelintPlugin, [options]);
 
-  neutrino.register('stylelintrc', (neutrino, override) => override(
+  neutrino.register('stylelintrc', (neutrino) =>
     neutrino.config
       .plugin('stylelint')
       .get('args')[0].config || {}
-  ));
+  );
 };


### PR DESCRIPTION
The override function is not really necessary, since:
* on the most part, people should be making customisations via the Neutrino API, rather than modifying the final config object.
* for everything but the mocha preset, it's still possible to inspect and modify the config generated by the output handler, even without the override function. (And for the mocha preset, if additional customisation is desired, this should probably happen via options passed to the preset instead.)

In addition, the webpack output handler now returns a config object instead of the generator function, which should reduce confusion for end users. (We no longer have a need for it, since we use `yargs` to determine `mode` instead of the arguments passed to the function.)