### PR TITLE
style: Enable mini-css-extract-plugin's esModule mode

### DIFF
--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -62,7 +62,9 @@ neutrino.use(
     modulesTest: /\.module.css$/,
     extract: {
       enabled: process.env.NODE_ENV === 'production',
-      loader: {},
+      loader: {
+        esModule: true,
+      },
       plugin: {
         filename:
           process.env.NODE_ENV === 'production'

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -19,7 +19,9 @@ module.exports = (opts = {}) => neutrino => {
       loaders: [],
       extract: {
         enabled: isProduction,
-        loader: {},
+        loader: {
+          esModule: true,
+        },
         plugin: {
           filename: isProduction
             ? 'assets/[name].[contenthash:8].css'


### PR DESCRIPTION
This makes the loader part of `mini-css-extract-plugin` output JS using ES modules syntax instead of CJS, allowing webpack's module concatenation and tree shaking features to work more effectively:
https://github.com/webpack-contrib/mini-css-extract-plugin#esmodule

Fixes #1511.