### PR TITLE
Correct the repository definition in package.json

### DIFF
--- a/packages/airbnb-base/package.json
+++ b/packages/airbnb-base/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/airbnb-base",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/airbnb-base"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/airbnb/package.json
+++ b/packages/airbnb/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/airbnb",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/airbnb"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/banner",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/banner"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/clean/package.json
+++ b/packages/clean/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/clean",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/clean"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/compile-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/compile-loader"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/copy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/copy"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/create-project/package.json
+++ b/packages/create-project/package.json
@@ -12,7 +12,11 @@
     "bin",
     "commands"
   ],
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/create-project",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/create-project"
+  },
   "author": "Hassan Ali <helfi92@gmail.com>",
   "license": "MPL-2.0",
   "keywords": [

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -14,7 +14,11 @@
   ],
   "author": "Constantine Genchevsky <const.gen@gmail.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/dev-server",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/dev-server"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/eslint"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/font-loader/package.json
+++ b/packages/font-loader/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/font-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/font-loader"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/html-loader/package.json
+++ b/packages/html-loader/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/html-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/html-loader"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/html-template",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/html-template"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/image-loader/package.json
+++ b/packages/image-loader/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/image-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/image-loader"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/jest",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/jest"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/karma/package.json
+++ b/packages/karma/package.json
@@ -12,7 +12,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/karma",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/karma"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -18,7 +18,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/library"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -9,7 +9,11 @@
     "bin",
     "transforms"
   ],
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/migrate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/migrate"
+  },
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "keywords": [

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -10,7 +10,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/mocha",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/mocha"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -13,7 +13,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/neutrino",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/neutrino"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/node",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/node"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -12,7 +12,11 @@
   ],
   "author": "Fahad Hossain <8bit.demoncoder@gmail.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/preact",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/preact"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -9,7 +9,11 @@
     "index.js"
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/react-components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/react-components"
+  },
   "license": "MPL-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/react",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/react"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/standardjs/package.json
+++ b/packages/standardjs/package.json
@@ -12,7 +12,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/standardjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/standardjs"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/start-server",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/start-server"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/style-loader/package.json
+++ b/packages/style-loader/package.json
@@ -12,7 +12,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/style-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/style-loader"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/style-minify/package.json
+++ b/packages/style-minify/package.json
@@ -13,7 +13,11 @@
   ],
   "author": "Tim Kelty <timkelty@gmail.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/style-minify",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/style-minify"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,7 +11,11 @@
   ],
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
-  "repository": "https://github.com/neutrinojs/neutrino/tree/master/packages/web",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neutrinojs/neutrino.git",
+    "directory": "packages/web"
+  },
   "homepage": "https://neutrinojs.org",
   "bugs": "https://github.com/neutrinojs/neutrino/issues",
   "publishConfig": {


### PR DESCRIPTION
Now matches the spec for monorepos at:
https://docs.npmjs.com/files/package.json#repository

Fixes renovatebot/renovate#4607.