### PR TITLE
Use webpack's default value for `minimizer`

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -146,9 +146,10 @@ improved functionality around `splitChunks` [#809](https://github.com/neutrinojs
 [the split chunks documentation](https://webpack.js.org/plugins/split-chunks-plugin/) for more information.
 Usage of the `vendor` entry point will now throw an error when used with v9 and should not be used.
 - **BREAKING CHANGE** The `@neutrinojs/babel-minify` preset has been removed in favor
-of the much faster `terser-webpack-plugin` (which will be the default in webpack 5)
-[#809](https://github.com/neutrinojs/neutrino/pull/809) and
-[#1158](https://github.com/neutrinojs/neutrino/pull/1158).
+of the much faster `terser-webpack-plugin` (which is the new default in webpack 4.26.0)
+[#809](https://github.com/neutrinojs/neutrino/pull/809),
+[#1158](https://github.com/neutrinojs/neutrino/pull/1158) and
+[#1215](https://github.com/neutrinojs/neutrino/pull/1215).
 - **BREAKING CHANGE** The `@neutrinojs/web` and dependent presets have renamed the `minify.babel` option
 to `minify.source` [#809](https://github.com/neutrinojs/neutrino/pull/809).
 - **BREAKING CHANGE** The `@neutrinojs/web` and dependent presets no longer include the
@@ -195,11 +196,6 @@ them yourself. In particular, due to a bug in the previous implementation, the d
 used to be accessible on all network interfaces, whereas it is now correctly only available
 over localhost. As such if running webpack-dev-server from within a Docker container or VM,
 you will now need to set `host` to `0.0.0.0` to allow connections from the host machine.
-- **BREAKING CHANGE** When using `@neutrinojs/web` and presets that depend on it,
-source maps must now be configured using the preset's `devtool` option rather than
-manually in a later middleware, to ensure that `terser-webpack-plugin` is configured
-correctly [#1158](https://github.com/neutrinojs/neutrino/pull/1158). See the
-[source maps documentation](./packages/web.md#source-maps) for more details.
 - **BREAKING CHANGE** Babel has been upgraded from v6 to v7 [#845](https://github.com/neutrinojs/neutrino/pull/809).
 Any additional Babel plugins and presets you use in your projects should be compatible with Babel v7 if
 they are still necessary.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier": "^1.14.3",
     "verdaccio": "^3.8.5",
     "verdaccio-memory": "^1.0.3",
-    "webpack": "^4.23.1",
+    "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10"
   },

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -393,10 +393,10 @@ require(['redux', 'redux-example'], ({ createStore }, reduxExample) => {
 
 ### Source minification
 
-By default script sources are minified in production only, using
-[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-(which replaces `uglifyjs-webpack-plugin`). To customise the options passed to `TerserPlugin`
-or even use a different minifier, override `optimization.minimizer`.
+By default script sources are minified in production only, using webpack's default of
+[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
+To customise the options passed to `TerserPlugin` or even use a different minifier,
+override `optimization.minimizer`.
 
 _Example: Adjust the `terser` minification settings:_
 
@@ -405,15 +405,22 @@ module.exports = {
   use: [
     '@neutrinojs/library',
     (neutrino) => {
-      // The `terser` minimizer plugin only exists in the configuration in production.
+      // Whilst the minimizer is only used when the separate `minimize` option is true
+      // (ie in production), the conditional avoids the expensive require() in development.
       if (process.env.NODE_ENV === 'production') {
         neutrino.config.optimization
           .minimizer('terser')
-          .tap(([defaultOptions]) => [{
-            ...defaultOptions,
+          .use(require.resolve('terser-webpack-plugin'), [{
+            // Default options used by webpack:
+            // https://github.com/webpack/webpack/blob/v4.26.0/lib/WebpackOptionsDefaulter.js#L308-L315
+            cache: true,
+            parallel: true,
+            sourceMap: neutrino.config.devtool && /source-?map/.test(neutrino.config.devtool),
+            // Pass custom options here.
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // https://github.com/terser-js/terser#minify-options
             terserOptions: {
+              // eg disable mangling of names
               mangle: false,
             },
           }]);

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -99,16 +99,6 @@ module.exports = (neutrino, opts = {}) => {
       modules: false
     })
     .when(process.env.NODE_ENV === 'production', (config) => {
-      // Use terser instead of the unmaintained uglify-es.
-      // This is a backport of the upcoming webpack 5 minimizer configuration:
-      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
-      config.optimization
-        .minimizer('terser')
-        .use(require.resolve('terser-webpack-plugin'), [{
-          cache: true,
-          parallel: true,
-          sourceMap: true
-        }]);
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -37,7 +37,6 @@
     "@neutrinojs/clean": "9.0.0-0",
     "@neutrinojs/compile-loader": "9.0.0-0",
     "deepmerge": "^1.5.2",
-    "terser-webpack-plugin": "^1.1.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -47,6 +47,7 @@ test('valid preset production', t => {
   // Common
   t.is(config.target, 'web');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
+  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -57,7 +58,6 @@ test('valid preset production', t => {
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
-  t.is(config.optimization.minimizer.length, 1);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -73,6 +73,7 @@ test('valid preset development', t => {
   // Common
   t.is(config.target, 'web');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
+  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -83,7 +84,6 @@ test('valid preset development', t => {
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
-  t.is(config.optimization, undefined);
 
   const errors = validate(config);
   t.is(errors.length, 0);

--- a/packages/neutrino/handlers.js
+++ b/packages/neutrino/handlers.js
@@ -8,31 +8,6 @@ const webpack = (neutrino) => {
     );
   }
 
-  const devtool = neutrino.config.get('devtool');
-  const usingSourcemap = typeof devtool === 'string' && /source-?map/.test(devtool);
-  const minimizer = neutrino.config.optimization.minimizers.get('terser');
-  // Catch cases where the user is configuring sourcemaps outside of the web preset,
-  // since it prevents the correct configuration of `terser-webpack-plugin`. eg:
-  //   module.exports = {
-  //     use: [
-  //       '@neutrinojs/web',
-  //       (neutrino) => neutrino.config.devtool('source-map'),
-  //     ]
-  //   };
-  // This cannot occur when using the node or library presets, since they unconditionally
-  // set sourceMap to `true`. If a project wants to configure neutrino.config.devtool but
-  // disable source maps in terser-webpack-plugin, then they can unset `sourceMap` rather
-  // than setting it to `false`.
-  if (usingSourcemap && minimizer && (minimizer.get('args')[0] || {}).sourceMap === false) {
-    throw new ConfigurationError(
-      `neutrino.config.devtool is set to '${devtool}', however terser-webpack-plugin ` +
-      'has not been correctly configured to allow source maps. ' +
-      'This can happen if the devtool is configured manually outside of the preset. ' +
-      'Use the web/react/vue/... preset\'s new `devtool` option instead. See:\n' +
-      'https://neutrinojs.org/packages/web/#source-maps'
-    );
-  }
-
   return neutrino.config.toConfig();
 };
 

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -41,20 +41,6 @@ test('throws when vendor entrypoint defined', t => {
   );
 });
 
-test('throws if devtool configured manually when using terser-webpack-plugin', t => {
-  process.env.NODE_ENV = 'production';
-  const mw = (neutrino) =>
-    neutrino.config
-      .devtool('source-map')
-      .optimization
-        .minimizer('terser')
-          .use(Function.prototype, [{ sourceMap: false }]);
-  t.throws(
-    () => neutrino(mw).output('webpack'),
-    /terser-webpack-plugin has not been correctly configured/
-  );
-});
-
 test('throws when trying to use a non-registered output', t => {
   t.throws(
     () => neutrino(Function.prototype).output('fake'),

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -107,16 +107,6 @@ module.exports = (neutrino, opts = {}) => {
         });
     })
     .when(process.env.NODE_ENV === 'production', (config) => {
-      // Use terser instead of the unmaintained uglify-es.
-      // This is a backport of the upcoming webpack 5 minimizer configuration:
-      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
-      config.optimization
-        .minimizer('terser')
-        .use(require.resolve('terser-webpack-plugin'), [{
-          cache: true,
-          parallel: true,
-          sourceMap: true
-        }]);
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 };

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,7 +32,6 @@
     "@neutrinojs/start-server": "9.0.0-0",
     "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0",
-    "terser-webpack-plugin": "^1.1.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -37,6 +37,7 @@ test('valid preset production', t => {
   // Common
   t.is(config.target, 'node');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
+  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -46,7 +47,6 @@ test('valid preset production', t => {
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
-  t.is(config.optimization.minimizer.length, 1);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -61,6 +61,7 @@ test('valid preset development', t => {
   // Common
   t.is(config.target, 'node');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
+  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -70,7 +71,6 @@ test('valid preset development', t => {
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'inline-sourcemap');
-  t.is(config.optimization, undefined);
 
   const errors = validate(config);
   t.is(errors.length, 0);

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -527,10 +527,10 @@ module.exports = {
 
 #### Source minification
 
-By default script sources are minified in production only, using
-[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
-(which replaces `uglifyjs-webpack-plugin`). To customise the options passed to `TerserPlugin`
-or even use a different minifier, override `optimization.minimizer`.
+By default script sources are minified in production only, using webpack's default of
+[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
+To customise the options passed to `TerserPlugin` or even use a different minifier,
+override `optimization.minimizer`.
 
 _Example: Adjust the `terser` minification settings:_
 
@@ -539,15 +539,22 @@ module.exports = {
   use: [
     '@neutrinojs/web',
     (neutrino) => {
-      // The `terser` minimizer plugin only exists in the configuration in production.
+      // Whilst the minimizer is only used when the separate `minimize` option is true
+      // (ie in production), the conditional avoids the expensive require() in development.
       if (process.env.NODE_ENV === 'production') {
         neutrino.config.optimization
           .minimizer('terser')
-          .tap(([defaultOptions]) => [{
-            ...defaultOptions,
+          .use(require.resolve('terser-webpack-plugin'), [{
+            // Default options used by webpack:
+            // https://github.com/webpack/webpack/blob/v4.26.0/lib/WebpackOptionsDefaulter.js#L308-L315
+            cache: true,
+            parallel: true,
+            sourceMap: neutrino.config.devtool && /source-?map/.test(neutrino.config.devtool),
+            // Pass custom options here.
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // https://github.com/terser-js/terser#minify-options
             terserOptions: {
+              // eg disable mangling of names
               mangle: false,
             },
           }]);

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -174,18 +174,6 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.config
     .optimization
       .minimize(options.minify.source)
-      // Use terser instead of the unmaintained uglify-es.
-      // This is a backport of the upcoming webpack 5 minimizer configuration:
-      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
-      .when(options.minify.source, (optimization) =>
-        optimization
-          .minimizer('terser')
-          .use(require.resolve('terser-webpack-plugin'), [{
-            cache: true,
-            parallel: true,
-            sourceMap: typeof devtool === 'string' && /source-?map/.test(devtool)
-          }])
-       )
       .splitChunks({
         // By default SplitChunksPlugin only splits out the async chunks (to avoid the
         // ever-changing file list breaking users who don't auto-generate their HTML):

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,6 @@
     "@neutrinojs/image-loader": "9.0.0-0",
     "@neutrinojs/style-loader": "9.0.0-0",
     "deepmerge": "^1.5.2",
-    "terser-webpack-plugin": "^1.1.0",
     "webpack-manifest-plugin": "^2.0.4"
   },
   "peerDependencies": {

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -42,7 +42,6 @@ test('valid preset production', t => {
 
   // NODE_ENV/command specific
   t.true(config.optimization.minimize);
-  t.is(config.optimization.minimizer.length, 1);
   t.false(config.optimization.splitChunks.name);
   t.is(config.output.publicPath, '/');
   t.is(config.devtool, undefined);
@@ -72,7 +71,6 @@ test('valid preset development', t => {
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
-  t.is(config.optimization.minimizer, undefined);
   t.true(config.optimization.splitChunks.name);
   t.is(config.devtool, 'cheap-module-eval-source-map');
   t.deepEqual(config.devServer, {
@@ -111,7 +109,6 @@ test('valid preset test', t => {
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
-  t.is(config.optimization.minimizer, undefined);
   t.true(config.optimization.splitChunks.name);
   t.is(config.devtool, 'source-map');
   t.is(config.devServer, undefined);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,11 +2668,6 @@ commander@^2.11.0, commander@^2.14.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
-commander@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
-
 common-path-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0"
@@ -7391,7 +7386,6 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
   version "0.4.0"
-  uid "06073fa93166277607a7814f4e1f83960081414c"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
   dependencies:
     chalk "^1.1.3"
@@ -10465,7 +10459,7 @@ scheduler@^0.11.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.4, schema-utils@^0.4.5:
+schema-utils@^0.4.4:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -11621,14 +11615,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-es@^3.3.4:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
-  integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
-
 uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
@@ -11651,20 +11637,6 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
   integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
-
-uglifyjs-webpack-plugin@^1.2.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz#75f548160858163a08643e086d5fefe18a5d67de"
-  integrity sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==
-  dependencies:
-    cacache "^10.0.4"
-    find-cache-dir "^1.0.0"
-    schema-utils "^0.4.5"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-es "^3.3.4"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 uid2@0.0.3:
   version "0.0.3"
@@ -12270,10 +12242,10 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.23.1:
-  version "4.25.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.25.1.tgz#4f459fbaea0f93440dc86c89f771bb3a837cfb6d"
-  integrity sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==
+webpack@^4.26.0:
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.26.0.tgz#adbe80b869148c8d108b7d88965d00d72b3178de"
+  integrity sha512-J/dP9SJIc5OtX2FZ/+U9ikQtd6H6Mcbqt0xeXtmPwYGDKf8nkbOQQA9KL2Y0rJOsN1Al9Pdn+/j63X58ub8gvQ==
   dependencies:
     "@webassemblyjs/ast" "1.7.11"
     "@webassemblyjs/helper-module-context" "1.7.11"
@@ -12296,7 +12268,7 @@ webpack@^4.23.1:
     node-libs-browser "^2.0.0"
     schema-utils "^0.4.4"
     tapable "^1.1.0"
-    uglifyjs-webpack-plugin "^1.2.4"
+    terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
 


### PR DESCRIPTION
Since as of webpack 4.26.0 `terser-webpack-plugin` is the new default, so we no longer need to set it manually:
https://github.com/webpack/webpack/releases/tag/v4.26.0

This is a partial revert of #1158.