### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -50,7 +50,7 @@ const scaffold = async ({ testName, ...prompts }) => {
   const directory = `${join(
     tmpdir(),
     testName.replace(/[/+ @:]/g, '_'),
-  )}_${Math.random().toString(36).substr(2)}`;
+  )}_${Math.random().toString(36).slice(2)}`;
 
   await run(require.resolve(join(__dirname, '../commands/init')))
     .withOptions({


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.