### PR TITLE
Update eslint-config-standard and switch from -jsx to -react

### DIFF
--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -12,13 +12,9 @@ module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
           ...baseConfig,
           extends: [
             require.resolve('eslint-config-standard'),
-            require.resolve('eslint-config-standard-jsx'),
+            require.resolve('eslint-config-standard-react'),
             ...(baseConfig.extends || []),
           ],
-          // Unfortunately we can't `require.resolve('eslint-plugin-standard')` due to:
-          // https://github.com/eslint/eslint/issues/6237
-          // ...so we have no choice but to rely on it being hoisted.
-          plugins: ['standard', ...(baseConfig.plugins || [])],
           rules: {
             // Disable rules for which there are eslint-plugin-babel replacements:
             // https://github.com/babel/eslint-plugin-babel#rules
@@ -29,23 +25,15 @@ module.exports = ({ eslint = {}, ...opts } = {}) => neutrino => {
             'no-unused-expressions': 'off',
             // Ensure the replacement rules use the options set by eslint-config-standard rather than ESLint defaults.
             'babel/new-cap': standardRules['new-cap'],
-            // eslint-config-standard doesn't currently have an explicit value for these two rules, so
-            // they default to off. The fallbacks are not added to the other rules, so changes in the
+            // eslint-config-standard doesn't currently have an explicit value for no-invalid-this, so
+            // it defaults to off. The fallback is not added to the other rules, so changes in the
             // preset configuration layout doesn't silently cause rules to be disabled.
             'babel/no-invalid-this': standardRules['no-invalid-this'] || 'off',
-            'babel/object-curly-spacing':
-              standardRules['object-curly-spacing'] || 'off',
+            'babel/object-curly-spacing': standardRules['object-curly-spacing'],
             'babel/semi': standardRules.semi,
             'babel/no-unused-expressions':
               standardRules['no-unused-expressions'],
             ...baseConfig.rules,
-          },
-          settings: {
-            ...baseConfig.settings,
-            react: {
-              version: 'detect',
-              ...(baseConfig.settings || {}).react,
-            },
           },
         },
       },

--- a/packages/standardjs/package.json
+++ b/packages/standardjs/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@neutrinojs/eslint": "9.0.0-rc.3",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-config-standard-jsx": "^6.0.2",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-config-standard-react": "^9.2.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -75,7 +75,7 @@ test('sets defaults when no options passed', t => {
       },
       extends: [
         require.resolve('eslint-config-standard'),
-        require.resolve('eslint-config-standard-jsx'),
+        require.resolve('eslint-config-standard-react'),
       ],
       globals: {
         process: true,
@@ -85,7 +85,7 @@ test('sets defaults when no options passed', t => {
         ecmaVersion: 2018,
         sourceType: 'module',
       },
-      plugins: ['babel', 'standard'],
+      plugins: ['babel'],
       root: true,
       rules: {
         'babel/new-cap': [
@@ -93,6 +93,7 @@ test('sets defaults when no options passed', t => {
           {
             capIsNew: false,
             newIsCap: true,
+            properties: true,
           },
         ],
         'babel/no-invalid-this': 'off',
@@ -111,11 +112,6 @@ test('sets defaults when no options passed', t => {
         'no-unused-expressions': 'off',
         'object-curly-spacing': 'off',
         semi: 'off',
-      },
-      settings: {
-        react: {
-          version: 'detect',
-        },
       },
     },
     cache: true,
@@ -166,7 +162,7 @@ test('merges options with defaults', t => {
       },
       extends: [
         require.resolve('eslint-config-standard'),
-        require.resolve('eslint-config-standard-jsx'),
+        require.resolve('eslint-config-standard-react'),
         'eslint-config-splendid',
       ],
       globals: {
@@ -178,7 +174,7 @@ test('merges options with defaults', t => {
         ecmaVersion: 2018,
         sourceType: 'module',
       },
-      plugins: ['babel', 'standard', 'jest'],
+      plugins: ['babel', 'jest'],
       root: true,
       rules: {
         'babel/new-cap': [
@@ -186,6 +182,7 @@ test('merges options with defaults', t => {
           {
             capIsNew: false,
             newIsCap: true,
+            properties: true,
           },
         ],
         'babel/no-invalid-this': 'off',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5361,15 +5361,22 @@ eslint-config-prettier@^6.0.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-standard-jsx@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
-  integrity sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
+eslint-config-standard-jsx@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz#314c62a0e6f51f75547f89aade059bec140edfc7"
+  integrity sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==
 
-eslint-config-standard@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
-  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==
+eslint-config-standard-react@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-react/-/eslint-config-standard-react-9.2.0.tgz#b21f05c087c1b0cfeea9fa3bff3cf42bd08a68a9"
+  integrity sha512-u+KRP2uCtthZ/W4DlLWCC59GZNV/y9k9yicWWammgTs/Omh8ZUUPF3EnYm81MAcbkYQq2Wg0oxutAhi/FQ8mIw==
+  dependencies:
+    eslint-config-standard-jsx "^8.0.0"
+
+eslint-config-standard@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz#b23da2b76fe5a2eba668374f246454e7058f15d4"
+  integrity sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Updates the ESLint standardjs presets to latest, and switches from `eslint-config-standard-jsx` to `eslint-config-standard-react`, since the latter is a superset of the former and required for full React support.

The new configs set the React version and plugins for us, so we no longer need to set them ourselves.

Fixes #1449 and fixes #1450.