### PR TITLE
Update eslint-config-airbnb and eslint-config-airbnb-base

### DIFF
--- a/packages/airbnb-base/package.json
+++ b/packages/airbnb-base/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@neutrinojs/eslint": "9.0.0-rc.3",
-    "eslint-config-airbnb-base": "^13.2.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2"
   },
   "peerDependencies": {

--- a/packages/airbnb/index.js
+++ b/packages/airbnb/index.js
@@ -15,8 +15,14 @@ module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
         ...eslint,
         baseConfig: eslintMerge(
           {
-            extends: [require.resolve('eslint-config-airbnb')],
+            extends: [
+              require.resolve('eslint-config-airbnb'),
+              require.resolve('eslint-config-airbnb/hooks'),
+            ],
             rules: {
+              // Override AirBnB's configuration of 'always', since they only set that value due to
+              // babel-preset-airbnb not supporting class properties, whereas @neutrinojs/react does.
+              'react/state-in-constructor': ['error', 'never'],
               // Disable rules for which there are eslint-plugin-babel replacements:
               // https://github.com/babel/eslint-plugin-babel#rules
               'new-cap': 'off',
@@ -33,13 +39,6 @@ module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
               'babel/semi': airbnbBaseStyle.semi,
               'babel/no-unused-expressions':
                 airbnbBaseBestPractices['no-unused-expressions'],
-            },
-            settings: {
-              react: {
-                // https://github.com/yannickcr/eslint-plugin-react#configuration
-                // This is undocumented, but equivalent to "latest version".
-                version: '999.999.999',
-              },
             },
           },
           eslint.baseConfig || {},

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -24,11 +24,12 @@
   },
   "dependencies": {
     "@neutrinojs/eslint": "9.0.0-rc.3",
-    "eslint-config-airbnb": "^17.1.1",
-    "eslint-config-airbnb-base": "^13.2.0",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.14.3"
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0",

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -73,7 +73,10 @@ test('sets defaults when no options passed', t => {
       env: {
         es6: true,
       },
-      extends: [require.resolve('eslint-config-airbnb')],
+      extends: [
+        require.resolve('eslint-config-airbnb'),
+        require.resolve('eslint-config-airbnb/hooks'),
+      ],
       globals: {
         process: true,
       },
@@ -86,6 +89,7 @@ test('sets defaults when no options passed', t => {
       plugins: ['babel'],
       root: true,
       rules: {
+        'react/state-in-constructor': ['error', 'never'],
         'babel/new-cap': [
           'error',
           {
@@ -116,11 +120,7 @@ test('sets defaults when no options passed', t => {
         'object-curly-spacing': 'off',
         semi: 'off',
       },
-      settings: {
-        react: {
-          version: '999.999.999',
-        },
-      },
+      settings: {},
     },
     cache: true,
     cwd: api.options.root,
@@ -170,6 +170,7 @@ test('merges options with defaults', t => {
       },
       extends: [
         require.resolve('eslint-config-airbnb'),
+        require.resolve('eslint-config-airbnb/hooks'),
         'eslint-config-splendid',
       ],
       globals: {
@@ -185,6 +186,7 @@ test('merges options with defaults', t => {
       plugins: ['babel', 'jest'],
       root: true,
       rules: {
+        'react/state-in-constructor': ['error', 'never'],
         'babel/new-cap': [
           'error',
           {

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -87,6 +87,7 @@ test('updates lint config by default', t => {
     .get('options');
   t.deepEqual(options.baseConfig.extends, [
     require.resolve('eslint-config-airbnb'),
+    require.resolve('eslint-config-airbnb/hooks'),
     'plugin:jest/recommended',
   ]);
 });

--- a/packages/neutrino/errors.js
+++ b/packages/neutrino/errors.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-classes-per-file */
+
 class ConfigurationError extends Error {
   get name() {
     return this.constructor.name;

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -73,9 +73,7 @@ module.exports = (opts = {}) => neutrino => {
                 },
                 settings: {
                   react: {
-                    // https://github.com/yannickcr/eslint-plugin-react#configuration
-                    // This is undocumented, but equivalent to "latest version".
-                    version: '999.999.999',
+                    version: 'detect',
                   },
                 },
               },

--- a/packages/react/test/react_test.js
+++ b/packages/react/test/react_test.js
@@ -84,7 +84,7 @@ test('updates lint config by default', t => {
   t.deepEqual(options.baseConfig.plugins, ['babel', 'react', 'react-hooks']);
   t.deepEqual(options.baseConfig.settings, {
     react: {
-      version: '999.999.999',
+      version: 'detect',
     },
   });
 });

--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -41,9 +41,7 @@ module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
             },
             settings: {
               react: {
-                // https://github.com/yannickcr/eslint-plugin-react#configuration
-                // This is undocumented, but equivalent to "latest version".
-                version: '999.999.999',
+                version: 'detect',
               },
             },
           },

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -115,7 +115,7 @@ test('sets defaults when no options passed', t => {
       },
       settings: {
         react: {
-          version: '999.999.999',
+          version: 'detect',
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,7 +3954,7 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
-confusing-browser-globals@^1.0.5:
+confusing-browser-globals@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz#93ffec1f82a6e2bf2bc36769cc3a92fa20e502f3"
   integrity sha512-lI7asCibVJ6Qd3FGU7mu4sfG4try4LX3+GVS+Gv8UlrEf2AeW57piecapnog2UHZSbcX/P/1UDWVaTsblowlZg==
@@ -5305,21 +5305,21 @@ escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^13.2.0:
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz#f6ea81459ff4dec2dda200c35f1d8f7419d57943"
-  integrity sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==
+eslint-config-airbnb-base@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz#8a7bcb9643d13c55df4dd7444f138bf4efa61e17"
+  integrity sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==
   dependencies:
-    confusing-browser-globals "^1.0.5"
+    confusing-browser-globals "^1.0.7"
     object.assign "^4.1.0"
     object.entries "^1.1.0"
 
-eslint-config-airbnb@^17.1.1:
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz#2272e0b86bb1e2b138cdf88d07a3b6f4cda3d626"
-  integrity sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==
+eslint-config-airbnb@^18.0.1:
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz#a3a74cc29b46413b6096965025381df8fb908559"
+  integrity sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==
   dependencies:
-    eslint-config-airbnb-base "^13.2.0"
+    eslint-config-airbnb-base "^14.0.0"
     object.assign "^4.1.0"
     object.entries "^1.1.0"
 


### PR DESCRIPTION
* Combines #1443 and #1444 (since they are dependant on each other)
* Adds the new AirBnB hooks preset to `@neutrinojs/airbnb`
* Removes the React `version` option from `@neutrinojs/airbnb` since it's now configured within `eslint-config-airbnb`
* Switches other React `version` usages to the new `'detect'` mode
* Overrides AirBnB's configuration for `react/state-in-constructor` since `@neutrinojs/react` supports class properties, so using the `always` mode is unnecessary.

Closes #1443 and closes #1444.