### PR TITLE
react: Enable eslint-plugin-react-hooks rules

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -55,6 +55,12 @@ module.exports = (opts = {}) => (neutrino) => {
         : merge(lintOptions, {
             baseConfig: {
               plugins: ['react', 'react-hooks'],
+              rules: {
+                // Enforces the rules of hooks:
+                // https://reactjs.org/docs/hooks-rules.html
+                'react-hooks/rules-of-hooks': 'error',
+                'react-hooks/exhaustive-deps': 'warn'
+              },
               settings: {
                 react: {
                   // https://github.com/yannickcr/eslint-plugin-react#configuration


### PR DESCRIPTION
The `eslint-plugin-react-hooks` plugin was added in #1309, however the rules it provides were not enabled. This enables those rules, using the settings recommended in the plugin README (which also matches those used by CRA):
https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks

Fixes #1300.