### PR TITLE
Remove extra externals usage in library middleware

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -66,7 +66,6 @@ module.exports = (neutrino, opts = {}) => {
     .when(options.externals, config => config.externals([nodeExternals(options.externals)]))
     .when(hasSourceMap, () => neutrino.use(banner))
     .devtool('source-map')
-    .externals([nodeExternals()])
     .target(options.target)
     .context(neutrino.options.root)
     .output


### PR DESCRIPTION
There was already a conditional `.externals()` call, so this one is a bug.

https://github.com/neutrinojs/neutrino/compare/master...eliperelman:fix-lib-double-externals?expand=1#diff-2be40b157961444bdf381c35002b0312R66