### PR TITLE
Stop using private ESLint APIs for ESLint config merging

### DIFF
--- a/packages/airbnb-base/index.js
+++ b/packages/airbnb-base/index.js
@@ -1,5 +1,4 @@
 const lint = require('@neutrinojs/eslint');
-const { merge: eslintMerge } = require('eslint/lib/config/config-ops');
 const {
   rules: airbnbBaseStyle,
 } = require('eslint-config-airbnb-base/rules/style');
@@ -8,35 +7,37 @@ const {
 } = require('eslint-config-airbnb-base/rules/best-practices');
 
 module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
+  const baseConfig = eslint.baseConfig || {};
   neutrino.use(
     lint({
       ...opts,
       eslint: {
         ...eslint,
-        baseConfig: eslintMerge(
-          {
-            extends: [require.resolve('eslint-config-airbnb-base')],
-            rules: {
-              // Disable rules for which there are eslint-plugin-babel replacements:
-              // https://github.com/babel/eslint-plugin-babel#rules
-              'new-cap': 'off',
-              'no-invalid-this': 'off',
-              'object-curly-spacing': 'off',
-              semi: 'off',
-              'no-unused-expressions': 'off',
-              // Ensure the replacement rules use the options set by airbnb-base rather than ESLint defaults.
-              'babel/new-cap': airbnbBaseStyle['new-cap'],
-              'babel/no-invalid-this':
-                airbnbBaseBestPractices['no-invalid-this'],
-              'babel/object-curly-spacing':
-                airbnbBaseStyle['object-curly-spacing'],
-              'babel/semi': airbnbBaseStyle.semi,
-              'babel/no-unused-expressions':
-                airbnbBaseBestPractices['no-unused-expressions'],
-            },
+        baseConfig: {
+          ...baseConfig,
+          extends: [
+            require.resolve('eslint-config-airbnb-base'),
+            ...(baseConfig.extends || []),
+          ],
+          rules: {
+            // Disable rules for which there are eslint-plugin-babel replacements:
+            // https://github.com/babel/eslint-plugin-babel#rules
+            'new-cap': 'off',
+            'no-invalid-this': 'off',
+            'object-curly-spacing': 'off',
+            semi: 'off',
+            'no-unused-expressions': 'off',
+            // Ensure the replacement rules use the options set by airbnb-base rather than ESLint defaults.
+            'babel/new-cap': airbnbBaseStyle['new-cap'],
+            'babel/no-invalid-this': airbnbBaseBestPractices['no-invalid-this'],
+            'babel/object-curly-spacing':
+              airbnbBaseStyle['object-curly-spacing'],
+            'babel/semi': airbnbBaseStyle.semi,
+            'babel/no-unused-expressions':
+              airbnbBaseBestPractices['no-unused-expressions'],
+            ...baseConfig.rules,
           },
-          eslint.baseConfig || {},
-        ),
+        },
       },
     }),
   );

--- a/packages/airbnb-base/test/airbnb_test.js
+++ b/packages/airbnb-base/test/airbnb_test.js
@@ -77,7 +77,6 @@ test('sets defaults when no options passed', t => {
       globals: {
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -116,7 +115,6 @@ test('sets defaults when no options passed', t => {
         'object-curly-spacing': 'off',
         semi: 'off',
       },
-      settings: {},
     },
     cache: true,
     cwd: api.options.root,
@@ -172,7 +170,6 @@ test('merges options with defaults', t => {
         jQuery: true,
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -195,14 +192,7 @@ test('merges options with defaults', t => {
           },
         ],
         'babel/no-invalid-this': 'off',
-        'babel/no-unused-expressions': [
-          'warn',
-          {
-            allowShortCircuit: false,
-            allowTaggedTemplates: false,
-            allowTernary: false,
-          },
-        ],
+        'babel/no-unused-expressions': 'warn',
         'babel/object-curly-spacing': ['error', 'always'],
         'babel/semi': ['error', 'always'],
         'new-cap': 'off',

--- a/packages/airbnb/index.js
+++ b/packages/airbnb/index.js
@@ -1,5 +1,4 @@
 const lint = require('@neutrinojs/eslint');
-const { merge: eslintMerge } = require('eslint/lib/config/config-ops');
 const {
   rules: airbnbBaseStyle,
 } = require('eslint-config-airbnb-base/rules/style');
@@ -8,41 +7,41 @@ const {
 } = require('eslint-config-airbnb-base/rules/best-practices');
 
 module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
+  const baseConfig = eslint.baseConfig || {};
   neutrino.use(
     lint({
       ...opts,
       eslint: {
         ...eslint,
-        baseConfig: eslintMerge(
-          {
-            extends: [
-              require.resolve('eslint-config-airbnb'),
-              require.resolve('eslint-config-airbnb/hooks'),
-            ],
-            rules: {
-              // Override AirBnB's configuration of 'always', since they only set that value due to
-              // babel-preset-airbnb not supporting class properties, whereas @neutrinojs/react does.
-              'react/state-in-constructor': ['error', 'never'],
-              // Disable rules for which there are eslint-plugin-babel replacements:
-              // https://github.com/babel/eslint-plugin-babel#rules
-              'new-cap': 'off',
-              'no-invalid-this': 'off',
-              'object-curly-spacing': 'off',
-              semi: 'off',
-              'no-unused-expressions': 'off',
-              // Ensure the replacement rules use the options set by airbnb rather than ESLint defaults.
-              'babel/new-cap': airbnbBaseStyle['new-cap'],
-              'babel/no-invalid-this':
-                airbnbBaseBestPractices['no-invalid-this'],
-              'babel/object-curly-spacing':
-                airbnbBaseStyle['object-curly-spacing'],
-              'babel/semi': airbnbBaseStyle.semi,
-              'babel/no-unused-expressions':
-                airbnbBaseBestPractices['no-unused-expressions'],
-            },
+        baseConfig: {
+          ...baseConfig,
+          extends: [
+            require.resolve('eslint-config-airbnb'),
+            require.resolve('eslint-config-airbnb/hooks'),
+            ...(baseConfig.extends || []),
+          ],
+          rules: {
+            // Override AirBnB's configuration of 'always', since they only set that value due to
+            // babel-preset-airbnb not supporting class properties, whereas @neutrinojs/react does.
+            'react/state-in-constructor': ['error', 'never'],
+            // Disable rules for which there are eslint-plugin-babel replacements:
+            // https://github.com/babel/eslint-plugin-babel#rules
+            'new-cap': 'off',
+            'no-invalid-this': 'off',
+            'object-curly-spacing': 'off',
+            semi: 'off',
+            'no-unused-expressions': 'off',
+            // Ensure the replacement rules use the options set by airbnb rather than ESLint defaults.
+            'babel/new-cap': airbnbBaseStyle['new-cap'],
+            'babel/no-invalid-this': airbnbBaseBestPractices['no-invalid-this'],
+            'babel/object-curly-spacing':
+              airbnbBaseStyle['object-curly-spacing'],
+            'babel/semi': airbnbBaseStyle.semi,
+            'babel/no-unused-expressions':
+              airbnbBaseBestPractices['no-unused-expressions'],
+            ...baseConfig.rules,
           },
-          eslint.baseConfig || {},
-        ),
+        },
       },
     }),
   );

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -80,7 +80,6 @@ test('sets defaults when no options passed', t => {
       globals: {
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -120,7 +119,6 @@ test('sets defaults when no options passed', t => {
         'object-curly-spacing': 'off',
         semi: 'off',
       },
-      settings: {},
     },
     cache: true,
     cwd: api.options.root,
@@ -177,7 +175,6 @@ test('merges options with defaults', t => {
         jQuery: true,
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -201,14 +198,7 @@ test('merges options with defaults', t => {
           },
         ],
         'babel/no-invalid-this': 'off',
-        'babel/no-unused-expressions': [
-          'warn',
-          {
-            allowShortCircuit: false,
-            allowTaggedTemplates: false,
-            allowTernary: false,
-          },
-        ],
+        'babel/no-unused-expressions': 'warn',
         'babel/object-curly-spacing': ['error', 'always'],
         'babel/semi': ['error', 'always'],
         'new-cap': 'off',

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.2",
     "eslint-loader": "^3.0.0",
-    "eslint-plugin-babel": "^5.3.0",
-    "lodash.pick": "^4.4.0"
+    "eslint-plugin-babel": "^5.3.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0",

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -134,11 +134,9 @@ test('sets defaults when no options passed', t => {
       env: {
         es6: true,
       },
-      extends: [],
       globals: {
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -146,7 +144,6 @@ test('sets defaults when no options passed', t => {
       },
       plugins: ['babel'],
       root: true,
-      settings: {},
     },
     cache: true,
     cwd: api.options.root,
@@ -161,11 +158,9 @@ test('sets defaults when no options passed', t => {
     env: {
       es6: true,
     },
-    extends: [],
     globals: {
       process: true,
     },
-    overrides: [],
     parser: require.resolve('babel-eslint'),
     parserOptions: {
       ecmaVersion: 2018,
@@ -173,7 +168,7 @@ test('sets defaults when no options passed', t => {
     },
     plugins: ['babel'],
     root: true,
-    settings: {},
+    rules: {},
   });
 });
 
@@ -319,7 +314,7 @@ test('merges options with defaults', t => {
     plugins: ['babel', 'react', 'jest'],
     root: true,
     rules: {
-      quotes: ['warn', 'single'],
+      quotes: 'warn',
     },
     settings: {
       react: {

--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -1,52 +1,53 @@
 const lint = require('@neutrinojs/eslint');
-const { merge: eslintMerge } = require('eslint/lib/config/config-ops');
 const { rules: standardRules } = require('eslint-config-standard');
 
 module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
+  const baseConfig = eslint.baseConfig || {};
   neutrino.use(
     lint({
       ...opts,
       eslint: {
         ...eslint,
-        baseConfig: eslintMerge(
-          {
-            extends: [
-              require.resolve('eslint-config-standard'),
-              require.resolve('eslint-config-standard-jsx'),
-            ],
-            // Unfortunately we can't `require.resolve('eslint-plugin-standard')` due to:
-            // https://github.com/eslint/eslint/issues/6237
-            // ...so we have no choice but to rely on it being hoisted.
-            plugins: ['standard'],
-            rules: {
-              // Disable rules for which there are eslint-plugin-babel replacements:
-              // https://github.com/babel/eslint-plugin-babel#rules
-              'new-cap': 'off',
-              'no-invalid-this': 'off',
-              'object-curly-spacing': 'off',
-              semi: 'off',
-              'no-unused-expressions': 'off',
-              // Ensure the replacement rules use the options set by eslint-config-standard rather than ESLint defaults.
-              'babel/new-cap': standardRules['new-cap'],
-              // eslint-config-standard doesn't currently have an explicit value for these two rules, so
-              // they default to off. The fallbacks are not added to the other rules, so changes in the
-              // preset configuration layout doesn't silently cause rules to be disabled.
-              'babel/no-invalid-this':
-                standardRules['no-invalid-this'] || 'off',
-              'babel/object-curly-spacing':
-                standardRules['object-curly-spacing'] || 'off',
-              'babel/semi': standardRules.semi,
-              'babel/no-unused-expressions':
-                standardRules['no-unused-expressions'],
-            },
-            settings: {
-              react: {
-                version: 'detect',
-              },
+        baseConfig: {
+          ...baseConfig,
+          extends: [
+            require.resolve('eslint-config-standard'),
+            require.resolve('eslint-config-standard-jsx'),
+            ...(baseConfig.extends || []),
+          ],
+          // Unfortunately we can't `require.resolve('eslint-plugin-standard')` due to:
+          // https://github.com/eslint/eslint/issues/6237
+          // ...so we have no choice but to rely on it being hoisted.
+          plugins: ['standard', ...(baseConfig.plugins || [])],
+          rules: {
+            // Disable rules for which there are eslint-plugin-babel replacements:
+            // https://github.com/babel/eslint-plugin-babel#rules
+            'new-cap': 'off',
+            'no-invalid-this': 'off',
+            'object-curly-spacing': 'off',
+            semi: 'off',
+            'no-unused-expressions': 'off',
+            // Ensure the replacement rules use the options set by eslint-config-standard rather than ESLint defaults.
+            'babel/new-cap': standardRules['new-cap'],
+            // eslint-config-standard doesn't currently have an explicit value for these two rules, so
+            // they default to off. The fallbacks are not added to the other rules, so changes in the
+            // preset configuration layout doesn't silently cause rules to be disabled.
+            'babel/no-invalid-this': standardRules['no-invalid-this'] || 'off',
+            'babel/object-curly-spacing':
+              standardRules['object-curly-spacing'] || 'off',
+            'babel/semi': standardRules.semi,
+            'babel/no-unused-expressions':
+              standardRules['no-unused-expressions'],
+            ...baseConfig.rules,
+          },
+          settings: {
+            ...baseConfig.settings,
+            react: {
+              version: 'detect',
+              ...(baseConfig.settings || {}).react,
             },
           },
-          eslint.baseConfig || {},
-        ),
+        },
       },
     }),
   );

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -80,7 +80,6 @@ test('sets defaults when no options passed', t => {
       globals: {
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -174,7 +173,6 @@ test('merges options with defaults', t => {
         jQuery: true,
         process: true,
       },
-      overrides: [],
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 2018,
@@ -191,14 +189,7 @@ test('merges options with defaults', t => {
           },
         ],
         'babel/no-invalid-this': 'off',
-        'babel/no-unused-expressions': [
-          'warn',
-          {
-            allowShortCircuit: true,
-            allowTaggedTemplates: true,
-            allowTernary: true,
-          },
-        ],
+        'babel/no-unused-expressions': 'warn',
         'babel/object-curly-spacing': ['error', 'always'],
         'babel/semi': ['error', 'never'],
         'new-cap': 'off',

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -61,7 +61,6 @@ test('updates lint config by default', t => {
     globals: {
       process: true,
     },
-    overrides: [],
     parser: 'vue-eslint-parser',
     parserOptions: {
       ecmaVersion: 2018,
@@ -70,7 +69,6 @@ test('updates lint config by default', t => {
     },
     plugins: ['babel', 'vue'],
     root: true,
-    settings: {},
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8892,11 +8892,6 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"


### PR DESCRIPTION
In #1182, the previous broken ESLint config merging functionality was replaced by using an internal ESLint `merge` function from `config-ops`.

Unfortunately in ESLint 6 that function no longer exists in a form that is easy for us to use, so in order to support ESLint 6, I have replaced it with simpler manual merges. These are virtually identical, with one difference - `rules` are now merged by a later rule entry completely replacing the first, rather than updating it.

For example, merging these:
`'foo': ['error', {'someSetting': false}]`
`'foo': 'warn'`

...used to give:
`'foo': ['warn', {'someSetting': false}]`

...but now results in:
`'foo': 'warn'`

I think this difference is a reasonable compromise for not having to rely on ESLint internals and/or implement our own more complex merging. I also believe hitting this will be rare, since:
* it doesn't affect merging with rules defined inside an `extends` external file
* it won't make a difference for rules that were already at default settings (or that were overridden with custom settings in the later rule definition being merged in)

This more simplistic merging behaviour is also what's used by Neutrino 8 (#1182 landed for Neutrino 9 only) - and we still have the other bug fixes included in #1182 that were the primary motivation for refactoring in the first place.

Refs #1423.