### PR TITLE
react: Use the react-hot-loader Babel plugin in production too

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -18,7 +18,9 @@ module.exports = (neutrino, opts = {}) => {
     babel: compileLoader.merge({
       plugins: [
         ...(
-          process.env.NODE_ENV === 'development' && options.hot && reactHotLoader
+          // The plugin is enabled in production too since it removes the `hot(module)(...)`
+          // wrapper, allowing webpack to use its concatenate modules optimization.
+          options.hot && reactHotLoader
             ? [reactHotLoader]
             : []
         ),


### PR DESCRIPTION
`react-hot-loader` internally uses `process.env.NODE_ENV` conditionals to make most of its functionality a no-op when in production.

Previously the production Babel plugin was a no-op too, however after gaearon/react-hot-loader#1081 and gaearon/react-hot-loader#1093 it now replaces instances of `hot(module)(App)` with `App`.

In addition to removing a few lines of RHL code, this allows webpack to now perform its module concatenation optimization, and avoids Content-Security-Policy script-src `unsafe-eval` false positives.

This change is compatible with all versions of RHL 4, however to see the benefit, users will need to upgrade to >=4.4.0 (in beta).