### PR TITLE
react: Use babel-preset-react's new useSpread option

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -43,9 +43,10 @@ module.exports = (opts = {}) => neutrino => {
             {
               // Enable development helpers both in development and testing.
               development: process.env.NODE_ENV !== 'production',
-              // Use the native built-in instead of polyfilling.
-              // Don't confuse this with `@babel/preset-env`'s `useBuiltIns` option, they are different.
-              useBuiltIns: true,
+              // When spreading props, use inline object with spread elements directly instead of
+              // Babel's extend helper or Object.assign. @babel/env will still transpile these down
+              // if required for the target browsers.
+              useSpread: true,
             },
           ],
         ],


### PR DESCRIPTION
A new `useSpread` option was added in Babel 7.7.0 (babel/babel#10572), which supersedes the babel-preset-react's existing `useBuiltIns` option:
https://babeljs.io/docs/en/babel-preset-react#usespread

Enabling this means that the JSX-> JS conversion will use an inline object with spread elements (for code that spreads props), rather than Babel's extend helper or `Object.assign`.

`@babel/env` will still transpile these down if required for the target browsers (the only reason `useSpread` is not already enabled by default is that for the upstream project this is a breaking change, since they cannot assume that users of `babel-preset-react` are always using it alongside `@babel/env`, even though most likely are).