### PR TITLE
Enable @babel/preset-env's ShippedProposals mode

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -47,6 +47,7 @@ module.exports = (opts = {}) => {
               {
                 debug: neutrino.options.debug,
                 useBuiltIns: coreJsVersion ? 'usage' : false,
+                shippedProposals: true,
                 targets: options.targets,
                 ...(coreJsVersion && { corejs: coreJsVersion.major }),
               },

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -51,6 +51,7 @@ module.exports = (opts = {}) => {
                 {
                   debug: neutrino.options.debug,
                   targets: options.targets,
+                  shippedProposals: true,
                   useBuiltIns: coreJsVersion ? 'usage' : false,
                   ...(coreJsVersion && { corejs: coreJsVersion.major }),
                 },

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -13,12 +13,6 @@ module.exports = (opts = {}) => (neutrino) => {
             require.resolve('@babel/plugin-transform-react-jsx'),
             { pragma: 'h', pragmaFrag: 'Fragment' },
           ],
-          // Using loose for the reasons here:
-          // https://github.com/facebook/create-react-app/issues/4263
-          [
-            require.resolve('@babel/plugin-proposal-class-properties'),
-            { loose: true },
-          ],
         ],
       },
       opts.babel || {},

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-transform-react-jsx": "^7.10.1",
     "@neutrinojs/web": "9.1.0",
     "babel-merge": "^3.0.0",

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -30,12 +30,6 @@ module.exports = (opts = {}) => (neutrino) => {
               removeImport: true,
             },
           ],
-          // Using loose for the reasons here:
-          // https://github.com/facebook/create-react-app/issues/4263
-          [
-            require.resolve('@babel/plugin-proposal-class-properties'),
-            { loose: true },
-          ],
         ].filter(Boolean),
         presets: [
           [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/preset-react": "^7.10.1",
     "@neutrinojs/web": "9.1.0",
     "babel-merge": "^3.0.0",

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -139,6 +139,7 @@ module.exports = (opts = {}) => (neutrino) => {
             {
               debug: neutrino.options.debug,
               useBuiltIns: coreJsVersion ? 'usage' : false,
+              shippedProposals: true,
               targets: options.targets,
               ...(coreJsVersion && { corejs: coreJsVersion.major }),
             },


### PR DESCRIPTION
Enabling this means that preset-env now injects additional plugins for any features that aren't yet stage 3, but have been shipped in at least one browser (meaning they are as good as finalised):
https://babeljs.io/docs/en/babel-preset-env#shippedproposals

Using this new mode also means we no longer need to manually include the `@babel/plugin-proposal-class-properties` plugin, since it's included in the shipped proposals list as of Babel 7.10.0:
https://github.com/babel/babel/pull/11451

This change does mean that `@babel/plugin-proposal-class-properties` will be used in strict mode rather than loose mode if browsers in the target list do not support it (so slight bundle size increase), however that seems like a reasonable trade-off to:
* ensure there are no surprises when targets change and the transform plugin stops being used
* reduce amount of Neutrino config boilerplate

...especially given several browsers already support it natively:
https://github.com/babel/babel/blob/426acf336e0ab8402714e25b12edf1a61a735ce5/packages/babel-compat-data/data/plugins.json#L13-L19

I've tested this change locally to ensure class properties do indeed continue to work (wish we had a better test suite for sample functionality that wasn't just the create-project templates, where we really don't want to add complexity since the examples should be simple).