### PR TITLE
Fix inspect test output from interfering with ava logging

### DIFF
--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -76,7 +76,13 @@ test('exposes webpack config from method', t => {
 });
 
 test('exposes inspect output handler', t => {
-  t.notThrows(() =>
-    neutrino(Function.prototype).output('inspect')
-  );
+  t.notThrows(() => {
+    // Overriding console.log to prevent the inspect() method from logging to
+    // the console during tests, interfering with the ava output.
+    const original = console.log;
+
+    console.log = Function.prototype;
+    neutrino(Function.prototype).output('inspect');
+    console.log = original.bind(console);
+  });
 });


### PR DESCRIPTION
When running tests with `inspect`, Node.js treats object inspect calls as special output. Overriding this during that test to prevent the output from interfering.

**Before:**

<img width="617" alt="screen shot 2019-03-08 at 9 32 45 am" src="https://user-images.githubusercontent.com/285899/54038238-a4a14900-4185-11e9-86e1-38e18925f057.png">

**After:**

<img width="539" alt="screen shot 2019-03-08 at 9 34 19 am" src="https://user-images.githubusercontent.com/285899/54038245-a79c3980-4185-11e9-8506-baeff95ea8bf.png">