### PR TITLE
Jest: Set testEnvironment to 'node' when targeting node

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -97,6 +97,7 @@ module.exports = neutrino => {
         relative(root, source),
         `**/*.{${extensions.join(',')}}`
       )],
+      testEnvironment: neutrino.config.get('target') === 'node' ? 'node' : 'jsdom',
       testRegex: `${basename(tests)}/.*(_test|_spec|\\.test|\\.spec)\\.(${
         extensions.join('|')
         })$`,


### PR DESCRIPTION
Since the `testEnvironment` default of `'jsdom'` is only suitable when testing code intended to run in a browser environment. See:
https://jestjs.io/docs/en/configuration.html#testenvironment-string

Fixes #1020.